### PR TITLE
(MAINT) Fix docs icon spacing

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,25 +4,25 @@ summary: >-
   This is an example site for digital books, built on Platen!
 ---
 
-![icon:stars](lucide) A GitHub (`gh`) CLI extension to display a dashboard with **pull requests**
+![icon:stars](lucide)&nbsp;A GitHub (`gh`) CLI extension to display a dashboard with **pull requests**
 and **issues** by filters you care about.
 
 [![Latest Release][shield-release]][releases]
 
 ![Preview gif showing gh-dash in the terminal][preview]
 
-## ![icon:stars](lucide) Features
+## ![icon:stars](lucide)&nbsp;Features
 
-- ![icon:settings](lucide) fully configurable - define sections using github filters
-- ![icon:search](lucide) search for both prs and issues
-- ![icon:edit](lucide) customize columns with `hidden`, `width` and `grow` props
-- ![icon:zap](lucide) act on prs and issues with checkout, comment, open, merge, diff, etc...
-- ![icon:keyboard](lucide) set custom actions with new keybindings
-- ![icon:palette](lucide) use custom themes
-- ![icon:view](lucide) view details about a pr/issue with a detailed sidebar
-- ![icon:layout-dashboard](lucide) write multiple configuration files to easily switch between
+- ![icon:settings](lucide)&nbsp;fully configurable - define sections using github filters
+- ![icon:search](lucide)&nbsp;search for both prs and issues
+- ![icon:edit](lucide)&nbsp;customize columns with `hidden`, `width` and `grow` props
+- ![icon:zap](lucide)&nbsp;act on prs and issues with checkout, comment, open, merge, diff, etc...
+- ![icon:keyboard](lucide)&nbsp;set custom actions with new keybindings
+- ![icon:palette](lucide)&nbsp;use custom themes
+- ![icon:view](lucide)&nbsp;view details about a pr/issue with a detailed sidebar
+- ![icon:layout-dashboard](lucide)&nbsp;write multiple configuration files to easily switch between
   completely different dashboards
-- ![icon:recycle](lucide) set an interval for auto refreshing the dashboard
+- ![icon:recycle](lucide)&nbsp;set an interval for auto refreshing the dashboard
 
 <!-- Link reference definitions -->
 [shield-release]: https://img.shields.io/github/release/dlvhdr/gh-dash.svg

--- a/docs/content/configuration/defaults.md
+++ b/docs/content/configuration/defaults.md
@@ -1,7 +1,7 @@
 ---
 title: Defaults
 linkTitle: >-
-  ![icon:settings-2](lucide) Defaults
+  ![icon:settings-2](lucide)&nbsp;Defaults
 summary: >-
   Documentation for the `defaults` setting options for your GitHub dashboard.
 weight: 4

--- a/docs/content/configuration/gh-dash.md
+++ b/docs/content/configuration/gh-dash.md
@@ -1,7 +1,7 @@
 ---
 title: Schema
 linkTitle: >-
-  ![icon:file-code-2](lucide)  Schema
+  ![icon:file-code-2](lucide)&nbsp;Schema
 summary: >-
   Documentation and schema for the configuration of your GitHub dashboard.
 weight: 1

--- a/docs/content/configuration/issue-section.md
+++ b/docs/content/configuration/issue-section.md
@@ -1,7 +1,7 @@
 ---
 title: Issue Section
 linkTitle: >-
-  ![icon:circle-dot](lucide) Issue Section
+  ![icon:circle-dot](lucide)&nbsp;Issue Section
 summary: >-
   Documentation for configuring the issues sections of your GitHub dashboard.
 weight: 3

--- a/docs/content/configuration/keybindings/_index.md
+++ b/docs/content/configuration/keybindings/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Keybindings
 linkTitle: >-
-  ![icon:keyboard](lucide) Keybindings
+  ![icon:keyboard](lucide)&nbsp;Keybindings
 summary: Documentation for defining commands for your GitHub dashboard.
 weight: 6
 platen:

--- a/docs/content/configuration/keybindings/entry.md
+++ b/docs/content/configuration/keybindings/entry.md
@@ -1,7 +1,7 @@
 ---
 title: Valid Keybindings
 linkTitle: >-
