### PR TITLE
Wildcard matching builtin

### DIFF
--- a/ui/common/repopath.go
+++ b/ui/common/repopath.go
@@ -5,17 +5,29 @@ import (
 	"strings"
 )
 
-// support [user|org]/* matching for repositories
-// and local path mapping to [partial path prefix]/*
-// prioritize full repo mapping if it exists
-func GetRepoLocalPath(repoName string, cfgPaths map[string]string) string {
+// GetRepoLocalPath returns the local path for a given repo name.
+// It will return the path if it exists in the config, or if the
+// repo name matches a wildcard path in the config.
+// It will prioritize exact repo name matches over wildcard matches.
+// If the second return value is true, the first return value is guaranteed
+// to be a valid path.
+// If the second return value is false, the first return value is undefined.
+// For a given config of:
+//
+//	{
+//	  "user/repo": "/path/to/user/repo",
+//	  "user_2/*":  "/path/to/user_2/*",
+//	}
+//
+// GetRepoLocalPath("user/repo", config) will return: "/path/to/user/repo", true
+// GetRepoLocalPath("user_2/some_repo", config) will return: "/path/to/user_2/some_repo", true
+// GetRepoLocalPath("user/other_repo", config) will return: "", false
+func GetRepoLocalPath(repoName string, cfgPaths map[string]string) (string, bool) {
 	exactMatchPath, ok := cfgPaths[repoName]
 	// prioritize full repo to path mapping in config
 	if ok {
-		return exactMatchPath
+		return exactMatchPath, true
 	}
-
-	var repoPath string
 
 	owner, repo, repoValid := func() (string, string, bool) {
 		repoParts := strings.Split(repoName, "/")
@@ -23,15 +35,18 @@ func GetRepoLocalPath(repoName string, cfgPaths map[string]string) string {
 		return repoParts[0], repoParts[len(repoParts)-1], len(repoParts) == 2
 	}()
 
-	if repoValid {
-		// match config:repoPath values of {owner}/* as map key
-		wildcardPath, wildcarded := cfgPaths[fmt.Sprintf("%s/*", owner)]
-
-		if wildcarded {
-			// adjust wildcard match to wildcard path - ~/somepath/* to ~/somepath/{repo}
-			repoPath = fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo)
-		}
+	if !repoValid {
+		return "", false
 	}
 
-	return repoPath
+	// match config:repoPath values of {owner}/* as map key
+	wildcardPath, wildcardFound := cfgPaths[fmt.Sprintf("%s/*", owner)]
+
+	if !wildcardFound {
+		return "", false
+	}
+
+	// adjust wildcard match to wildcard path - ~/somepath/* to ~/somepath/{repo}
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo), true
+
 }

--- a/ui/common/repopath.go
+++ b/ui/common/repopath.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// support [user|org]/* matching for repositories
+// and local path mapping to [partial path prefix]/*
+// prioritize full repo mapping if it exists
+func GetRepoLocalPath(repoName string, cfgPaths map[string]string) string {
+	exactMatchPath, ok := cfgPaths[repoName]
+	// prioritize full repo to path mapping in config
+	if ok {
+		return exactMatchPath
+	}
+
+	var repoPath string
+
+	owner, repo, repoValid := func() (string, string, bool) {
+		repoParts := strings.Split(repoName, "/")
+		// return repo owner, repo, and indicate properly owner/repo format
+		return repoParts[0], repoParts[len(repoParts)-1], len(repoParts) == 2
+	}()
+
+	if repoValid {
+		// match config:repoPath values of {owner}/* as map key
+		wildcardPath, wildcarded := cfgPaths[fmt.Sprintf("%s/*", owner)]
+
+		if wildcarded {
+			// adjust wildcard match to wildcard path - ~/somepath/* to ~/somepath/{repo}
+			repoPath = fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo)
+		}
+	}
+
+	return repoPath
+}

