### PR TITLE
Fix pending checks not always rendering as pending

### DIFF
--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -64,6 +64,9 @@ func (pr PullRequest) GetStatusChecksRollup() string {
 			}
 		} else if statusCheck.Typename == "StatusContext" {
 			conclusion = string(statusCheck.StatusContext.State)
+			if isStatusWaiting(conclusion) {
+				accStatus = "PENDING"
+			}
 		}
 
 		if isConclusionAFailure(conclusion) {

--- a/ui/components/prsidebar/checks.go
+++ b/ui/components/prsidebar/checks.go
@@ -70,7 +70,12 @@ func renderCheckRunConclusion(checkRun data.CheckRun) string {
 }
 
 func renderStatusContextConclusion(statusContext data.StatusContext) string {
-	if data.IsConclusionAFailure(string(statusContext.State)) {
+	conclusionStr := string(statusContext.State)
+	if data.IsStatusWaiting(conclusionStr) {
+		return constants.WaitingGlyph
+	}
+
+	if data.IsConclusionAFailure(conclusionStr) {
 		return constants.FailureGlyph
 	}
 

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -94,7 +94,7 @@ func (m *Model) renderChecksPill() string {
 		return pillStyle.Copy().
 			Background(styles.DefaultTheme.WarningText).
 			Render(" Checks")
-	} else if status == "SUCCESS" {
+	} else if status == "PENDING" {
 		return pillStyle.Copy().
 			Background(styles.DefaultTheme.FaintText).
 			Foreground(styles.DefaultTheme.MainText).

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -7,7 +7,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dlvhdr/gh-dash/data"
 	"github.com/dlvhdr/gh-dash/ui/components/pr"
-	"github.com/dlvhdr/gh-dash/ui/constants"
 	"github.com/dlvhdr/gh-dash/ui/markdown"
 	"github.com/dlvhdr/gh-dash/ui/styles"
 )
@@ -95,10 +94,12 @@ func (m *Model) renderChecksPill() string {
 		return pillStyle.Copy().
 			Background(styles.DefaultTheme.WarningText).
 			Render(" Checks")
-	} else if status == "PENDING" {
+	} else if status == "SUCCESS" {
 		return pillStyle.Copy().
 			Background(styles.DefaultTheme.FaintText).
-			Render(constants.WaitingGlyph + " Checks")
+			Foreground(styles.DefaultTheme.MainText).
+			Faint(true).
+			Render(" Checks")
 	}
 
 	return pillStyle.Copy().


### PR DESCRIPTION
# Summary

Pending checks that are defined in the `StatusContext` were not properly rendering as pending.  Check runs worked fine, but external CI services like Buildkite which use `StatusContext` were not rendering properly.

I also improved the formatting of the pending checks pill which was rendering strangely before.

## How did you test this change?

Verified that pending checks work properly after this change.

## Images/Videos

### Before
![image](https://user-images.githubusercontent.com/25914066/170786017-5a598954-58f3-47f9-a93a-715ee6c10eae.png)

### After

![image](https://user-images.githubusercontent.com/25914066/170785607-d9a941c5-d938-4ef8-9150-046a9d27ef4d.png)