### PR TITLE
fix: support config.yaml

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -15,7 +15,8 @@ import (
 )
 
 const DashDir = "gh-dash"
-const ConfigFileName = "config.yml"
+const ConfigYmlFileName = "config.yml"
+const ConfigYamlFileName = "config.yaml"
 const DEFAULT_XDG_CONFIG_DIRNAME = ".config"
 
 var validate *validator.Validate
@@ -243,7 +244,7 @@ func (parser ConfigParser) getDefaultConfigYamlContents() string {
 
 func (e configError) Error() string {
 	return fmt.Sprintf(
-		`Couldn't find a config.yml configuration file.
+		`Couldn't find a config.yml or a config.yaml configuration file.
 Create one under: %s
 
 Example of a config.yml file:
@@ -253,7 +254,7 @@ For more info, go to https://github.com/dlvhdr/gh-dash
 press q to exit.
 
 Original error: %v`,
-		path.Join(e.configDir, DashDir, ConfigFileName),
+		path.Join(e.configDir, DashDir, ConfigYmlFileName),
 		string(e.parser.getDefaultConfigYamlContents()),
 		e.err,
 	)
@@ -296,7 +297,12 @@ func (parser ConfigParser) getExistingConfigFile() (*string, error) {
 		xdgConfigDir = filepath.Join(homeDir, DEFAULT_XDG_CONFIG_DIRNAME)
 	}
 
-	dashConfigFile = filepath.Join(xdgConfigDir, DashDir, ConfigFileName)
+	dashConfigFile = filepath.Join(xdgConfigDir, DashDir, ConfigYmlFileName)
+	if _, err := os.Stat(dashConfigFile); err == nil {
+		return &dashConfigFile, nil
+	}
+
+	dashConfigFile = filepath.Join(xdgConfigDir, DashDir, ConfigYamlFileName)
 	if _, err := os.Stat(dashConfigFile); err == nil {
 		return &dashConfigFile, nil
 	}
@@ -306,7 +312,12 @@ func (parser ConfigParser) getExistingConfigFile() (*string, error) {
 		return nil, err
 	}
 
-	dashConfigFile = filepath.Join(userConfigDir, DashDir, ConfigFileName)
+	dashConfigFile = filepath.Join(userConfigDir, DashDir, ConfigYmlFileName)
+	if _, err := os.Stat(dashConfigFile); err == nil {
+		return &dashConfigFile, nil
+	}
+
+	dashConfigFile = filepath.Join(userConfigDir, DashDir, ConfigYamlFileName)
 	if _, err := os.Stat(dashConfigFile); err == nil {
 		return &dashConfigFile, nil
 	}
@@ -340,7 +351,7 @@ func (parser ConfigParser) getDefaultConfigFileOrCreateIfMissing() (string, erro
 		return "", configError{parser: parser, configDir: configDir, err: err}
 	}
 
-	configFilePath := filepath.Join(dashConfigDir, ConfigFileName)
+	configFilePath := filepath.Join(dashConfigDir, ConfigYmlFileName)
 	err = parser.createConfigFileIfMissing(configFilePath)
 	if err != nil {
 		return "", configError{parser: parser, configDir: configDir, err: err}


### PR DESCRIPTION
# Summary
I saw the issue on https://github.com/dlvhdr/gh-dash/issues/43 and made changes to support the config.yaml file as well.

## How did you test this change?

I placed the config.yaml file in the following directory to see if I could read this file and see the UI.

`~/.config/gh-dash/config.yaml` 

If correct, the `config.yml` file should run without being generated.

## Images/Videos
![test](https://user-images.githubusercontent.com/26328745/200888912-4eba1427-4879-4866-9b82-90bdde53e57f.gif)



