### PR TITLE
fix layout disruption when resizing window with help displayed

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -504,7 +504,11 @@ func (m *Model) onWindowSizeChanged(msg tea.WindowSizeMsg) {
 	m.footer.SetWidth(msg.Width)
 	m.ctx.ScreenWidth = msg.Width
 	m.ctx.ScreenHeight = msg.Height
-	m.ctx.MainContentHeight = msg.Height - common.TabsHeight - common.FooterHeight
+	if m.footer.ShowAll {
+		m.ctx.MainContentHeight = msg.Height - common.TabsHeight - common.ExpandedHelpHeight
+	} else {
+		m.ctx.MainContentHeight = msg.Height - common.TabsHeight - common.FooterHeight
+	}
 	m.syncMainContentWidth()
 }
 


### PR DESCRIPTION
# Summary
close #339

I've fixed the issue where resizing the window height while the help is displayed no longer disrupts the layout.
This is a fix for issue #339. 

## How did you test this change?
Manually tested by resizing the terminal window with the help view open.

## Images/Videos

https://github.com/dlvhdr/gh-dash/assets/27483768/b119812c-080f-4c3a-9bcf-8707e177661d


