### PR TITLE
(MAINT) Update docs theme

### DIFF
--- a/docs/data/_params/platen.yaml
+++ b/docs/data/_params/platen.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=https://platen.io/modules/platen/config/site/config/schema.json
 theme:
+  mode: auto
   fonts:
     settings:
       body: 
@@ -14,6 +15,26 @@ theme:
     styles:
       - import_name: firacode
       - import_name: mona-sans
+
+display:
+  table_of_contents:
+    use_legacy: false
+  menu:
+    languages_icon:
+      use_legacy: false
+  mobile:
+    menu_control:
+      use_legacy: false
+    toc_control:
+      use_legacy: false
+  header:
+    title_as_heading: true
+  footer:
+    last_edited_on:
+      use_legacy: false
+    edit_this_page:
+      use_legacy: false
+
 
 features:
   shoelace:

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,6 +3,6 @@ module github.com/dlvhdr/gh-dash/docs
 go 1.19
 
 require (
-	github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a // indirect
-	github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a // indirect
+	github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196 // indirect
+	github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196 // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -4,9 +4,17 @@ github.com/platenio/platen/modules/platen v0.0.0-20230504053552-c70b34ba1161 h1:
 github.com/platenio/platen/modules/platen v0.0.0-20230504053552-c70b34ba1161/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a h1:KGJf06tIhskc3foiPrp8mCn964g6WXaUZ4gc84CkgUg=
 github.com/platenio/platen/modules/platen v0.0.0-20230505122247-609ea1124a0a/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
+github.com/platenio/platen/modules/platen v0.0.0-20230530030614-0a5bf77211cc h1:shcO+PyOzcl5WaMQUcodVM17+lYrYCv3qBla/rz5VnA=
+github.com/platenio/platen/modules/platen v0.0.0-20230530030614-0a5bf77211cc/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
+github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196 h1:rSOUejTdKH6VGNCMFn2ti9MhGOcFj+PvnDuYibJoakk=
+github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d h1:PhpSZzd1YFHCZzsJJinIHoMU3Bw/w/GPYkWXz/flnvU=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
 github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161 h1:t0wxjK59xg5ggSEpWEZHtooO0COoV5oC/WFIPcJLhRM=
 github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
 github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a h1:u1oDxHF2VElyGBZxJPqGU3ozEQvJWBfpjx6APNHEL24=
 github.com/platenio/platen/modules/schematize v0.0.0-20230505122247-609ea1124a0a/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
+github.com/platenio/platen/modules/schematize v0.0.0-20230530030614-0a5bf77211cc h1:snTYqWSXf7pltBy++i1mSxV+Cl0v4U89kGqsMMQ4cgg=
+github.com/platenio/platen/modules/schematize v0.0.0-20230530030614-0a5bf77211cc/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
+github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196 h1:p4GUmZTuMEdDkhLG8V7Eo+YY8DVWR4h872Ohd1HqPRI=
+github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -35,9 +35,3 @@ params:
   description: >-
     A GitHub CLI extension to display a dashboard with pull requests and issues
     by filters you care about.
-  platen:
-    theme:
-      mode: auto
-    display:
-      header:
-        title_as_heading: true


### PR DESCRIPTION
# Summary

This change updates the configuration and version of the docs theme to the latest version of Platen and opts-into the new display modes.

This update includes a fix to a build error caused by the Platen reimplementing the TOC building logic and ensures that the docs site builds correctly without errors or warnings.

The new opt-in features gets the docs site ahead of the eventual deprecation and removal of legacy functionality and keeps the build logs clean. It also ensures:

1. The site can more effectively use icons.
1. The TOC nodes with nested items can be collapsed.
1. The mobile buttons are more usable and accessible.
1. The site-level icons are configurable and can be kept cohesive.

Finally, the change moves the remaining Platen configuration out of the `hugo.yaml` file, colocating it with the rest of the Platen-specific configuration in `docs/data/_params/platen.yaml`.

## How did you test this change?

Local testing of the docs site with `hugo serve`.

## Images/Videos

N/A