### PR TITLE
Premature error fix for issue #353

### DIFF
--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -124,7 +124,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 		log.Fatal("Failed parse keybinding template", err)
 	}
 
-	// Set the command to error out if required input (e.g. repoPath) is missing
+	// Set the command to error out if required input (e.g. RepoPath) is missing
 	cmd = cmd.Option("missingkey=error")
 
 	var buff bytes.Buffer

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -125,7 +125,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 	var buff bytes.Buffer
 	err = cmd.Execute(&buff, input)
 	if err != nil {
-		log.Fatal("Failed executing keybinding command", err)
+		return func() tea.Msg { return constants.ErrMsg{Err: fmt.Errorf("Failed to parsetemplate %s", commandTemplate)} }
 	}
 	return m.executeCustomCommand(buff.String())
 }

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -109,13 +109,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 
 func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
 	repoName := prData.GetRepoNameWithOwner()
-	repoPath, ok := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
-
-	if !ok {
-		return func() tea.Msg {
-			return constants.ErrMsg{Err: fmt.Errorf("Failed to find local path for repo %s", repoName)}
-		}
-	}
+	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
 
 	input := PRCommandTemplateInput{
 		RepoName:    repoName,
@@ -129,6 +123,9 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 	if err != nil {
 		log.Fatal("Failed parse keybinding template", err)
 	}
+
+	// Set the command to error out if required input (e.g. repoPath) is missing
+	cmd = cmd.Option("missingkey=error")
 
 	var buff bytes.Buffer
 	err = cmd.Execute(&buff, input)


### PR DESCRIPTION
 As per #353, commands were failing due to unavailable data

#### How did you test this change?
Duplicate a hotkey command akin to that reported as failing to confirm.
Grepped the source for elements I needed to remove/modify.

Ran `go test` suite, manually verified command now successfully executes.