### PR TITLE
feat(ui): ability to prompt a confirmation before an action is performed

### DIFF
--- a/ui/common/styles.go
+++ b/ui/common/styles.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	SearchHeight       = 4
+	SearchHeight       = 3
 	FooterHeight       = 1
 	ExpandedHelpHeight = 11
 	InputBoxHeight     = 8

--- a/ui/common/styles.go
+++ b/ui/common/styles.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	SearchHeight       = 3
+	SearchHeight       = 4
 	FooterHeight       = 1
 	ExpandedHelpHeight = 11
 	InputBoxHeight     = 8

--- a/ui/components/issuessection/issuessection.go
+++ b/ui/components/issuessection/issuessection.go
@@ -72,7 +72,6 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 
 		if m.IsPromptConfirmationFocused() {
 
-			var promptCmd tea.Cmd
 			switch {
 
 			case msg.Type == tea.KeyCtrlC, msg.Type == tea.KeyEsc:
@@ -97,8 +96,7 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 
 				return &m, tea.Batch(cmd, blinkCmd)
 			}
-			m.PromptConfirmationBox, promptCmd = m.PromptConfirmationBox.Update(msg)
-			return &m, promptCmd
+			break
 		}
 
 	case UpdateIssueMsg:
@@ -141,7 +139,10 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 
 	search, searchCmd := m.SearchBar.Update(msg)
 	m.SearchBar = search
-	return &m, tea.Batch(cmd, searchCmd)
+
+	prompt, promptCmd := m.PromptConfirmationBox.Update(msg)
+	m.PromptConfirmationBox = prompt
+	return &m, tea.Batch(cmd, searchCmd, promptCmd)
 }
 
 func GetSectionColumns(

--- a/ui/components/prompt/prompt.go
+++ b/ui/components/prompt/prompt.go
@@ -60,3 +60,7 @@ func (m *Model) SetPrompt(prompt string) {
 func (m *Model) Reset() {
 	m.prompt.Reset()
 }
+
+func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
+	m.ctx = ctx
+}

--- a/ui/components/prompt/prompt.go
+++ b/ui/components/prompt/prompt.go
@@ -1,0 +1,62 @@
+package prompt
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dlvhdr/gh-dash/ui/context"
+)
+
+type Model struct {
+	ctx    *context.ProgramContext
+	prompt textinput.Model
+}
+
+func NewModel(ctx *context.ProgramContext) Model {
+	ti := textinput.New()
+	ti.Focus()
+	ti.Blur()
+	ti.CursorStart()
+
+	return Model{
+		ctx:    ctx,
+		prompt: ti,
+	}
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.prompt, cmd = m.prompt.Update(msg)
+	return m, cmd
+}
+
+func (m Model) View() string {
+	return m.prompt.View()
+}
+
+func (m Model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m *Model) Blur() {
+	m.prompt.Blur()
+}
+
+func (m *Model) Focus() tea.Cmd {
+	return m.prompt.Focus()
+}
+
+func (m *Model) SetValue(value string) {
+	m.prompt.SetValue(value)
+}
+
+func (m *Model) Value() string {
+	return m.prompt.Value()
+}
+
+func (m *Model) SetPrompt(prompt string) {
+	m.prompt.Prompt = prompt
+}
+
+func (m *Model) Reset() {
+	m.prompt.Reset()
+}

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -75,7 +75,6 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 		}
 
 		if m.IsPromptConfirmationFocused() {
-			var promptCmd tea.Cmd
 			switch {
 
 			case msg.Type == tea.KeyCtrlC, msg.Type == tea.KeyEsc:
@@ -104,8 +103,8 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 
 				return &m, tea.Batch(cmd, blinkCmd)
 			}
-			m.PromptConfirmationBox, promptCmd = m.PromptConfirmationBox.Update(msg)
-			return &m, promptCmd
+
+			break
 		}
 
 		switch {
@@ -167,7 +166,10 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 
 	search, searchCmd := m.SearchBar.Update(msg)
 	m.SearchBar = search
-	return &m, tea.Batch(cmd, searchCmd)
+
+	prompt, promptCmd := m.PromptConfirmationBox.Update(msg)
+	m.PromptConfirmationBox = prompt
+	return &m, tea.Batch(cmd, searchCmd, promptCmd)
 }
 
 func GetSectionColumns(

--- a/ui/components/section/section.go
+++ b/ui/components/section/section.go
@@ -313,7 +313,6 @@ func (m *Model) View() string {
 			lipgloss.Left,
 			search,
 			m.GetMainContent(),
-			m.GetPromptConfirmation(),
 		),
 	)
 }
