### PR TITLE
Add support for custom keybindings on issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,16 +149,28 @@ It can be useful if you want to have a 🧳 work and 👩‍💻 personal dashbo
 ### ⌨️ Keybindings
 
 Define your own custom keybindings to run bash commands using [Go Templates](https://pkg.go.dev/text/template).
-The available arguments are:
+This is available for both PRs and Issues.
 
-| Arguement     | Description                                                                     |
+For PRs, the available arguments are:
+
+| Argument      | Description                                                                     |
 | ------------- | ------------------------------------------------------------------------------- |
 | `RepoName`    | The full name of the repo (e.g. `dlvhdr/gh-dash`)                               |
 | `RepoPath`    | The path to the Repo, using the `config.yml` `repoPaths` key to get the mapping |
 | `PrNumber`    | The PR number                                                                   |
 | `HeadRefName` | The PR's remote branch name                                                     |
 
-For example, to review a PR with either Neovim or VSCode, include this in your `config.yml` file:
+For Issues, the available arguments are:
+
+| Argument      | Description                                                                     |
+| ------------- | ------------------------------------------------------------------------------- |
+| `RepoName`    | The full name of the repo (e.g. `dlvhdr/gh-dash`)                               |
+| `RepoPath`    | The path to the Repo, using the `config.yml` `repoPaths` key to get the mapping |
+| `IssueNumber` | The Issue number                                                                |
+
+#### Examples
+
+To review a PR with either Neovim or VSCode include the following in your `config.yml` file:
 
 ```yaml
 repoPaths:
@@ -177,6 +189,15 @@ keybindings:
         cd {{.RepoPath}} &&
         code . &&
         gh pr checkout {{.PrNumber}}
+```
+
+To pin an issue include the following in your `config.yml` file:
+
+```yaml
+keybindings:
+  issues:
+    - key: P
+      command: gh issue pin {{.IssueNumber}} --repo {.RepoName}
 ```
 
 ### 🚥 Repo Path Matching

--- a/config/parser.go
+++ b/config/parser.go
@@ -101,7 +101,8 @@ type Keybinding struct {
 }
 
 type Keybindings struct {
-	Prs []Keybinding `yaml:"prs"`
+	Issues []Keybinding `yaml:"issues"`
+	Prs    []Keybinding `yaml:"prs"`
 }
 
 type Pager struct {
@@ -235,7 +236,8 @@ func (parser ConfigParser) getDefaultConfig() Config {
 			},
 		},
 		Keybindings: Keybindings{
-			Prs: []Keybinding{},
+			Issues: []Keybinding{},
+			Prs:    []Keybinding{},
 		},
 		RepoPaths: map[string]string{},
 	}

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -12,6 +12,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/dlvhdr/gh-dash/config"
 	"github.com/dlvhdr/gh-dash/data"
 	"github.com/dlvhdr/gh-dash/ui/components/section"
 	"github.com/dlvhdr/gh-dash/ui/constants"
@@ -88,7 +89,14 @@ func getRepoLocalPath(repoName string, cfgPaths map[string]string) string {
 	return repoPath
 }
 