--- a/ui/common/repopath_test.go
+++ b/ui/common/repopath_test.go
@@ -15,7 +15,10 @@ var (
 
 func TestGetRepoLocalPathExactMatch(t *testing.T) {
 	want := "/path/to/user/repo"
-	got := common.GetRepoLocalPath("user/repo", configPaths)
+	got, found := common.GetRepoLocalPath("user/repo", configPaths)
+	if !found {
+		t.Errorf("expected to find path for repo 'user/repo'")
+	}
 	if want != got {
 		t.Errorf("want '%s', got '%s'", want, got)
 	}
@@ -23,7 +26,10 @@ func TestGetRepoLocalPathExactMatch(t *testing.T) {
 
 func TestGetRepoLocalPathExactNoMatch(t *testing.T) {
 	want := ""
-	got := common.GetRepoLocalPath("user/other_repo", configPaths)
+	got, found := common.GetRepoLocalPath("user/other_repo", configPaths)
+	if found {
+		t.Errorf("expected to not find path for repo 'user/other_repo'")
+	}
 	if want != got {
 		t.Errorf("want '%s', got '%s'", want, got)
 	}
@@ -31,7 +37,10 @@ func TestGetRepoLocalPathExactNoMatch(t *testing.T) {
 
 func TestGetRepoLocalPathWildcardMatch(t *testing.T) {
 	want := "/path/to/user_2/repo123"
-	got := common.GetRepoLocalPath("user_2/repo123", configPaths)
+	got, found := common.GetRepoLocalPath("user_2/repo123", configPaths)
+	if !found {
+		t.Errorf("expected to find path for repo 'user_2/repo123'")
+	}
 	if want != got {
 		t.Errorf("want '%s', got '%s'", want, got)
 	}
@@ -39,7 +48,10 @@ func TestGetRepoLocalPathWildcardMatch(t *testing.T) {
 
 func TestGetRepoLocalPathBadPath(t *testing.T) {
 	want := ""
-	got := common.GetRepoLocalPath("invalid-lookup", configPaths)
+	got, found := common.GetRepoLocalPath("invalid-lookup", configPaths)
+	if found {
+		t.Errorf("expected to not find path for repo 'invalid-lookup'")
+	}
 	if want != got {
 		t.Errorf("want '%s', got '%s'", want, got)
 	}

--- a/ui/common/repopath_test.go
+++ b/ui/common/repopath_test.go
@@ -1,0 +1,46 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/dlvhdr/gh-dash/ui/common"
+)
+
+var (
+	configPaths = map[string]string{
+		"user/repo": "/path/to/user/repo",
+		"user_2/*":  "/path/to/user_2/*",
+	}
+)
+
+func TestGetRepoLocalPathExactMatch(t *testing.T) {
+	want := "/path/to/user/repo"
+	got := common.GetRepoLocalPath("user/repo", configPaths)
+	if want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}
+
+func TestGetRepoLocalPathExactNoMatch(t *testing.T) {
+	want := ""
+	got := common.GetRepoLocalPath("user/other_repo", configPaths)
+	if want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}
+
+func TestGetRepoLocalPathWildcardMatch(t *testing.T) {
+	want := "/path/to/user_2/repo123"
+	got := common.GetRepoLocalPath("user_2/repo123", configPaths)
+	if want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}
+
+func TestGetRepoLocalPathBadPath(t *testing.T) {
+	want := ""
+	got := common.GetRepoLocalPath("invalid-lookup", configPaths)
+	if want != got {
+		t.Errorf("want '%s', got '%s'", want, got)
+	}
+}

--- a/ui/components/prssection/checkout.go
+++ b/ui/components/prssection/checkout.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dlvhdr/gh-dash/ui/common"
 	"github.com/dlvhdr/gh-dash/ui/constants"
 	"github.com/dlvhdr/gh-dash/ui/context"
 )
@@ -15,9 +16,9 @@ import (
 func (m *Model) checkout() (tea.Cmd, error) {
 	pr := m.GetCurrRow()
 	repoName := pr.GetRepoNameWithOwner()
-	repoPath, ok := m.Ctx.Config.RepoPaths[repoName]
+	repoPath := common.GetRepoLocalPath(repoName, m.Ctx.Config.RepoPaths)
 
-	if !ok {
+	if repoPath == "" {
 		return nil, errors.New("Local path to repo not specified, set one in your config.yml under repoPaths")
 	}
 

--- a/ui/components/prssection/checkout.go
+++ b/ui/components/prssection/checkout.go
@@ -16,9 +16,9 @@ import (
 func (m *Model) checkout() (tea.Cmd, error) {
 	pr := m.GetCurrRow()
 	repoName := pr.GetRepoNameWithOwner()
-	repoPath := common.GetRepoLocalPath(repoName, m.Ctx.Config.RepoPaths)
+	repoPath, ok := common.GetRepoLocalPath(repoName, m.Ctx.Config.RepoPaths)
 
-	if repoPath == "" {
+	if !ok {
 		return nil, errors.New("Local path to repo not specified, set one in your config.yml under repoPaths")
 	}
 

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -107,7 +107,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 
 func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
 	repoName := prData.GetRepoNameWithOwner()
-	repoPath := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
 
 	input := PRCommandTemplateInput{
 		RepoName:    repoName,
@@ -131,7 +131,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 
 func (m *Model) runCustomIssueCommand(commandTemplate string, issueData *data.IssueData) tea.Cmd {
 	repoName := issueData.GetRepoNameWithOwner()
-	repoPath := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
 
 	input := IssueCommandTemplateInput{
 		RepoName:    repoName,

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -107,7 +107,13 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 
 func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
 	repoName := prData.GetRepoNameWithOwner()
-	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+	repoPath, ok := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+
+	if !ok {
+		return func() tea.Msg {
+			return constants.ErrMsg{Err: fmt.Errorf("Failed to find local path for repo %s", repoName)}
+		}
+	}
 
 	input := PRCommandTemplateInput{
 		RepoName:    repoName,
@@ -131,7 +137,13 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 
 func (m *Model) runCustomIssueCommand(commandTemplate string, issueData *data.IssueData) tea.Cmd {
 	repoName := issueData.GetRepoNameWithOwner()
-	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+	repoPath, ok := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
+
+	if !ok {
+		return func() tea.Msg {
+			return constants.ErrMsg{Err: fmt.Errorf("Failed to find local path for repo %s", repoName)}
+		}
+	}
 
 	input := IssueCommandTemplateInput{
 		RepoName:    repoName,


### PR DESCRIPTION
# Summary

This PR adds support for using wildcard paths for repo lookup for built-in commands in addition to the existing support for custom commands. Currently only custom commands support wildcard lookups for repo paths.

I had to refactor the existing code into a third package to avoid an import loop.

Additionally, as part of this refactor, I was able to improve the error handling for custom commands when the repo lookup failed.

Finally, I added unit tests for the wildcard matching, as I felt it was the easiest way to track the behavior of this function. I used vanilla golang testing - I did not add any additional libraries.

Fixes #250 

## How did you test this change?

I confirmed that this change allows wildcard matching for built-in commands via manual testing. I used the `C`/`checkout` command as that interacts with the file system. For improving the custom command error handling, I used the example from the README:

```
keybindings:
  prs:
    - key: v
      command: >
        cd {{.RepoPath}} &&
        code . &&
        gh pr checkout {{.PrNumber}}
```

For the built-in commands, before the change I would see the error:

```
Local path to repo not specified, set one in your config.yml under repoPaths
```

After the change I would see the command succeed.


For the custom commands, previously it would give an unhelpful error:

```
Whoops, got an error: exit status 127
```

And now it gives the more familiar (and useful) error:

```
Local path to repo not specified, set one in your config.yml under repoPaths
```

All tests were done with a valid config for wildcard paths.

## Images/Videos

I can add them if we think this is necessary.