### PR TITLE
fix: duplicate record display on rapid consecutive refreshes

### DIFF
--- a/ui/components/issuessection/issuessection.go
+++ b/ui/components/issuessection/issuessection.go
@@ -125,7 +125,7 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 		}
 
 	case SectionIssuesFetchedMsg:
-		if m.LastTaskId == msg.TaskId {
+		if m.LastFetchTaskId == msg.TaskId {
 			if m.PageInfo != nil {
 				m.Issues = append(m.Issues, msg.Issues...)
 			} else {
@@ -261,7 +261,7 @@ func (m *Model) FetchNextPageSectionRows() []tea.Cmd {
 		startCursor = m.PageInfo.StartCursor
 	}
 	taskId := fmt.Sprintf("fetching_issues_%d_%s", m.Id, startCursor)
-	m.LastTaskId = taskId
+	m.LastFetchTaskId = taskId
 	task := context.Task{
 		Id:        taskId,
 		StartText: fmt.Sprintf(`Fetching issues for "%s"`, m.Config.Title),

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -156,7 +156,7 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 		}
 
 	case SectionPullRequestsFetchedMsg:
-		if m.LastTaskId == msg.TaskId {
+		if m.LastFetchTaskId == msg.TaskId {
 			if m.PageInfo != nil {
 				m.Prs = append(m.Prs, msg.Prs...)
 			} else {
@@ -314,7 +314,7 @@ func (m *Model) FetchNextPageSectionRows() []tea.Cmd {
 		startCursor = m.PageInfo.StartCursor
 	}
 	taskId := fmt.Sprintf("fetching_prs_%d_%s", m.Id, startCursor)
-	m.LastTaskId = taskId
+	m.LastFetchTaskId = taskId
 	task := context.Task{
 		Id:        taskId,
 		StartText: fmt.Sprintf(`Fetching PRs for "%s"`, m.Config.Title),

--- a/ui/components/section/section.go
+++ b/ui/components/section/section.go
@@ -37,6 +37,7 @@ type Model struct {
 	PromptConfirmationBox     prompt.Model
 	IsPromptConfirmationShown bool
 	PromptConfirmationAction  string
+	LastTaskId                string
 }
 
 func NewModel(

--- a/ui/components/section/section.go
+++ b/ui/components/section/section.go
@@ -37,7 +37,7 @@ type Model struct {
 	PromptConfirmationBox     prompt.Model
 	IsPromptConfirmationShown bool
 	PromptConfirmationAction  string
-	LastTaskId                string
+	LastFetchTaskId           string
 }
 
 func NewModel(


### PR DESCRIPTION
# Summary
This PR addresses https://github.com/dlvhdr/gh-dash/issues/294

I have implemented a modification to retain the TaskID for each fetch task within the model. This TaskID is identical to the one included in the msg sent upon the completion of a record fetch. Saving taskID within the model is a Last-Write-Wins basis, ensuring that only the most recent TaskID is stored in the model.

The PR and issue lists within the model are updated only if the TaskID in the model matches the TaskID in the incoming message. 

## How did you test this change?
I manually tested this change following the procedures shown in the video below. I confirmed that the issue was resolved without negatively impacting other functionalities such as paging or searching.

## Images/Videos

https://github.com/dlvhdr/gh-dash/assets/27483768/a78eb21e-f217-4771-8865-d3f2a76a32d6