-  ![icon:check-check](lucide) Valid Keybindings
+  ![icon:check-check](lucide)&nbsp;Valid Keybindings
 summary: >-
   Documentation for defining a valid keybinding in your GitHub dashboard.
 weight: 99

--- a/docs/content/configuration/keybindings/issues.md
+++ b/docs/content/configuration/keybindings/issues.md
@@ -1,7 +1,7 @@
 ---
 title: Issues
 linkTitle: >-
-  ![icon:circle-dot](lucide) Issues
+  ![icon:circle-dot](lucide)&nbsp;Issues
 weight: 2
 summary: >-
   Documentation for defining commands in the Issues view of your GitHub dashboard.

--- a/docs/content/configuration/keybindings/prs.md
+++ b/docs/content/configuration/keybindings/prs.md
@@ -1,7 +1,7 @@
 ---
 title: PRs
 linkTitle: >-
-  ![icon:git-pull-request](lucide) PRs
+  ![icon:git-pull-request](lucide)&nbsp;PRs
 weight: 1
 summary: >-
   Documentation for defining commands in the PRs view of your GitHub dashboard.

--- a/docs/content/configuration/layout/_index.md
+++ b/docs/content/configuration/layout/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Layout
 linkTitle: >-
-  ![icon:layout-dashboard](lucide) Layout
+  ![icon:layout-dashboard](lucide)&nbsp;Layout
 summary: Documentation for configuring your GitHub dashboard's layout.
 weight: 5
 platen:

--- a/docs/content/configuration/layout/issue.md
+++ b/docs/content/configuration/layout/issue.md
@@ -1,7 +1,7 @@
 ---
 title: Issue Layout
 linkTitle: >-
-  ![icon:circle-dot](lucide) Issue Layout
+  ![icon:circle-dot](lucide)&nbsp;Issue Layout
 weight: 2
 summary: >-
   Documentation for defining the layout of an issue section in your GitHub dashboard.

--- a/docs/content/configuration/layout/options.md
+++ b/docs/content/configuration/layout/options.md
@@ -1,7 +1,7 @@
 ---
 title: Valid Options
 linkTitle: >-
-  ![icon:check-check](lucide) Valid Options
+  ![icon:check-check](lucide)&nbsp;Valid Options
 summary: >-
   Documentation for the valid options of columns in your GitHub dashboard's layout.
 weight: 99

--- a/docs/content/configuration/layout/pr.md
+++ b/docs/content/configuration/layout/pr.md
@@ -1,7 +1,7 @@
 ---
 title: PR Layout
 linkTitle: >-
-  ![icon:git-pull-request](lucide) PR Layout
+  ![icon:git-pull-request](lucide)&nbsp;PR Layout
 weight: 1
 summary: >-
   Documentation for defining the layout of a PR section in your GitHub dashboard.

--- a/docs/content/configuration/pr-section.md
+++ b/docs/content/configuration/pr-section.md
@@ -1,7 +1,7 @@
 ---
 title: PR Section
 linkTitle: >-
-  ![icon:git-pull-request](lucide) PR Section
+  ![icon:git-pull-request](lucide)&nbsp;PR Section
 summary: >-
   Documentation for configuring the PR sections of your GitHub dashboard.
 weight: 2

--- a/docs/content/configuration/theme.md
+++ b/docs/content/configuration/theme.md
@@ -1,7 +1,7 @@
 ---
 title: Theme
 linkTitle: >-
-  ![icon:palette](lucide) Theme
+  ![icon:palette](lucide)&nbsp;Theme
 summary: >-
   Documentation for configuring your GitHub dashboard's theme.
 weight: 7

--- a/docs/content/contributing/_index.md
+++ b/docs/content/contributing/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 linkTitle: >-
-  ![icon:heart-handshake](lucide) Contributing
+  ![icon:heart-handshake](lucide)&nbsp;Contributing
 summary: >-
   Explains how folks can contribute to the `gh-dash` project.
 weight: 3

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 linkTitle: >-
-  ![icon:package-open](lucide) Installation
+  ![icon:package-open](lucide)&nbsp;Installation
 summary: >-
   Get started installing `gh-dash`.
 weight: 1

