### PR TITLE
Streamline custom commands

### DIFF
--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -124,7 +124,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 		log.Fatal("Failed parse keybinding template", err)
 	}
 
-	// Set the command to error out if required input (e.g. repoPath) is missing
+	// Set the command to error out if required input (e.g. RepoPath) is missing
 	cmd = cmd.Option("missingkey=error")
 
 	var buff bytes.Buffer

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -105,7 +105,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 // contextData is a map of key-value pairs of data specific to the context the command is being run in.
 func (m *Model) runCustomCommand(commandTemplate string, contextData *map[string]any) tea.Cmd {
 	// A generic map is a pretty easy & flexible way to populate a template if there's no pressing need
-	// for sructured data, existing structs, etc. Especially if holes in the data are expected.
+	// for structured data, existing structs, etc. Especially if holes in the data are expected.
 	// Common data shared across contexts could be set here.
 	input := map[string]any {
 	}

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -125,7 +125,7 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 	var buff bytes.Buffer
 	err = cmd.Execute(&buff, input)
 	if err != nil {
-		log.Fatal("Failed executing keybinding command", err)
+		return func() tea.Msg { return constants.ErrMsg{Err: fmt.Errorf("Failed to parsetemplate %s", commandTemplate)} }
 	}
 	return m.executeCustomCommand(buff.String())
 }

--- a/ui/modelUtils.go
+++ b/ui/modelUtils.go
@@ -109,13 +109,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 
 func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequestData) tea.Cmd {
 	repoName := prData.GetRepoNameWithOwner()
-	repoPath, ok := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
-
-	if !ok {
-		return func() tea.Msg {
-			return constants.ErrMsg{Err: fmt.Errorf("Failed to find local path for repo %s", repoName)}
-		}
-	}
+	repoPath, _ := common.GetRepoLocalPath(repoName, m.ctx.Config.RepoPaths)
 
 	input := PRCommandTemplateInput{
 		RepoName:    repoName,
@@ -129,6 +123,9 @@ func (m *Model) runCustomPRCommand(commandTemplate string, prData *data.PullRequ
 	if err != nil {
 		log.Fatal("Failed parse keybinding template", err)
 	}
+
+	// Set the command to error out if required input (e.g. repoPath) is missing
+	cmd = cmd.Option("missingkey=error")
 
 	var buff bytes.Buffer
 	err = cmd.Execute(&buff, input)


### PR DESCRIPTION
# Summary
Moved common functionality from `runCustomPRCommand()` & `runCustomIssueCommand()` into new `runCustomCommand()` function

## How did you test this change?
Set and ran rudimentary custom commands in each context. Could probably do with some more robust testing though tbh.

I've left an empty `input` map still initialised in the new function, and merged in the specific data from the calls from different contexts, as I'm not sure what common data might want to be made available common to different contexts.