### PR TITLE
Remove truncation of repo name.

### DIFF
--- a/ui/components/issue/issue.go
+++ b/ui/components/issue/issue.go
@@ -39,7 +39,7 @@ func (issue *Issue) renderUpdateAt() string {
 }
 
 func (issue *Issue) renderRepoName() string {
-	repoName := utils.TruncateString(issue.Data.Repository.Name, 18)
+	repoName := issue.Data.Repository.Name
 	return issue.getTextStyle().Render(repoName)
 }
 

--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -103,7 +103,7 @@ func (m Model) View() string {
 func (m *Model) renderFullNameAndNumber() string {
 	return lipgloss.NewStyle().
 		Foreground(m.ctx.Theme.SecondaryText).
-		Render(fmt.Sprintf("%s #%d", m.issue.Data.GetRepoNameWithOwner(), m.issue.Data.GetNumber()))
+		Render(fmt.Sprintf("#%d · %s", m.issue.Data.GetNumber(), m.issue.Data.GetRepoNameWithOwner()))
 }
 
 func (m *Model) renderTitle() string {

--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -1,6 +1,7 @@
 package issuesidebar
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -73,6 +74,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func (m Model) View() string {
 	s := strings.Builder{}
+
+	s.WriteString(m.renderFullNameAndNumber())
+	s.WriteString("\n")
+
 	s.WriteString(m.renderTitle())
 	s.WriteString("\n\n")
 	s.WriteString(m.renderStatusPill())
@@ -93,6 +98,12 @@ func (m Model) View() string {
 	}
 
 	return s.String()
+}
+
+func (m *Model) renderFullNameAndNumber() string {
+	return lipgloss.NewStyle().
+		Foreground(m.ctx.Theme.SecondaryText).
+		Render(fmt.Sprintf("%s #%d", m.issue.Data.GetRepoNameWithOwner(), m.issue.Data.GetNumber()))
 }
 
 func (m *Model) renderTitle() string {

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -140,7 +140,7 @@ func (pr *PullRequest) renderAuthor() string {
 }
 
 func (pr *PullRequest) renderRepoName() string {
-	repoName := utils.TruncateString(pr.Data.HeadRepository.Name, 18)
+	repoName := pr.Data.HeadRepository.Name
 	return pr.getTextStyle().Render(repoName)
 }
 

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -1,6 +1,7 @@
 package prsidebar
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -73,6 +74,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func (m Model) View() string {
 	s := strings.Builder{}
+
+	s.WriteString(m.renderFullNameAndNumber())
+	s.WriteString("\n")
+
 	s.WriteString(m.renderTitle())
 	s.WriteString("\n")
 	s.WriteString(m.renderBranches())
@@ -90,6 +95,12 @@ func (m Model) View() string {
 	}
 
 	return s.String()
+}
+
+func (m *Model) renderFullNameAndNumber() string {
+	return lipgloss.NewStyle().
+		Foreground(m.ctx.Theme.SecondaryText).
+		Render(fmt.Sprintf("%s #%d", m.pr.Data.GetRepoNameWithOwner(), m.pr.Data.GetNumber()))
 }
 
 func (m *Model) renderTitle() string {

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -100,7 +100,7 @@ func (m Model) View() string {
 func (m *Model) renderFullNameAndNumber() string {
 	return lipgloss.NewStyle().
 		Foreground(m.ctx.Theme.SecondaryText).
-		Render(fmt.Sprintf("%s #%d", m.pr.Data.GetRepoNameWithOwner(), m.pr.Data.GetNumber()))
+		Render(fmt.Sprintf("#%d · %s", m.pr.Data.GetNumber(), m.pr.Data.GetRepoNameWithOwner()))
 }
 
 func (m *Model) renderTitle() string {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -68,32 +68,6 @@ func OpenBrowser(url string) {
 	}
 }
 
-func TruncateString(str string, num int) string {
-	truncated := str
-	if num <= 3 {
-		return str
-	}
-	if len(str) > num {
-		if num > 3 {
-			num -= 3
-		}
-		truncated = str[0:num] + "…"
-	}
-	return truncated
-}
-
-func TruncateStringTrailing(str string, num int) string {
-	truncated := str
-	if len(str) > num {
-		if num > 3 {
-			num -= 3
-		}
-		skipped := len(str) - num
-		truncated = "..." + str[skipped:]
-	}
-	return truncated
-}
-
 func TimeElapsed(then time.Time) string {
 	var parts []string
 	var text string


### PR DESCRIPTION
# Summary

Removes truncation on repo name and adds full name + number to the sidebar. See #217 .

## How did you test this change?

Manually, with a repo name longer than the default of 18 characters.

## Images/Videos
