### PR TITLE
(MAINT) Update docs site dependencies & build

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -56,7 +56,7 @@ jobs:
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
 
       - name: Setup Hugo modules
-        run: hugo mod get -u
+        run: hugo mod get
         working-directory: ./docs
 
       - name: Build with Hugo

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -78,6 +79,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,6 +3,6 @@ module github.com/dlvhdr/gh-dash/docs
 go 1.19
 
 require (
-	github.com/platenio/platen/modules/platen v0.0.0-20230504053552-c70b34ba1161 // indirect
-	github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161 // indirect
+	github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a // indirect
+	github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -2,7 +2,11 @@ github.com/platenio/platen/modules/platen v0.0.0-20230417130935-f8a3fca1013d h1:
 github.com/platenio/platen/modules/platen v0.0.0-20230417130935-f8a3fca1013d/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/platen v0.0.0-20230504053552-c70b34ba1161 h1:ggnlUsTuC2E4sGxASlX+qmMBtuYP0vkKWgVj8tZZDpE=
 github.com/platenio/platen/modules/platen v0.0.0-20230504053552-c70b34ba1161/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
+github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a h1:KGJf06tIhskc3foiPrp8mCn964g6WXaUZ4gc84CkgUg=
+github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d h1:PhpSZzd1YFHCZzsJJinIHoMU3Bw/w/GPYkWXz/flnvU=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
 github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161 h1:t0wxjK59xg5ggSEpWEZHtooO0COoV5oC/WFIPcJLhRM=
 github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
+github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a h1:u1oDxHF2VElyGBZxJPqGU3ozEQvJWBfpjx6APNHEL24=
+github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -23,11 +23,11 @@ menu:
 
 module:
   replacements: >-
-    https://github.com/dlvhdr/gh-dash -> ../
+    github.com/dlvhdr/gh-dash -> ../
   imports:
     - path: github.com/platenio/platen/modules/platen
     - path: github.com/platenio/platen/modules/schematize
-    - path: https://github.com/dlvhdr/gh-dash
+    - path: github.com/dlvhdr/gh-dash
       ignoreConfig: true
       ignoreImports: true
 


### PR DESCRIPTION
# Summary

Prior to this change, the docs site could not build in GHA because it was being built for a base URL that is in a folder after the top-level domain name. This change updates the Hugo module dependencies now that a fix for this bug was merged upstream for the schematize module.

This change also corrects the module declaration for `gh-dash`, which should not have any effect as the module is replaced with the local reference in the configuration, but might as well be technically correct.

Finally, this change updates the GHA for building the site, removing the `-u` flag from the module install, which updates the modules. This way, dependency updates can be intentional and the `go.mod` / `go.sum` files in the repository are the sources of truth.

## How did you test this change?

Local build/serve with the updated URL, ensured a clean build and correct rendering.

## Images/Videos

N/A