@@ -346,7 +345,6 @@ func (m *Model) GetPagerContent() string {
 	pager := m.Ctx.Styles.ListViewPort.PagerStyle.Copy().Render(pagerContent)
 	return pager
 }
-
 func (m *Model) GetPromptConfirmation() string {
 	if m.IsPromptConfirmationShown {
 		var prompt string
@@ -369,9 +367,10 @@ func (m *Model) GetPromptConfirmation() string {
 		case m.PromptConfirmationAction == "reopen" && m.Ctx.View == config.IssuesView:
 			prompt = "Are you sure you want to reopen this issue? (Y/n) "
 		}
+
 		m.PromptConfirmationBox.SetPrompt(prompt)
 
-		return m.PromptConfirmationBox.View()
+		return m.Ctx.Styles.ListViewPort.PagerStyle.Copy().Render(m.PromptConfirmationBox.View())
 	}
 
 	return ""

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -129,7 +129,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		log.Debug("Key pressed", "key", msg.String())
 		m.ctx.Error = nil
 
-		if currSection != nil && currSection.IsSearchFocused() {
+		if currSection != nil && currSection.IsSearchFocused() || currSection.IsPromptConfirmationFocused() {
 			cmd = m.updateSection(currSection.GetId(), currSection.GetType(), msg)
 			return m, cmd
 		}
@@ -242,6 +242,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncMainContentWidth()
 			m.syncSidebar()
 			m.sidebar.ScrollToBottom()
+			return m, cmd
+
+		case key.Matches(msg, keys.PRKeys.Close, keys.PRKeys.Reopen, keys.PRKeys.Ready, keys.PRKeys.Merge, keys.IssueKeys.Close, keys.IssueKeys.Reopen):
+
+			var action string
+			switch {
+			case key.Matches(msg, keys.PRKeys.Close, keys.IssueKeys.Close):
+				action = "close"
+
+			case key.Matches(msg, keys.PRKeys.Reopen, keys.IssueKeys.Reopen):
+				action = "reopen"
+
+			case key.Matches(msg, keys.PRKeys.Ready):
+				action = "ready"
+
+			case key.Matches(msg, keys.PRKeys.Merge):
+				action = "merge"
+			}
+
+			if currSection != nil {
+				currSection.SetPromptConfirmationAction(action)
+				cmd = currSection.SetIsPromptConfirmationShown(true)
+			}
 			return m, cmd
 
 		case key.Matches(msg, keys.IssueKeys.Assign), key.Matches(msg, keys.PRKeys.Assign):

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -401,8 +401,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	m.footer, footerCmd = m.footer.Update(msg)
 	if currSection != nil {
-		m.footer.SetLeftSection(currSection.GetPagerContent())
+		if currSection.IsPromptConfirmationFocused() {
+			m.footer.SetLeftSection(currSection.GetPromptConfirmation())
+		}
+
+		if !currSection.IsPromptConfirmationFocused() {
+			m.footer.SetLeftSection(currSection.GetPagerContent())
+		}
 	}
+
 	sectionCmd := m.updateCurrentSection(msg)
 	cmds = append(
 		cmds,


### PR DESCRIPTION
# Summary
Add prompt confirmation before closing a PR in #197
Add prompt confirmation before performing a gh action related to PRs and Issues as additional

- PR actions
  - close
  - reopen
  - ready
  - merge
- Issue action
  - close
  - reopen 

## How did you test this change?
I tested this newly added feature manually for every PR and Issue action.
## Images/Videos

![gh-dash](https://github.com/dlvhdr/gh-dash/assets/34588445/066e85f0-ebb8-4f93-a2a4-d2f29b804cee)
