### PR TITLE
Change default Subscribed tab to Involved

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -125,8 +125,8 @@ func (parser ConfigParser) getDefaultConfig() Config {
 				Filters: "is:open review-requested:@me",
 			},
 			{
-				Title:   "Subscribed",
-				Filters: "is:open -author:@me repo:cli/cli repo:dlvhdr/gh-dash",
+				Title:   "Involved",
+				Filters: "is:open involves:@me -author:@me",
 			},
 		},
 		IssuesSections: []SectionConfig{
@@ -139,8 +139,8 @@ func (parser ConfigParser) getDefaultConfig() Config {
 				Filters: "is:open assignee:@me",
 			},
 			{
-				Title:   "Subscribed",
-				Filters: "is:open -author:@me repo:cli/cli repo:dlvhdr/gh-dash",
+				Title:   "Involved",
+				Filters: "is:open involves:@me -author:@me",
 			},
 		},
 		Keybindings: Keybindings{


### PR DESCRIPTION
# Summary

This changes the `Subscribed` tabs in the default config to `Involved`
tabs and changes the filter from hard-coded repos (such as `cli/cli`) to
`involves:@me`.

This addresses behavior that has surprised some folks such as in #74 and #129.

Ideally, we could fetch issues/PRs that the user has subscribed to, but
it looks like there's not an obvious way to do that. In its absence, the
`involves` filter might be a reasonable default that is less surprising
to people.

## How did you test this change?

I changed my local config to match this and ran `gh dash` to observe the results.

Admittedly I did not set up a `go` environment to test these changes.

## Images/Videos

<img width="677" alt="Screen Shot 2022-08-17 at 9 41 39 AM" src="https://user-images.githubusercontent.com/977929/185149216-71bbd2bc-8809-4cf2-bb3c-282a616bf9cc.png">