### PR TITLE
Add Go build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@
    cd gh-dash
    ```
 
-3. Install it locally
+3. Build it
+
+   ```bash
+   go build
+   ```
+
+4. Install it locally
    ```bash
    gh extension install .
    ```


### PR DESCRIPTION
# Summary
When trying to manually install `gh-dash` I couldn't make it work, getting the error:

```
failed to run extension: fork/exec /Users/sebastiaramon/.local/share/gh/extensions/gh-dash/gh-dash: no such file or directory
```

## How did you test this change?
After running `go build` I stopped getting the error above.