-type CommandTemplateInput struct {
+type IssueCommandTemplateInput struct {
+	RepoName    string
+	RepoPath    string
+	IssueNumber int
+	HeadRefName string
+}
+
+type PRCommandTemplateInput struct {
 	RepoName    string
 	RepoPath    string
 	PrNumber    int
@@ -97,47 +105,94 @@ type CommandTemplateInput struct {
 
 func (m *Model) executeKeybinding(key string) tea.Cmd {
 	currRowData := m.getCurrRowData()
-	for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-		if keybinding.Key != key {
-			continue
-		}
 
-		switch data := currRowData.(type) {
-		case *data.PullRequestData:
-			return m.runCustomCommand(keybinding.Command, data)
+	switch m.ctx.View {
+	case config.IssuesView:
+		for _, keybinding := range m.ctx.Config.Keybindings.Issues {
+			if keybinding.Key != key {
+				continue
+			}
+
+			switch data := currRowData.(type) {
+			case *data.IssueData:
+				return m.runCustomIssueCommand(keybinding.Command, data)
+			}
 		}
+	case config.PRsView:
+		for _, keybinding := range m.ctx.Config.Keybindings.Prs {
+			if keybinding.Key != key {
+				continue
+			}
+
+			switch data := currRowData.(type) {
+			case *data.PullRequestData:
+				return m.runCustomPRCommand(keybinding.Command, data)
+			}
+		}
+	default:
+		// Not a valid case - ignore it
 	}
+
 	return nil
 }
 
-func (m *Model) runCustomCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
-	cmd, err := template.New("keybinding_command").Parse(commandTemplate)
-	if err != nil {
-		log.Fatal(err)
-	}
+func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
 	repoName := prData.GetRepoNameWithOwner()
 	repoPath := getRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
 
-	var buff bytes.Buffer
-	err = cmd.Execute(&buff, CommandTemplateInput{
+	input := PRCommandTemplateInput{
 		RepoName:    repoName,
 		RepoPath:    repoPath,
 		PrNumber:    prData.Number,
 		HeadRefName: prData.HeadRefName,
-	})
+	}
+
+	cmd, err := template.New("keybinding_command").Parse(commandTemplate)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	var buff bytes.Buffer
+	err = cmd.Execute(&buff, input)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return m.executeCustomCommand(buff.String())
+}
+
+func (m *Model) runCustomIssueCommand(commandTemplate string, issueData *data.IssueData) tea.Cmd {
+	repoName := issueData.GetRepoNameWithOwner()
+	repoPath := getRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+
+	input := IssueCommandTemplateInput{
+		RepoName:    repoName,
+		RepoPath:    repoPath,
+		IssueNumber: issueData.Number,
+	}
+
+	cmd, err := template.New("keybinding_command").Parse(commandTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var buff bytes.Buffer
+	err = cmd.Execute(&buff, input)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return m.executeCustomCommand(buff.String())
+}
+
+func (m *Model) executeCustomCommand(cmd string) tea.Cmd {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		shell = "sh"
 	}
-	c := exec.Command(shell, "-c", buff.String())
+	c := exec.Command(shell, "-c", cmd)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		if err != nil {
 			mdRenderer := markdown.GetMarkdownRenderer(m.ctx.ScreenWidth)
-			md, mdErr := mdRenderer.Render(fmt.Sprintf("While running: `%s`", buff.String()))
+			md, mdErr := mdRenderer.Render(fmt.Sprintf("While running: `%s`", cmd))
 			if mdErr != nil {
 				return constants.ErrMsg{Err: mdErr}
 			}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -518,13 +518,19 @@ func (m *Model) switchSelectedView() config.ViewType {
 }
 
 func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
-	if m.ctx.View != config.PRsView {
-		return false
+	if m.ctx.View == config.IssuesView {
+		for _, keybinding := range m.ctx.Config.Keybindings.Issues {
+			if keybinding.Key == msg.String() {
+				return true
+			}
+		}
 	}
 
-	for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-		if keybinding.Key == msg.String() {
-			return true
+	if m.ctx.View == config.PRsView {
+		for _, keybinding := range m.ctx.Config.Keybindings.Prs {
+			if keybinding.Key == msg.String() {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary

This PR adds support for custom keybindings for issues. This is essentially identical to what already exists for PRs. I personally leverage this feature quite a lot, and it will also make it easy to iterate on any potential future built-in commands for issues, as we can prototype them first via this mechanism.

There are a few areas where the de-duplication between issues and PRs could have achieved in multiple different ways. For example, one could leverage generics, but I felt the overhead wasn't worth the minor reduction in code.

If you want to refactor things a different way - no problem. Just let me know

## How did you test this change?

I added the example issue keybinding from the readme and validated that it worked as expected.

## Images/Videos

None - because the lack of feedback when running custom commands makes it hard to demonstrate via images/video.
