### PR TITLE
fix: #124 exclude pull requests of archived repositories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  pull_request:
+    types:
+      - "opened"
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Test
+        run: go test -v ./...

--- a/data/prapi.go
+++ b/data/prapi.go
@@ -31,14 +31,16 @@ type PullRequestData struct {
 	HeadRef struct {
 		Name string
 	}
-	Repository struct {
-		NameWithOwner string
-		IsArchived    bool
-	}
+	Repository    Repository
 	Comments      Comments `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
 	LatestReviews Reviews  `graphql:"latestReviews(last: 3)"`
 	IsDraft       bool
 	Commits       Commits `graphql:"commits(last: 1)"`
+}
+
+type Repository struct {
+	NameWithOwner string
+	IsArchived    bool
 }
 
 type CheckRun struct {

--- a/data/prapi.go
+++ b/data/prapi.go
@@ -33,6 +33,7 @@ type PullRequestData struct {
 	}
 	Repository struct {
 		NameWithOwner string
+		IsArchived    bool
 	}
 	Comments      Comments `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
 	LatestReviews Reviews  `graphql:"latestReviews(last: 3)"`

--- a/ui/components/prssection/pressection_test.go
+++ b/ui/components/prssection/pressection_test.go
@@ -1,0 +1,99 @@
+package prssection
+
+import (
+	"testing"
+
+	"github.com/dlvhdr/gh-dash/data"
+)
+
+func Test_excludeArchivedPullRequests(t *testing.T) {
+	m := &Model{}
+
+	tests := []struct {
+		name     string
+		prs      []data.PullRequestData
+		expected int
+	}{
+		{
+			name: "Not all pull requests are archived",
+			prs: []data.PullRequestData{
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: false,
+					},
+				},
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: false,
+					},
+				},
+			},
+			expected: 2,
+		},
+		{
+			name: "All pull requests are archived",
+			prs: []data.PullRequestData{
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: true,
+					},
+				},
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: true,
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "There is only one archived pull request",
+			prs: []data.PullRequestData{
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: false,
+					},
+				},
+				{
+					Repository: struct {
+						NameWithOwner string
+						IsArchived    bool
+					}{
+						IsArchived: true,
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name:     "Empty pull requests",
+			prs:      []data.PullRequestData{},
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prs := m.excludeArchivedPullRequests(tt.prs)
+			actual := len(prs)
+			if actual != tt.expected {
+				t.Errorf("atcual : %d, expected: %d", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/ui/components/prssection/pressection_test.go
+++ b/ui/components/prssection/pressection_test.go
@@ -18,18 +18,12 @@ func Test_excludeArchivedPullRequests(t *testing.T) {
 			name: "Not all pull requests are archived",
 			prs: []data.PullRequestData{
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: false,
 					},
 				},
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: false,
 					},
 				},
@@ -40,18 +34,12 @@ func Test_excludeArchivedPullRequests(t *testing.T) {
 			name: "All pull requests are archived",
 			prs: []data.PullRequestData{
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: true,
 					},
 				},
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: true,
 					},
 				},
@@ -62,18 +50,12 @@ func Test_excludeArchivedPullRequests(t *testing.T) {
 			name: "There is only one archived pull request",
 			prs: []data.PullRequestData{
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: false,
 					},
 				},
 				{
-					Repository: struct {
-						NameWithOwner string
-						IsArchived    bool
-					}{
+					Repository: data.Repository{
 						IsArchived: true,
 					},
 				},

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -255,16 +255,29 @@ func (m *Model) FetchSectionRows() tea.Cmd {
 			}
 		}
 
-		sort.Slice(fetchedPrs, func(i, j int) bool {
-			return fetchedPrs[i].UpdatedAt.After(fetchedPrs[j].UpdatedAt)
+		filteredPrs := m.excludeArchivedPullRequests(fetchedPrs)
+
+		sort.Slice(filteredPrs, func(i, j int) bool {
+			return filteredPrs[i].UpdatedAt.After(filteredPrs[j].UpdatedAt)
 		})
 		return SectionPullRequestsFetchedMsg{
-			Prs: fetchedPrs,
+			Prs: filteredPrs,
 		}
 	}
 	cmds = append(cmds, m.MakeSectionCmd(cmd))
 
 	return tea.Batch(cmds...)
+}
+
+func (m *Model) excludeArchivedPullRequests(fetchedPrs []data.PullRequestData) []data.PullRequestData {
+	prs := make([]data.PullRequestData, 0)
+	for _, v := range fetchedPrs {
+		if v.Repository.IsArchived {
+			continue
+		}
+		prs = append(prs, v)
+	}
+	return prs
 }
 
 func FetchAllSections(ctx context.ProgramContext) (sections []section.Section, fetchAllCmd tea.Cmd) {


### PR DESCRIPTION
# Summary

I have seen this issue. I added a change to exclude PRs in archived repositories.

https://github.com/dlvhdr/gh-dash/issues/124

I would have liked to be able to remove PRs from archived repositories in the Github API arguments, but after checking the documentation I found it difficult to do so. I have added an implementation to remove pull requests from archived repositories after fetching pull requests.

## How did you test this change?

I wrote unit tests for the added functions.

I ran the command `gh dash` to see if it was successful in removing pull requests from archived repositories.

I used this archived repository.
https://github.com/yokishava/k8s-manifest-ci-demo

## Images/Videos

#### before
<img width="1410" alt="スクリーンショット 2022-11-11 1 47 38" src="https://user-images.githubusercontent.com/26328745/201158720-8d91140f-a390-4314-8bb2-c56f5aae23e7.png">


#### after
<img width="1421" alt="スクリーンショット 2022-11-11 1 48 08" src="https://user-images.githubusercontent.com/26328745/201158747-bb8a1172-1071-4ce0-9b84-176ef8594a33.png">

