### PR TITLE
Use "Switch to issues" and "Switch to PRs" for better observability

### DIFF
--- a/ui/keys/issueKeys.go
+++ b/ui/keys/issueKeys.go
@@ -8,6 +8,7 @@ type IssueKeyMap struct {
 	Comment  key.Binding
 	Close    key.Binding
 	Reopen   key.Binding
+	ViewPRs  key.Binding
 }
 
 var IssueKeys = IssueKeyMap{
@@ -31,6 +32,10 @@ var IssueKeys = IssueKeyMap{
 		key.WithKeys("X"),
 		key.WithHelp("X", "reopen"),
 	),
+	ViewPRs: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "switch to PRs"),
+	),
 }
 
 func IssueFullHelp() []key.Binding {
@@ -40,5 +45,6 @@ func IssueFullHelp() []key.Binding {
 		IssueKeys.Comment,
 		IssueKeys.Close,
 		IssueKeys.Reopen,
+		IssueKeys.ViewPRs,
 	}
 }

--- a/ui/keys/keys.go
+++ b/ui/keys/keys.go
@@ -21,7 +21,6 @@ type KeyMap struct {
 	PageUp        key.Binding
 	NextSection   key.Binding
 	PrevSection   key.Binding
-	SwitchView    key.Binding
 	Search        key.Binding
 	CopyUrl       key.Binding
 	CopyNumber    key.Binding
@@ -71,7 +70,6 @@ func (k KeyMap) AppKeys() []key.Binding {
 	return []key.Binding{
 		k.Refresh,
 		k.RefreshAll,
-		k.SwitchView,
 		k.TogglePreview,
 		k.OpenGithub,
 		k.CopyNumber,
@@ -132,10 +130,6 @@ var Keys = KeyMap{
 	PrevSection: key.NewBinding(
 		key.WithKeys("left", "h"),
 		key.WithHelp("󰁍/h", "previous section"),
-	),
-	SwitchView: key.NewBinding(
-		key.WithKeys("s"),
-		key.WithHelp("s", "switch view"),
 	),
 	Search: key.NewBinding(
 		key.WithKeys("/"),

--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -15,6 +15,7 @@ type PRKeyMap struct {
 	Reopen      key.Binding
 	Merge       key.Binding
 	WatchChecks key.Binding
+	ViewIssues  key.Binding
 }
 
 var PRKeys = PRKeyMap{
@@ -58,6 +59,10 @@ var PRKeys = PRKeyMap{
 		key.WithKeys("w"),
 		key.WithHelp("w", "Watch checks"),
 	),
+	ViewIssues: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "Switch to issues"),
+	),
 }
 
 func PRFullHelp() []key.Binding {
@@ -72,5 +77,6 @@ func PRFullHelp() []key.Binding {
 		PRKeys.Reopen,
 		PRKeys.Merge,
 		PRKeys.WatchChecks,
+		PRKeys.ViewIssues,
 	}
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -198,7 +198,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncMainContentWidth()
 
 		case key.Matches(msg, m.keys.OpenGithub):
-			var currRow = m.getCurrRowData()
+			currRow := m.getCurrRowData()
 			b := browser.New("", os.Stdout, os.Stdin)
 			if currRow != nil {
 				err := b.Browse(currRow.GetUrl())
@@ -217,7 +217,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setCurrentViewSections(newSections)
 			cmds = append(cmds, fetchSectionsCmds)
 
-		case key.Matches(msg, m.keys.SwitchView):
+		case key.Matches(msg, keys.PRKeys.ViewIssues, keys.IssueKeys.ViewPRs):
 			m.ctx.View = m.switchSelectedView()
 			m.syncMainContentWidth()
 			m.setCurrSectionId(1)
@@ -675,16 +675,14 @@ func (m *Model) renderRunningTask() string {
 	var currTaskStatus string
 	switch task.State {
 	case context.TaskStart:
-		currTaskStatus =
-
-			lipgloss.NewStyle().
-				Background(m.ctx.Theme.SelectedBackground).
-				Render(
-					fmt.Sprintf(
-						"%s%s",
-						m.taskSpinner.View(),
-						task.StartText,
-					))
+		currTaskStatus = lipgloss.NewStyle().
+			Background(m.ctx.Theme.SelectedBackground).
+			Render(
+				fmt.Sprintf(
+					"%s%s",
+					m.taskSpinner.View(),
+					task.StartText,
+				))
 	case context.TaskError:
 		currTaskStatus = lipgloss.NewStyle().
 			Foreground(m.ctx.Theme.WarningText).


### PR DESCRIPTION
# Summary

It was hard for me to find the capability to view issues -- I saw it mentioned in the README, but I couldn't find it in the `?` menu. This PR proposes varying the help text for the "switch view" action so that the words "issues" or "PRs" are present where applicable.


E.g.:

```
...
s Switch to issues
```

or

```
s Switch to PRs
```

Alternatively, we could use the simpler

```
s View issues
```

but that would lose the nice acronym. Also, "switch" feels like a relevant hint that this will fully replace the current view.

## How did you test this change?

```sh
go run .
```

## Images/Videos
