### PR TITLE
Bump version to 3.7.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:     "gh dash",
 		Short:   "A gh extension that shows a configurable dashboard of pull requests and issues.",
-		Version: "3.5.1",
+		Version: "3.7.0",
 	}
 )
 


### PR DESCRIPTION
# Summary

Bump hard-coded version used by `--version` flag.

## How did you test this change?

Before:

```
❯ go run . --version
gh dash version 3.5.1
```

After:

```
❯ go run . --version
gh dash version 3.7.0
```