--- a/docs/content/getting-started/keybindings/_index.md
+++ b/docs/content/getting-started/keybindings/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Keybindings
 linkTitle: >-
-  ![icon:keyboard](lucide) Keybindings
+  ![icon:keyboard](lucide)&nbsp;Keybindings
 weight: 3
 summary: >-
   Get started using key presses to interact with the dashboard.

--- a/docs/content/getting-started/keybindings/global.md
+++ b/docs/content/getting-started/keybindings/global.md
@@ -1,7 +1,7 @@
 ---
 title: Global
 linkTitle: >-
-  ![icon:globe](lucide) Global
+  ![icon:globe](lucide)&nbsp;Global
 weight: 1
 summary: >-
   Lists the default keybindings for controlling the dashboard globally.

--- a/docs/content/getting-started/keybindings/navigation.md
+++ b/docs/content/getting-started/keybindings/navigation.md
@@ -1,7 +1,7 @@
 ---
 title: Navigation
 linkTitle: >-
-  ![icon:navigation](lucide) Navigation
+  ![icon:navigation](lucide)&nbsp;Navigation
 weight: 2
 summary: >-
   Lists the default keybindings for navigating the dashboard.

--- a/docs/content/getting-started/keybindings/preview.md
+++ b/docs/content/getting-started/keybindings/preview.md
@@ -1,7 +1,7 @@
 ---
 title: Preview Pane
 linkTitle: >-
-  ![icon:view](lucide) Preview Pane
+  ![icon:view](lucide)&nbsp;Preview Pane
 weight: 6
 summary: >-
   Lists the default keybindings for interacting with the preview pane in the Dashboard.

--- a/docs/content/getting-started/keybindings/selected-issue.md
+++ b/docs/content/getting-started/keybindings/selected-issue.md
@@ -1,7 +1,7 @@
 ---
 title: Selected Issue
 linkTitle: >-
-  ![icon:circle-dot](lucide) Selected Issue
+  ![icon:circle-dot](lucide)&nbsp;Selected Issue
 weight: 4
 summary: >-
   Lists the default keybindings for interacting with an actively selected item

--- a/docs/content/getting-started/keybindings/selected-item.md
+++ b/docs/content/getting-started/keybindings/selected-item.md
@@ -1,7 +1,7 @@
 ---
 title: Selected Item
 linkTitle: >-
-  ![icon:box-select](lucide) Selected Item
+  ![icon:box-select](lucide)&nbsp;Selected Item
 weight: 3
 summary: >-
   Lists the default keybindings for interacting with active items in the dashboard in any view.

--- a/docs/content/getting-started/keybindings/selected-pr.md
+++ b/docs/content/getting-started/keybindings/selected-pr.md
@@ -1,7 +1,7 @@
 ---
 title: Selected PR
 linkTitle: >-
-  ![icon:git-pull-request](lucide) Selected PR
+  ![icon:git-pull-request](lucide)&nbsp;Selected PR
 weight: 5
 summary: >-
   Lists the default keybindings for interacting with an actively selected item

--- a/docs/content/getting-started/usage.md
+++ b/docs/content/getting-started/usage.md
@@ -1,7 +1,7 @@
 ---
 title: Usage
 linkTitle: >-
-  ![icon:terminal](lucide) Usage
+  ![icon:terminal](lucide)&nbsp;Usage
 summary: >-
   Get started using `gh-dash`.
 weight: 2


### PR DESCRIPTION
# Summary

Prior to this change, the icons in the docs site were smushed up against the text following them when the icons are rendered at the beginning of a list item or heading, as on the landing page and in the site menu.

This is because the build uses the `--minify` flag, which unfortunately sees the space between the icons and the text as unnecessary and removes it.

This change switches the spaces to use the HTML code for a non-breaking space, `&nbsp;`, which ensures the spaces are respected.

In the long-term, I plan to update Platen to better support using icons in page headings and to support defining unordered lists with custom icons for the bullets. For now, this change makes the UI less jarring.

## How did you test this change?

Locally tested with `hugo serve --gc --minify`, which are the same flags used in the GHA.

## Images/Videos

N/A