### PR TITLE
add `$GH_DASH_CONFIG` environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Usage:
   gh dash [flags]
 
 Flags:
-  -c, --config string   use this configuration file (default is $XDG_CONFIG_HOME/gh-dash/config.yml)
+  -c, --config string   use this configuration file (default is $GH_DASH_CONFIG, or if not set, $XDG_CONFIG_HOME/gh-dash/config.yml)
       --debug           passing this flag will allow writing debug output to debug.log
   -h, --help            help for gh-dash
 ```
@@ -91,7 +91,7 @@ A section is defined by a:
 - title - shown in the TUI
 - filters - how the repo's PRs should be filtered - these are plain [github filters](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)
 
-All configuration is provided within a `config.yml` file under the extension's directory (either `$XDG_CONFIG_HOME/gh-dash` or `~/.config/gh-dash/` or your OS config dir)
+All configuration is provided within a `config.yml` file under the extension's directory (either `$XDG_CONFIG_HOME/gh-dash` or `~/.config/gh-dash/` or your OS config dir) or `$GH_DASH_CONFIG`.
 
 An example `config.yml` file contains:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func init() {
 		"config",
 		"c",
 		"",
-		"use this configuration file (default is $XDG_CONFIG_HOME/gh-dash/config.yml)",
+		"use this configuration file (default is $GH_DASH_CONFIG, or if not set, \n$XDG_CONFIG_HOME/gh-dash/config.yml)",
 	)
 	rootCmd.MarkFlagFilename("config", "yaml", "yml")
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -319,8 +319,6 @@ func (parser ConfigParser) getExistingConfigFile() (*string, error) {
 		os.Getenv("GH_DASH_CONFIG"), // If GH_DASH_CONFIG is empty, the os.Stat call fails
 		filepath.Join(xdgConfigDir, DashDir, ConfigYmlFileName),
 		filepath.Join(xdgConfigDir, DashDir, ConfigYamlFileName),
-		filepath.Join(userConfigDir, DashDir, ConfigYmlFileName),
-		filepath.Join(userConfigDir, DashDir, ConfigYamlFileName),
 	}
 
 	// Check if each config file exists, return the first one that does

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -13,16 +13,18 @@ cascade:
 
 `gh-dash` has extensive configuration options.
 
-You can use the default configuration file or use the [`--config`][01] flag to specify an alternate
-configuration.
+You can use the default configuration file, use the [`--config`][01] flag or
+`$GH_DASH_CONFIG` to specify an alternate configuration.
 
 If you don't specify the `--config` flag, `gh-dash` uses the default configuration. If the default
 configuration file doesn't already exist, `gh-dash` creates it. The location of the default
 configuration file depends on your system:
 
-1. If `$XDG_CONFIG_HOME` is a non-empty string, the default path is
-   `$XDG_CONFIG_HOME/gh-dash/config.yml`.
-1. If `$XDG_CONFIG_HOME` isn't set, then:
+1. If `$GH_DASH_CONFIG` is a non-empty string, `gh-dash` will use this file for
+    its configuration.
+1. If `$GH_DASH_CONFIG` isn't set and `$XDG_CONFIG_HOME` is a non-empty string,
+    the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
+1. If neither `$GH_DASH_CONFIG` or `$XDG_CONFIG_HOME` are set, then:
    - On Linux and macOS systems, the default path is `$HOME/gh-dash/config.yml`.
    - On Windows systems, the default path is `%USERPROFILE%\gh-dash\config.yml`.
 

--- a/docs/content/getting-started/usage.md
+++ b/docs/content/getting-started/usage.md
@@ -23,7 +23,7 @@ To use `gh-dash`, follow these steps after you've [installed it][01]:
      gh dash [flags]
 
    Flags:
-     -c, --config string   use this configuration file (default is $XDG_CONFIG_HOME/gh-dash/config.yml)
+     -c, --config string   use this configuration file (default is $GH_DASH_CONFIG, or if not set, $XDG_CONFIG_HOME/gh-dash/config.yml)
          --debug           passing this flag will allow writing debug output to debug.log
      -h, --help            help for gh-dash
    ```
@@ -41,15 +41,15 @@ gh dash --config path/to/configuration/file.yml
 
 | Aliases |  Type  |                Default                |
 | :------ | :----: | :------------------------------------ |
-| `-c`    | String | `$XDG_CONFIG_HOME/gh-dash-config.yml` |
+| `-c`    | String | `$GH_DASH_CONFIG` or if not set, `$XDG_CONFIG_HOME/gh-dash-config.yml` |
 
-If you don't specify this flag, `gh-dash` uses the default configuration. If the default
-configuration file doesn't already exist, `gh-dash` creates it. The location of the default
-configuration file depends on your system:
+If you don't specify this flag, `gh-dash` uses the default configuration. If the file doesn't exist, gh-dash will create it. The location of the default configuration file depends on your system:
 
-1. If `$XDG_CONFIG_HOME` is a non-empty string, the default path is
-   `$XDG_CONFIG_HOME/gh-dash/config.yml`.
-1. If `$XDG_CONFIG_HOME` isn't set, then:
+1. If `$GH_DASH_CONFIG` is a non-empty string, `gh-dash` will use this file for
+    its configuration.
+1. If `$GH_DASH_CONFIG` isn't set and `$XDG_CONFIG_HOME` is a non-empty string,
+    the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
+1. If neither `$GH_DASH_CONFIG` or `$XDG_CONFIG_HOME` are set, then:
    - On Linux and macOS systems, the default path is `$HOME/gh-dash/config.yml`.
    - On Windows systems, the default path is `%USERPROFILE%\gh-dash\config.yml`.
 


### PR DESCRIPTION
# Summary

This PR adds functionality to specify a location for the configuration file using an environmental variable (`$GH_DASH_CONFIG`). Users can specify a default path for the config file outside of `$XDG_CONFIG_HOME/gh-dash/config.yml`.

Additionally, it refactors getExistingConfigFile and getDefaultConfigFileOrCreateIfMissing, and updates the documentation. 

## How did you test this change?
* reads and generates configuration files in the default location when `$GH_DASH_CONFIG` is not set.
* reads and generates configuration files in location specified by `$GH_DASH_CONFIG` if `$GH_DASH_CONFIG` is set. If the directory does not exist, it creates it.
* accepts `--config` overrides.


## Images/Videos

N/A