### PR TITLE
Add assignees to PRs.

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -62,6 +62,7 @@ type PrsLayoutConfig struct {
 	UpdatedAt    ColumnConfig `yaml:"updatedAt,omitempty"`
 	Repo         ColumnConfig `yaml:"repo,omitempty"`
 	Author       ColumnConfig `yaml:"author,omitempty"`
+	Assignees    ColumnConfig `yaml:"assignees,omitempty"`
 	Title        ColumnConfig `yaml:"title,omitempty"`
 	ReviewStatus ColumnConfig `yaml:"reviewStatus,omitempty"`
 	State        ColumnConfig `yaml:"state,omitempty"`
@@ -181,6 +182,9 @@ func (parser ConfigParser) getDefaultConfig() Config {
 					},
 					Author: ColumnConfig{
 						Width: utils.IntPtr(15),
+					},
+					Assignees: ColumnConfig{
+						Width: utils.IntPtr(20),
 					},
 					Lines: ColumnConfig{
 						Width: utils.IntPtr(lipgloss.Width("123450 / -123450")),

--- a/data/assignee.go
+++ b/data/assignee.go
@@ -1,0 +1,9 @@
+package data
+
+type Assignees struct {
+	Nodes []Assignee
+}
+
+type Assignee struct {
+	Login string
+}

--- a/data/issueapi.go
+++ b/data/issueapi.go
@@ -25,14 +25,6 @@ type IssueData struct {
 	Labels     IssueLabels    `graphql:"labels(first: 3)"`
 }
 
-type Assignees struct {
-	Nodes []Assignee
-}
-
-type Assignee struct {
-	Login string
-}
-
 type IssueReactions struct {
 	TotalCount int
 }

--- a/data/prapi.go
+++ b/data/prapi.go
@@ -31,8 +31,9 @@ type PullRequestData struct {
 		Name string
 	}
 	Repository    Repository
-	Comments      Comments `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
-	LatestReviews Reviews  `graphql:"latestReviews(last: 3)"`
+	Assignees     Assignees `graphql:"assignees(first: 3)"`
+	Comments      Comments  `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
+	LatestReviews Reviews   `graphql:"latestReviews(last: 3)"`
 	IsDraft       bool
 	Commits       Commits `graphql:"commits(last: 1)"`
 }

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -2,6 +2,7 @@ package pr
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dlvhdr/gh-dash/data"
@@ -139,6 +140,14 @@ func (pr *PullRequest) renderAuthor() string {
 	return pr.getTextStyle().Render(pr.Data.Author.Login)
 }
 
+func (pr *PullRequest) renderAssignees() string {
+	assignees := make([]string, 0, len(pr.Data.Assignees.Nodes))
+	for _, assignee := range pr.Data.Assignees.Nodes {
+		assignees = append(assignees, assignee.Login)
+	}
+	return pr.getTextStyle().Render(strings.Join(assignees, ","))
+}
+
 func (pr *PullRequest) renderRepoName() string {
 	repoName := pr.Data.HeadRepository.Name
 	return pr.getTextStyle().Render(repoName)
@@ -173,6 +182,7 @@ func (pr *PullRequest) ToTableRow() table.Row {
 		pr.renderRepoName(),
 		pr.renderTitle(),
 		pr.renderAuthor(),
+		pr.renderAssignees(),
 		pr.renderReviewStatus(),
 		pr.renderCiStatus(),
 		pr.renderLines(),

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -146,6 +146,7 @@ func GetSectionColumns(cfg config.PrsSectionConfig, ctx *context.ProgramContext)
 	repoLayout := config.MergeColumnConfigs(dLayout.Repo, sLayout.Repo)
 	titleLayout := config.MergeColumnConfigs(dLayout.Title, sLayout.Title)
 	authorLayout := config.MergeColumnConfigs(dLayout.Author, sLayout.Author)
+	assigneesLayout := config.MergeColumnConfigs(dLayout.Assignees, sLayout.Assignees)
 	reviewStatusLayout := config.MergeColumnConfigs(dLayout.ReviewStatus, sLayout.ReviewStatus)
 	stateLayout := config.MergeColumnConfigs(dLayout.State, sLayout.State)
 	ciLayout := config.MergeColumnConfigs(dLayout.Ci, sLayout.Ci)
@@ -175,6 +176,11 @@ func GetSectionColumns(cfg config.PrsSectionConfig, ctx *context.ProgramContext)
 			Title:  "Author",
 			Width:  authorLayout.Width,
 			Hidden: authorLayout.Hidden,
+		},
+		{
+			Title:  "Assignees",
+			Width:  assigneesLayout.Width,
+			Hidden: assigneesLayout.Hidden,
 		},
 		{
 			Title:  "",


### PR DESCRIPTION
# Summary

This PR adds the `assignees` field to PRs. It is essentially identical to what already exists for issues. The default configuration is for this field to be rendered (i.e. `hidden: false`) - as is the case for issues - and the length is `20` - again, the same as for issues.

I (and others on my team) use the assignment feature to keep track of PRs that we are responsible for, independent of who created the PR. It is helpful for us to see which PRs are unassigned or assigned to others.

## How did you test this change?

I tested this change by configuring the dashboard to look at repositories with a mixture of assigned and unassigned PRs. See screenshot below.

## Images/Videos

<img width="1905" alt="Screen Shot 2023-01-19 at 1 02 58 PM" src="https://user-images.githubusercontent.com/7230694/213524397-14b7c31e-5555-4e68-b9cb-1326c3aee709.png">
