### PR TITLE
feat(pagination): fix #112 Implement pagination for issues section 

### DIFF
--- a/ui/components/listviewport/listviewport.go
+++ b/ui/components/listviewport/listviewport.go
@@ -56,6 +56,10 @@ func (m *Model) GetCurrItem() int {
 	return m.currId
 }
 
+func (m *Model) GetLastItem() int {
+	return m.NumItems
+}
+
 func (m *Model) NextItem() int {
 	atBottomOfViewport := m.currId >= m.bottomBoundId
 	if atBottomOfViewport {

--- a/ui/components/table/table.go
+++ b/ui/components/table/table.go
@@ -56,6 +56,10 @@ func (m *Model) GetCurrItem() int {
 	return m.rowsViewport.GetCurrItem()
 }
 
+func (m *Model) GetLastItem() int {
+	return m.rowsViewport.GetLastItem()
+}
+
 func (m *Model) PrevItem() int {
 	currItem := m.rowsViewport.PrevItem()
 	m.SyncViewPortContent()
@@ -220,5 +224,4 @@ func (m *Model) renderRow(rowId int, headerColumns []string) string {
 	return rowStyle.Copy().
 		MaxWidth(m.dimensions.Width).
 		Render(lipgloss.JoinHorizontal(lipgloss.Top, renderedColumns...))
-
 }


### PR DESCRIPTION
This Pr adds the functionality for loading more issues when the cursor reaches the 5th last item in the issues

This is the inital working draft, if there are no issues with this PR and its implementation will complete the same feature for the PRs section

## How did you test this change?
On reaching the 5th last issue fetch n more issues (based on issuesLimit value) 

## Images/Videos
default View
![image](https://user-images.githubusercontent.com/21305685/196754683-d6e9da29-1a33-41a8-859a-9b6160f89505.png)

On reaching/ crossing the 5th last issue load more
![image](https://user-images.githubusercontent.com/21305685/196754999-2d527664-1bcf-473a-8cbe-1d8854add867.png)
