### PR TITLE
Update gh-extension-precompile

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -13,4 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cli/gh-extension-precompile@v1.1.2
+      - uses: cli/gh-extension-precompile@v1
+        with:
+          go_version: "1.17"


### PR DESCRIPTION
- Use stable `@v1` version for this action. This ensures that gh-dash will continue to get fixes and other updates from this Action, such as new Go platforms added for binaries. The `v1` branch intends to never break backwards compatibility.
- Explicitly specify Go version used for building, otherwise it will be Go 1.16

Ref. https://github.com/cli/gh-extension-precompile/releases/tag/v1.2.0

Note that binaries produced by `gh-extension-precompile` follow a slightly different naming convention than `release.sh` in this repository: it uses `386` in the filename of `GOARCH=386` binaries instead of `i386`. When installing extensions, gh will look up available assets based on literal GOARCH, so `i386` will actually not match 32-bit systems.

Fixes https://github.com/dlvhdr/gh-dash/issues/131, fixes https://github.com/dlvhdr/gh-dash/issues/113