### PR TITLE
Differentiate draft PRs from open PRs

### DIFF
--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -37,7 +37,11 @@ func (pr PullRequest) renderState() string {
 	mergeCellStyle := lipgloss.NewStyle()
 	switch pr.Data.State {
 	case "OPEN":
-		return mergeCellStyle.Foreground(openPR).Render("")
+		if pr.Data.IsDraft {
+			return mergeCellStyle.Foreground(styles.DefaultTheme.FaintText).Render("")
+		} else {
+			return mergeCellStyle.Foreground(openPR).Render("")
+		}
 	case "CLOSED":
 		return mergeCellStyle.Foreground(closedPR).Render("")
 	case "MERGED":
@@ -139,7 +143,11 @@ func (pr PullRequest) renderUpdateAt() string {
 func (pr PullRequest) RenderState() string {
 	switch pr.Data.State {
 	case "OPEN":
-		return " Open"
+		if pr.Data.IsDraft {
+			return " Draft"
+		} else {
+			return " Open"
+		}
 	case "CLOSED":
 		return "﫧Closed"
 	case "MERGED":

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -61,7 +61,11 @@ func (m *Model) renderStatusPill() string {
 	bgColor := ""
 	switch m.pr.Data.State {
 	case "OPEN":
-		bgColor = openPR.Dark
+		if m.pr.Data.IsDraft {
+			bgColor = styles.DefaultTheme.FaintText.Dark
+		} else {
+			bgColor = openPR.Dark
+		}
 	case "CLOSED":
 		bgColor = closedPR.Dark
 	case "MERGED":


### PR DESCRIPTION
# Summary

Tweak a couple of key bits of the UI to differentiate an open draft PR from an open non-draft PR in the table view and the sidebar.

I decided to scope this change to only affect _open_ draft PRs.  A closed PR could also be a draft, but that seems much less useful and important once it's been closed.

Fixes #157

## How did you test this change?

I ran it locally with my config which currently contains a draft PR.

## Images/Videos

**Before**
![gh-dash draft PR before](https://user-images.githubusercontent.com/180317/185409148-8a80df3c-da74-4227-82b5-845c7a6cfbb9.png)

**After**
![gh-dash draft PR after](https://user-images.githubusercontent.com/180317/185409164-3991ad3c-ce37-4aa9-b881-7f0775e4336d.png)