### PR TITLE
include project name in release assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
 
 archives:
   - format: binary
-    name_template: "{{ .Os }}-{{ .Arch }}"
+    name_template: "gh-dash_{{ .Tag }}_{{ .Os }}-{{ .Arch }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
includes project name in the release assets 

Fixes #335 

<details><summary>Details</summary>
<p>

```bash
goreleaser release --snapshot
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • skipping announce, publish and validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=bf3764ced0f35251bc315e634366ea4582313e90 branch=main current_tag=v3.14.0 previous_tag=v3.13.1 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=3.14.1-next
  • running before hooks
    • running                                        hook=go mod tidy
    • took: 8s
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/gh-dash_linux_amd64_v1/gh-dash
    • took: 1s
  • archives
    • skip archiving                                 binary=gh-dash name=gh-dash_v3.14.0_linux-amd64
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 9s
  • thanks for using goreleaser!
```

</p>
</details> 