### PR TITLE
linux arm v6 and v7 compilation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,11 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - "386"
     ldflags:
       - -s -w
       - -X github.com/dlvhdr/gh-dash/cmd.Version={{.Version}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
       - linux
       - windows
       - darwin
+      - android
     goarch:
       - amd64
       - arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,12 +10,14 @@ builds:
       - linux
       - windows
       - darwin
-      - android
     goarch:
       - amd64
       - arm64
       - arm
       - "386"
+    goarm:
+      - 6
+      - 7
     ldflags:
       - -s -w
       - -X github.com/dlvhdr/gh-dash/cmd.Version={{.Version}}


### PR DESCRIPTION
# Summary
This adds support for 32 bit arm as well as android arm64 to fix #266.  This is definitely a niche change, and while I did try to take care of #249 at the same time, I ran into android specific compilation errors so abandoned that change.

## How did you test this change?
I only tested the build procedure, not the actual running software due to lack of hardware.

## Images/Videos
<img width="956" alt="Screenshot 2023-05-02 at 7 24 44 PM" src="https://user-images.githubusercontent.com/839261/235822131-a5a24380-28f3-4fe0-b125-5fc1dc469d09.png">
