### PR TITLE
Allow BaseRefName in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ For PRs, the available arguments are:
 | `RepoPath`    | The path to the Repo, using the `config.yml` `repoPaths` key to get the mapping |
 | `PrNumber`    | The PR number                                                                   |
 | `HeadRefName` | The PR's remote branch name                                                     |
+| `BaseRefName` | The PR's base branch name                                                       |
 
 For Issues, the available arguments are:
 

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -71,6 +71,7 @@ type PRCommandTemplateInput struct {
 	RepoPath    string
 	PrNumber    int
 	HeadRefName string
+	BaseRefName string
 }
 
 func (m *Model) executeKeybinding(key string) tea.Cmd {
@@ -121,6 +122,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 		RepoPath:    repoPath,
 		PrNumber:    prData.Number,
 		HeadRefName: prData.HeadRefName,
+		BaseRefName: prData.BaseRefName,
 	}
 
 	cmd, err := template.New("keybinding_command").Parse(commandTemplate)


### PR DESCRIPTION
# Summary
closes #346

## How did you test this change?
I could successfully use `BaseRefName` in the config to view the PRs' diff in neovim for different PRs with different base branches in the same repository.
