### PR TITLE
Add "open in Github" to the help

### DIFF
--- a/ui/keys/keys.go
+++ b/ui/keys/keys.go
@@ -55,7 +55,7 @@ func (k KeyMap) NavigationKeys() []key.Binding {
 }
 
 func (k KeyMap) AppKeys() []key.Binding {
-	return []key.Binding{k.Refresh, k.SwitchView, k.TogglePreview, k.Search}
+	return []key.Binding{k.Refresh, k.SwitchView, k.TogglePreview, k.OpenGithub, k.Search}
 }
 
 func (k KeyMap) QuitAndHelpKeys() []key.Binding {


### PR DESCRIPTION
# Summary

Add back "open in GitHub" to the help.

## How did you test this change?

I ran it locally and toggled the help screen.

## Images/Videos

Before:
<img width="800" alt="image" src="https://user-images.githubusercontent.com/628/197070506-b0c9a1a7-e936-4aea-8ca5-c5a7a966f371.png">

After:
![open-in-github](https://user-images.githubusercontent.com/628/197070545-000bbe64-4256-4de0-9143-433486f19cc3.jpg)

