### PR TITLE
Add labels to PR sidebar.

### DIFF
--- a/data/prapi.go
+++ b/data/prapi.go
@@ -39,7 +39,8 @@ type PullRequestData struct {
 	LatestReviews Reviews       `graphql:"latestReviews(last: 3)"`
 	ReviewThreads ReviewThreads `graphql:"reviewThreads(last: 20)"`
 	IsDraft       bool
-	Commits       Commits `graphql:"commits(last: 1)"`
+	Commits       Commits  `graphql:"commits(last: 1)"`
+	Labels        PRLabels `graphql:"labels(first: 3)"`
 }
 
 type CheckRun struct {
@@ -140,6 +141,15 @@ type ReviewThreads struct {
 		Path         string
 		Comments     ReviewComments `graphql:"comments(first: 10)"`
 	}
+}
+
+type PRLabel struct {
+	Color string
+	Name  string
+}
+
+type PRLabels struct {
+	Nodes []Label
 }
 
 type PageInfo struct {

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -133,9 +133,17 @@ func (m Model) View() string {
 	s.WriteString("\n\n")
 	s.WriteString(m.renderPills())
 	s.WriteString("\n\n")
+
+	labels := m.renderLabels()
+	if labels != "" {
+		s.WriteString(labels)
+		s.WriteString("\n\n")
+	}
+
 	s.WriteString(m.renderDescription())
 	s.WriteString("\n\n")
 	s.WriteString(m.renderChecks())
+
 	s.WriteString("\n\n")
 	s.WriteString(m.renderActivity())
 
@@ -226,6 +234,21 @@ func (m *Model) renderPills() string {
 	mergeablePill := m.renderMergeablePill()
 	checksPill := m.renderChecksPill()
 	return lipgloss.JoinHorizontal(lipgloss.Top, statusPill, " ", mergeablePill, " ", checksPill)
+}
+
+func (m *Model) renderLabels() string {
+	labels := make([]string, 0, len(m.pr.Data.Labels.Nodes))
+	for _, label := range m.pr.Data.Labels.Nodes {
+		labels = append(
+			labels,
+			m.ctx.Styles.PrSidebar.PillStyle.Copy().
+				Background(lipgloss.Color("#"+label.Color)).
+				Render(label.Name),
+		)
+		labels = append(labels, " ")
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, labels...)
 }
 
 func (m *Model) renderDescription() string {


### PR DESCRIPTION
# Summary

This PR adds support for labels in the PR sidebar, essentially identical to how they already render for issues.

I leverage PR labels a lot in my workflow, so this is helpful to quickly see which PRs have (or are missing) labels.

## How did you test this change?

Add labels to PRs - see that they render similar to labels 

## Images/Videos

Here is an example PR with a label (PR can be found [here](https://github.com/robdimsdale/gh-dash/pull/1)).

<img width="947" alt="Screenshot 2024-05-24 at 11 17 19" src="https://github.com/dlvhdr/gh-dash/assets/7230694/33274c96-a8c3-463e-9e86-ff9c2dfd673d">
