### PR TITLE
Remove `default_path` support in `repoPaths` configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ defaults:
     width: 60 # width in columns
   refetchIntervalMinutes: 30 # will refetch all sections every 30 minutes
 repoPaths: # configure where to locate repos when checking out PRs
-  default_path: ~/code/repos # fallback value if none of the other paths match
   :owner/:repo: ~/src/github.com/:owner/:repo # template if you always clone github repos in a consistent location
   dlvhdr/*: ~/code/repos/dlvhdr/* # will match dlvhdr/repo-name to ~/code/repos/dlvhdr/repo-name
   dlvhdr/gh-dash: ~/code/gh-dash # will not match wildcard and map to specified path
@@ -214,9 +213,10 @@ Repo name to path mappings can be exact match (full name, full path) or wildcard
 
 An exact match for the full repo name to a full path takes priority over a matching wildcard, and wildcard matches must match to a wildcard path.
 
+An `:owner/:repo` template can be specified as a generic fallback.
+
 ```yaml
 repoPaths:
-  default_path: ~/code/repos # fallback value if none of the other paths match
   :owner/:repo: ~/src/github.com/:owner/:repo # template if you always clone github repos in a consistent location
   dlvhdr/*: ~/code/repos/dlvhdr/*       # will match dlvhdr/repo-name to ~/code/repos/dlvhdr/repo-name
   dlvhdr/gh-dash: ~/code/gh-dash # will not match wildcard and map to specified path

--- a/ui/common/repopath.go
+++ b/ui/common/repopath.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 )
 
@@ -50,11 +49,6 @@ func GetRepoLocalPath(repoName string, cfgPaths map[string]string) (string, bool
 
 	if template, ok := cfgPaths[":owner/:repo"]; ok {
 		return strings.ReplaceAll(strings.ReplaceAll(template, ":owner", owner), ":repo", repo), true
-	}
-
-	if defaultPath, found := cfgPaths["default_path"]; found {
-		p := strings.TrimSuffix(defaultPath, "/*")
-		return filepath.Join(p, repo), true
 	}
 
 	return "", false

--- a/ui/common/repopath_test.go
+++ b/ui/common/repopath_test.go
@@ -13,10 +13,10 @@ var configPaths = map[string]string{
 	"user_2/*":  "/path/to/user_2/*",
 }
 
-var configPathsWithDefaultPath = map[string]string{
+var configPathsWithOwnerRepoTemplateIgnoringOwner = map[string]string{
 	"user/repo":    "/path/to/user/repo",
 	"user_2/*":     "/path/to/user_2/*",
-	"default_path": "/path/to/user/dev",
+	":owner/:repo": "/path/to/user/dev/:repo",
 }
 
 var configPathsWithOwnerRepoTemplate = map[string]string{
@@ -56,11 +56,11 @@ func TestGetRepoLocalPath(t *testing.T) {
 			found:       false,
 			configPaths: configPaths,
 		},
-		"default path": {
+		"with :owner/:repo template: ignoring owner substitution": {
 			repo:        "user3/repo",
 			want:        "/path/to/user/dev/repo",
 			found:       true,
-			configPaths: configPathsWithDefaultPath,
+			configPaths: configPathsWithOwnerRepoTemplateIgnoringOwner,
 		},
 		"with :owner/:repo template: exact match": {
 			repo:        "user/repo",


### PR DESCRIPTION
# Summary

Now that we support the more general `:owner/:repo` template configuration (https://github.com/dlvhdr/gh-dash/pull/343), the prior `default_path` functionality (https://github.com/dlvhdr/gh-dash/pull/327) is redundant - e.g. this configuration:
```yml
default_path: ~/code/repos
```
can be achieved equivalently with:
```yml
:owner/:repo: ~/code/repos/:repo
```

Thus, we are removing the `default_path` syntax.

## How did you test this change?

I updated the automated tests to show how the `default_path` test case is covered with the `:owner/:repo` syntax.