### PR TITLE
feat(ui): update the PR view diff changes summary

### DIFF
--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -127,13 +127,14 @@ func (pr *PullRequest) renderLines() string {
 		deletions = pr.Data.Deletions
 	}
 
+	diffs := "\033[32m+%d \033[31m-%d"
 	return pr.getTextStyle().Render(
-		fmt.Sprintf(
-            "\033[0;32m+%d\033[0m \033[0;31m-%d\033[0m",
+        fmt.Sprintf(
+            diffs,
             pr.Data.Additions,
             deletions,
         ),
-	)
+    )
 }
 
 func (pr *PullRequest) renderTitle() string {

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -128,7 +128,11 @@ func (pr *PullRequest) renderLines() string {
 	}
 
 	return pr.getTextStyle().Render(
-		fmt.Sprintf("%d / -%d", pr.Data.Additions, deletions),
+		fmt.Sprintf(
+            "\033[0;32m+%d\033[0m \033[0;31m-%d\033[0m",
+            pr.Data.Additions,
+            deletions,
+        ),
 	)
 }
 

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -127,12 +127,13 @@ func (pr *PullRequest) renderLines() string {
 		deletions = pr.Data.Deletions
 	}
 
-	diffs := "\033[32m+%s \033[31m-%s"
-	return pr.getTextStyle().Render(
-        fmt.Sprintf(
-            diffs,
-            components.FormatNumber(pr.Data.Additions),
-            components.FormatNumber(deletions),
+    return pr.getTextStyle().Render(
+        components.KeepSameSpacesOnAddDeletions(
+            fmt.Sprintf(
+                "\033[32m+%s \033[31m-%s",
+                components.FormatNumber(pr.Data.Additions),
+                components.FormatNumber(deletions),
+            ),
         ),
     )
 }

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -127,12 +127,12 @@ func (pr *PullRequest) renderLines() string {
 		deletions = pr.Data.Deletions
 	}
 
-	diffs := "\033[32m+%d \033[31m-%d"
+	diffs := "\033[32m+%s \033[31m-%s"
 	return pr.getTextStyle().Render(
         fmt.Sprintf(
             diffs,
-            pr.Data.Additions,
-            deletions,
+            components.FormatNumber(pr.Data.Additions),
+            components.FormatNumber(deletions),
         ),
     )
 }

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -145,6 +145,7 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 	}
 
 	search, searchCmd := m.SearchBar.Update(msg)
+	m.Table.SetRows(m.BuildRows())
 	m.SearchBar = search
 	return &m, tea.Batch(cmd, searchCmd)
 }
@@ -232,9 +233,14 @@ func GetSectionColumns(
 
 func (m *Model) BuildRows() []table.Row {
 	var rows []table.Row
-	for _, currPr := range m.Prs {
+	currItem := m.Table.GetCurrItem()
+	for i, currPr := range m.Prs {
+		i := i
 		prModel := pr.PullRequest{Ctx: m.Ctx, Data: currPr}
-		rows = append(rows, prModel.ToTableRow())
+		rows = append(
+			rows,
+			prModel.ToTableRow(currItem == i),
+		)
 	}
 
 	if rows == nil {

--- a/ui/components/utils.go
+++ b/ui/components/utils.go
@@ -9,6 +9,11 @@ import (
 	"github.com/dlvhdr/gh-dash/ui/context"
 )
 
+func KeepSameSpacesOnAddDeletions(str string) string {
+    str_as_list := strings.Split(str, " ")
+    return fmt.Sprintf("%7s", str_as_list[0]) + " " + fmt.Sprintf("%7s", str_as_list[1])
+}
+
 func FormatNumber(num int) string {
 	if num >= 1000000 {
 		million := float64(num) / 1000000.0

--- a/ui/components/utils.go
+++ b/ui/components/utils.go
@@ -2,17 +2,13 @@ package components
 
 import (
 	"fmt"
-	"strings"
 	"strconv"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
 	"github.com/dlvhdr/gh-dash/ui/context"
 )
-
-func KeepSameSpacesOnAddDeletions(str string) string {
-    str_as_list := strings.Split(str, " ")
-    return fmt.Sprintf("%7s", str_as_list[0]) + " " + fmt.Sprintf("%7s", str_as_list[1])
-}
 
 func FormatNumber(num int) string {
 	if num >= 1000000 {
@@ -26,14 +22,22 @@ func FormatNumber(num int) string {
 	return strconv.Itoa(num)
 }
 
-func GetIssueTextStyle(ctx *context.ProgramContext, state string) lipgloss.Style {
+func GetIssueTextStyle(
+	ctx *context.ProgramContext,
+	state string,
+) lipgloss.Style {
 	if state == "OPEN" {
 		return lipgloss.NewStyle().Foreground(ctx.Theme.PrimaryText)
 	}
 	return lipgloss.NewStyle().Foreground(ctx.Theme.FaintText)
 }
 
-func RenderIssueTitle(ctx *context.ProgramContext, state string, title string, number int) string {
+func RenderIssueTitle(
+	ctx *context.ProgramContext,
+	state string,
+	title string,
+	number int,
+) string {
 	prNumber := fmt.Sprintf("#%d", number)
 	var prNumberFg lipgloss.AdaptiveColor
 	if state != "OPEN" {

--- a/ui/components/utils.go
+++ b/ui/components/utils.go
@@ -3,10 +3,23 @@ package components
 import (
 	"fmt"
 	"strings"
+	"strconv"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/dlvhdr/gh-dash/ui/context"
 )
+
+func FormatNumber(num int) string {
+	if num >= 1000000 {
+		million := float64(num) / 1000000.0
+		return strconv.FormatFloat(million, 'f', 1, 64) + "M"
+	} else if num >= 1000 {
+		kilo := float64(num) / 1000.0
+		return strconv.FormatFloat(kilo, 'f', 1, 64) + "k"
+	}
+
+	return strconv.Itoa(num)
+}
 
 func GetIssueTextStyle(ctx *context.ProgramContext, state string) lipgloss.Style {
 	if state == "OPEN" {


### PR DESCRIPTION
# Summary

UI changes proposal on +/- with colors like the view we have on github.
- [x] update colors (green/red) for adds/deletions.
- [x] add a formater util function for killos /Millions changes diffs.
- [x] add a sync amount of spaces between adds and deletions.

## How did you test this change?

On my Ubuntu Os 20.04 , tmux, under allacrity.

```bash
go run gh-dash.go --debug
```

## Images/Videos

### BEFORE

![Screenshot from 2023-07-22 19-19-04](https://github.com/dlvhdr/gh-dash/assets/22576758/f2046c7e-02b5-4dab-83eb-3c19bcd498d0)

### AFTER

![Screenshot from 2023-07-22 19-09-07](https://github.com/dlvhdr/gh-dash/assets/22576758/5f575ba1-86d1-4fe3-bade-0c044254633c)

## NOTE

- This should work for all Unix based system.
- I didn't create an issue because i thought there were not too many things to do on this branch, I hope it's okay.
