### PR TITLE
Add date format option to defaults

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -98,6 +98,7 @@ type Defaults struct {
 	View                   ViewType      `yaml:"view"`
 	Layout                 LayoutConfig  `yaml:"layout,omitempty"`
 	RefetchIntervalMinutes int           `yaml:"refetchIntervalMinutes,omitempty"`
+	DateFormat             string        `yaml:"dateFormat,omitempty"`
 }
 
 type Keybinding struct {

--- a/docs/data/schemas/defaults.yaml
+++ b/docs/data/schemas/defaults.yaml
@@ -15,6 +15,7 @@ schematize:
       - Only fetch 20 PRs and issues at a time for each section.
       - Display the PRs view when the dashboard loads.
       - Refetch PRs and issues for each section every 30 minutes.
+      - Display dates using relative values.
 
       For more details on the default layouts, see the documentation for [sref:PR] and [sref:issue]
       layout definitions.
@@ -151,6 +152,24 @@ properties:
 
         [refresh current section]: /getting-started/keybindings/global/#refresh-current-section
         [refresh all sections]:    /getting-started/keybindings/global/#refresh-all-sections
+    type: integer
+    minimum: 1
+    default: 30
+  dateFormat:
+    title: Date format
+    description: Specifies how dates are formatted.
+    schematize:
+      weight: 5
+      details: |
+        This setting defines how dates are formatted. The format can be either be "relative" or a 
+        [go time format].
+
+        By default, the format is "relative" which fits just inside the default column width of
+        updated at in the issues and pull request layouts.
+
+        You may need to adjust the layout column width depending on your format.
+
+        [go time format]: https://pkg.go.dev/time#pkg-constants
     type: integer
     minimum: 1
     default: 30

--- a/ui/components/issue/issue.go
+++ b/ui/components/issue/issue.go
@@ -38,7 +38,7 @@ func (issue *Issue) renderUpdateAt() string {
 	timeFormat := issue.Ctx.Config.Defaults.DateFormat
 
 	updatedAtOutput := ""
-	if timeFormat == "" || timeFormat == "RELATIVE" {
+	if timeFormat == "" || timeFormat == "relative" {
 		updatedAtOutput = utils.TimeElapsed(issue.Data.UpdatedAt)
 	} else {
 		updatedAtOutput = issue.Data.UpdatedAt.Format(timeFormat)

--- a/ui/components/issue/issue.go
+++ b/ui/components/issue/issue.go
@@ -35,7 +35,16 @@ func (issue *Issue) getTextStyle() lipgloss.Style {
 }
 
 func (issue *Issue) renderUpdateAt() string {
-	return issue.getTextStyle().Render(utils.TimeElapsed(issue.Data.UpdatedAt))
+	timeFormat := issue.Ctx.Config.Defaults.DateFormat
+
+	updatedAtOutput := ""
+	if timeFormat == "" || timeFormat == "RELATIVE" {
+		updatedAtOutput = utils.TimeElapsed(issue.Data.UpdatedAt)
+	} else {
+		updatedAtOutput = issue.Data.UpdatedAt.Format(timeFormat)
+	}
+
+	return issue.getTextStyle().Render(updatedAtOutput)
 }
 
 func (issue *Issue) renderRepoName() string {

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -200,8 +200,16 @@ func (pr *PullRequest) renderRepoName() string {
 }
 
 func (pr *PullRequest) renderUpdateAt() string {
-	return pr.getTextStyle().
-		Render(utils.TimeElapsed(pr.Data.UpdatedAt))
+	timeFormat := pr.Ctx.Config.Defaults.DateFormat
+
+	updatedAtOutput := ""
+	if timeFormat == "" || timeFormat == "RELATIVE" {
+		updatedAtOutput = utils.TimeElapsed(pr.Data.UpdatedAt)
+	} else {
+		updatedAtOutput = pr.Data.UpdatedAt.Format(timeFormat)
+	}
+
+	return pr.getTextStyle().Render(updatedAtOutput)
 }
 
 func (pr *PullRequest) renderBaseName() string {

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -203,7 +203,7 @@ func (pr *PullRequest) renderUpdateAt() string {
 	timeFormat := pr.Ctx.Config.Defaults.DateFormat
 
 	updatedAtOutput := ""
-	if timeFormat == "" || timeFormat == "RELATIVE" {
+	if timeFormat == "" || timeFormat == "relative" {
 		updatedAtOutput = utils.TimeElapsed(pr.Data.UpdatedAt)
 	} else {
 		updatedAtOutput = pr.Data.UpdatedAt.Format(timeFormat)


### PR DESCRIPTION
Currently only affects the updated at field for PRs and issues.
Hoping to get feedback on this idea and help contribute to documentation or schema update as required.

Closes #67

# Summary

## How did you test this change?

This config will use a simple yyyy-mm-dd format with a larger column layout. Not entirely sure why its 12 width and not 10, maybe there is some padding by default.
```yaml
defaults:
  layout:
    prs:
      updatedAt:
        width: 12
        grow: true
  dateFormat: "2006-01-02"
```

The special value of RELATIVE, or no value at all, will keep the existing relative dates.
```yaml
defaults:
  dateFormat: "relative"
```

## Images/Videos
![gh-dash-updated-at-date-format](https://github.com/dlvhdr/gh-dash/assets/8585244/a88fc2c7-359f-49d1-bd38-0b7e82ff2c0b)

With format `2006-01-02`