### PR TITLE
Support `:owner/:repo` template in repoPaths configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ defaults:
   refetchIntervalMinutes: 30 # will refetch all sections every 30 minutes
 repoPaths: # configure where to locate repos when checking out PRs
   default_path: ~/code/repos # fallback value if none of the other paths match
+  :owner/:repo: ~/src/github.com/:owner/:repo # template if you always clone github repos in a consistent location
   dlvhdr/*: ~/code/repos/dlvhdr/* # will match dlvhdr/repo-name to ~/code/repos/dlvhdr/repo-name
   dlvhdr/gh-dash: ~/code/gh-dash # will not match wildcard and map to specified path
 keybindings: # optional, define custom keybindings - see more info below
@@ -216,6 +217,7 @@ An exact match for the full repo name to a full path takes priority over a match
 ```yaml
 repoPaths:
   default_path: ~/code/repos # fallback value if none of the other paths match
+  :owner/:repo: ~/src/github.com/:owner/:repo # template if you always clone github repos in a consistent location
   dlvhdr/*: ~/code/repos/dlvhdr/*       # will match dlvhdr/repo-name to ~/code/repos/dlvhdr/repo-name
   dlvhdr/gh-dash: ~/code/gh-dash # will not match wildcard and map to specified path
 ```

--- a/ui/common/repopath.go
+++ b/ui/common/repopath.go
@@ -48,6 +48,10 @@ func GetRepoLocalPath(repoName string, cfgPaths map[string]string) (string, bool
 		return fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo), true
 	}
 
+	if template, ok := cfgPaths[":owner/:repo"]; ok {
+		return strings.ReplaceAll(strings.ReplaceAll(template, ":owner", owner), ":repo", repo), true
+	}
+
 	if defaultPath, found := cfgPaths["default_path"]; found {
 		p := strings.TrimSuffix(defaultPath, "/*")
 		return filepath.Join(p, repo), true

--- a/ui/common/repopath.go
+++ b/ui/common/repopath.go
@@ -44,8 +44,8 @@ func GetRepoLocalPath(repoName string, cfgPaths map[string]string) (string, bool
 	wildcardPath, wildcardFound := cfgPaths[fmt.Sprintf("%s/*", owner)]
 
 	if wildcardFound {
-        // adjust wildcard match to wildcard path - ~/somepath/* to ~/somepath/{repo}
-        return fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo), true
+		// adjust wildcard match to wildcard path - ~/somepath/* to ~/somepath/{repo}
+		return fmt.Sprintf("%s/%s", strings.TrimSuffix(wildcardPath, "/*"), repo), true
 	}
 
 	if defaultPath, found := cfgPaths["default_path"]; found {

--- a/ui/common/repopath_test.go
+++ b/ui/common/repopath_test.go
@@ -13,7 +13,7 @@ var configPaths = map[string]string{
 	"user_2/*":  "/path/to/user_2/*",
 }
 
-var configPathsWithDefultPath = map[string]string{
+var configPathsWithDefaultPath = map[string]string{
 	"user/repo":    "/path/to/user/repo",
 	"user_2/*":     "/path/to/user_2/*",
 	"default_path": "/path/to/user/dev",
@@ -54,7 +54,7 @@ func TestGetRepoLocalPath(t *testing.T) {
 			repo:        "user3/repo",
 			want:        "/path/to/user/dev/repo",
 			found:       true,
-			configPaths: configPathsWithDefultPath,
+			configPaths: configPathsWithDefaultPath,
 		},
 	}
 

--- a/ui/common/repopath_test.go
+++ b/ui/common/repopath_test.go
@@ -19,6 +19,12 @@ var configPathsWithDefaultPath = map[string]string{
 	"default_path": "/path/to/user/dev",
 }
 
+var configPathsWithOwnerRepoTemplate = map[string]string{
+	"user/repo":    "/path/to/the_repo",
+	"org/*":        "/path/to/the_org/*",
+	":owner/:repo": "/path/to/github.com/:owner/:repo",
+}
+
 func TestGetRepoLocalPath(t *testing.T) {
 	testCases := map[string]struct {
 		repo        string
@@ -55,6 +61,36 @@ func TestGetRepoLocalPath(t *testing.T) {
 			want:        "/path/to/user/dev/repo",
 			found:       true,
 			configPaths: configPathsWithDefaultPath,
+		},
+		"with :owner/:repo template: exact match": {
+			repo:        "user/repo",
+			want:        "/path/to/the_repo",
+			found:       true,
+			configPaths: configPathsWithOwnerRepoTemplate,
+		},
+		"with :owner/:repo template: no match for this sibling repo": {
+			repo:        "user/another_repo",
+			want:        "/path/to/github.com/user/another_repo",
+			found:       true,
+			configPaths: configPathsWithOwnerRepoTemplate,
+		},
+		"with :owner/:repo template: wildcard repo match": {
+			repo:        "org/some_repo",
+			want:        "/path/to/the_org/some_repo",
+			found:       true,
+			configPaths: configPathsWithOwnerRepoTemplate,
+		},
+		"with :owner/:repo template: general fallback": {
+			repo:        "any-owner/any-repo",
+			want:        "/path/to/github.com/any-owner/any-repo",
+			found:       true,
+			configPaths: configPathsWithOwnerRepoTemplate,
+		},
+		"with :owner/:repo template: repeated :repo substitution": {
+			repo:        "any-owner/any-repo",
+			want:        "src/github.com/any-owner/any-repo/any-repo",
+			found:       true,
+			configPaths: map[string]string{":owner/:repo": "src/github.com/:owner/:repo/:repo"},
 		},
 	}
 


### PR DESCRIPTION
# Summary

Previously, we supported a "wildcard" mapping like
```yml
user1/*: /path/to/user1_repos/*
```
to map any repository owned by `user1` to the directory of the same name within `/path/to/user1_repos/`.

But for folks who store all GitHub repositories under a path that includes the owner's name and the repo's name, this would still require them to enter a wildcard entry for every owner. To avoid that, this PR introduces support for an `:owner/:repo` template in the `repoPaths` configuration. Now we can specify a `repoPaths` entry like:
```yml
:owner/:repo: /path/to/github.com/:owner/:repo
```
which will cover everything. It can still be overridden with individual entries that specify either an exact repository or a specific owner wildcard.

## How did you test this change?

I added more test cases to `ui/common/repopath_test.go`. I also built it locally and ran `./gh-dash` using an `:owner/:repo` template in my `repoPaths` configuration and confirmed that it was now able to successfully check out a PR using my configured location.