### PR TITLE
ci: add FreeBSD builds

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -13,6 +13,9 @@ fi
 rm -rf dist
 GOOS=darwin GOARCH=amd64 go build -o "dist/darwin-amd64"
 GOOS=darwin GOARCH=arm64 go build -o "dist/darwin-arm64"
+GOOS=freebsd GOARCH=386 go build -o "dist/freebsd-386"
+GOOS=freebsd GOARCH=amd64 go build -o "dist/freebsd-amd64"
+GOOS=freebsd GOARCH=arm64 go build -o "dist/freebsd-arm64"
 GOOS=linux GOARCH=386 go build -o "dist/linux-i386"
 GOOS=linux GOARCH=amd64 go build -o "dist/linux-amd64"
 GOOS=linux GOARCH=arm GOARM=6 go build -o "dist/linux-arm-6"


### PR DESCRIPTION
# Summary

Add FreeBSD builds to the release process (free with Go's cross compilation).
