### PR TITLE
Render labels cleanly across multiple lines.

### DIFF
--- a/ui/common/labels.go
+++ b/ui/common/labels.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/dlvhdr/gh-dash/data"
+)
+
+func RenderLabels(sidebarWidth int, labels []data.Label, pillStyle lipgloss.Style) string {
+	width := sidebarWidth
+
+	renderedRows := []string{}
+
+	rowContentsWidth := 0
+	currentRowLabels := []string{}
+
+	for _, l := range labels {
+		currentLabel := pillStyle.Copy().
+			Background(lipgloss.Color("#" + l.Color)).
+			Render(l.Name)
+
+		currentLabelWidth := lipgloss.Width(currentLabel)
+
+		if rowContentsWidth+currentLabelWidth <= width {
+			currentRowLabels = append(
+				currentRowLabels,
+				currentLabel,
+			)
+			rowContentsWidth += currentLabelWidth
+		} else {
+			currentRowLabels = append(currentRowLabels, "\n")
+			renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
+
+			currentRowLabels = []string{currentLabel}
+			rowContentsWidth = currentLabelWidth
+		}
+
+		// +1 for the space between labels
+		currentRowLabels = append(currentRowLabels, " ")
+		rowContentsWidth += 1
+	}
+
+	renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
+
+	return lipgloss.JoinVertical(lipgloss.Left, renderedRows...)
+}

--- a/ui/common/labels_test.go
+++ b/ui/common/labels_test.go
@@ -1,0 +1,110 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/data"
+	"github.com/dlvhdr/gh-dash/ui/common"
+)
+
+var (
+	defaultStyle = lipgloss.NewStyle().PaddingLeft(1).PaddingRight(1)
+)
+
+func TestRenderLabels(t *testing.T) {
+	testCases := map[string]struct {
+		width     int
+		labels    []data.Label
+		baseStyle lipgloss.Style
+		want      string
+	}{
+		"one label, one row": {
+			width:     20,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "label-1",
+				},
+			},
+			want: " label-1  ",
+		},
+		"two labels, one row": {
+			width:     20,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "l-1",
+				},
+				{
+					Name: "l-2",
+				},
+			},
+			want: " l-1   l-2  ",
+		},
+		"two labels, two rows": {
+			width:     10,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "label-1",
+				},
+				{
+					Name: "label-2",
+				},
+			},
+			want: " label-1  \n          \n label-2  ",
+		},
+		"three labels, two rows": {
+			width:     20,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "l-1",
+				},
+				{
+					Name: "l-2",
+				},
+				{
+					Name: "label-3",
+				},
+			},
+			want: " l-1   l-2  \n            \n label-3    ",
+		},
+		"two labels, two rows, labels equal width": {
+			width:     5,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "l-1",
+				},
+				{
+					Name: "l-2",
+				},
+			},
+			want: " l-1  \n      \n l-2  ",
+		},
+		"two labels, one row, labels equal width": {
+			width:     11,
+			baseStyle: defaultStyle,
+			labels: []data.Label{
+				{
+					Name: "l-1",
+				},
+				{
+					Name: "l-2",
+				},
+			},
+			want: " l-1   l-2  ",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := common.RenderLabels(tc.width, tc.labels, tc.baseStyle)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -204,18 +204,42 @@ func (m *Model) renderBody() string {
 }
 
 func (m *Model) renderLabels() string {
-	labels := make([]string, 0, len(m.issue.Data.Labels.Nodes))
-	for _, label := range m.issue.Data.Labels.Nodes {
-		labels = append(
-			labels,
-			m.ctx.Styles.PrSidebar.PillStyle.Copy().
-				Background(lipgloss.Color("#"+label.Color)).
-				Render(label.Name),
-		)
-		labels = append(labels, " ")
+	width := m.getIndentedContentWidth()
+
+	renderedRows := []string{}
+
+	rowContentsWidth := 0
+	currentRowLabels := []string{}
+
+	for _, l := range m.issue.Data.Labels.Nodes {
+		currentLabel := m.ctx.Styles.PrSidebar.PillStyle.Copy().
+			Background(lipgloss.Color("#" + l.Color)).
+			Render(l.Name)
+
+		currentLabelWidth := lipgloss.Width(currentLabel)
+
+		if rowContentsWidth+currentLabelWidth <= width {
+			currentRowLabels = append(
+				currentRowLabels,
+				currentLabel,
+			)
+			rowContentsWidth += currentLabelWidth
+		} else {
+			currentRowLabels = append(currentRowLabels, "\n")
+			renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
+
+			currentRowLabels = []string{currentLabel}
+			rowContentsWidth = currentLabelWidth
+		}
+
+		// +1 for the space between labels
+		currentRowLabels = append(currentRowLabels, " ")
+		rowContentsWidth += 1
 	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, labels...)
+	renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
+
+	return lipgloss.JoinVertical(lipgloss.Left, renderedRows...)
 }
 
 func (m *Model) getIndentedContentWidth() int {

--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -205,41 +205,10 @@ func (m *Model) renderBody() string {
 
 func (m *Model) renderLabels() string {
 	width := m.getIndentedContentWidth()
+	labels := m.issue.Data.Labels.Nodes
+	style := m.ctx.Styles.PrSidebar.PillStyle
 
-	renderedRows := []string{}
-
-	rowContentsWidth := 0
-	currentRowLabels := []string{}
-
-	for _, l := range m.issue.Data.Labels.Nodes {
-		currentLabel := m.ctx.Styles.PrSidebar.PillStyle.Copy().
-			Background(lipgloss.Color("#" + l.Color)).
-			Render(l.Name)
-
-		currentLabelWidth := lipgloss.Width(currentLabel)
-
-		if rowContentsWidth+currentLabelWidth <= width {
-			currentRowLabels = append(
-				currentRowLabels,
-				currentLabel,
-			)
-			rowContentsWidth += currentLabelWidth
-		} else {
-			currentRowLabels = append(currentRowLabels, "\n")
-			renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
-
-			currentRowLabels = []string{currentLabel}
-			rowContentsWidth = currentLabelWidth
-		}
-
-		// +1 for the space between labels
-		currentRowLabels = append(currentRowLabels, " ")
-		rowContentsWidth += 1
-	}
-
-	renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
-
-	return lipgloss.JoinVertical(lipgloss.Left, renderedRows...)
+	return common.RenderLabels(width, labels, style)
 }
 
 func (m *Model) getIndentedContentWidth() int {

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -238,41 +238,10 @@ func (m *Model) renderPills() string {
 
 func (m *Model) renderLabels() string {
 	width := m.getIndentedContentWidth()
+	labels := m.pr.Data.Labels.Nodes
+	style := m.ctx.Styles.PrSidebar.PillStyle
 
-	renderedRows := []string{}
-
-	rowContentsWidth := 0
-	currentRowLabels := []string{}
-
-	for _, l := range m.pr.Data.Labels.Nodes {
-		currentLabel := m.ctx.Styles.PrSidebar.PillStyle.Copy().
-			Background(lipgloss.Color("#" + l.Color)).
-			Render(l.Name)
-
-		currentLabelWidth := lipgloss.Width(currentLabel)
-
-		if rowContentsWidth+currentLabelWidth <= width {
-			currentRowLabels = append(
-				currentRowLabels,
-				currentLabel,
-			)
-			rowContentsWidth += currentLabelWidth
-		} else {
-			currentRowLabels = append(currentRowLabels, "\n")
-			renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
-
-			currentRowLabels = []string{currentLabel}
-			rowContentsWidth = currentLabelWidth
-		}
-
-		// +1 for the space between labels
-		currentRowLabels = append(currentRowLabels, " ")
-		rowContentsWidth += 1
-	}
-
-	renderedRows = append(renderedRows, lipgloss.JoinHorizontal(lipgloss.Top, currentRowLabels...))
-
-	return lipgloss.JoinVertical(lipgloss.Left, renderedRows...)
+	return common.RenderLabels(width, labels, style)
 }
 
 func (m *Model) renderDescription() string {


### PR DESCRIPTION
# Summary

Fixes an issue where labels did not wrap neatly when their total length was longer than one line. (see https://github.com/dlvhdr/gh-dash/pull/369#issuecomment-2132224396). The previous behavior was inconsistent - sometimes it would wrap the label color but not the label text; sometimes it would fail to render labels at all.

I also backported the same logic to the issue sidebar, as it was already present there but we just hadn't discovered it yet.

## How did you test this change?

With a PR (and issue) that had multiple labels associated with them

## Images/Videos

This is the new behavior. Notice the clean wrapping across multiple lines

<img width="329" alt="Screenshot 2024-05-28 at 15 00 07" src="https://github.com/dlvhdr/gh-dash/assets/7230694/a0e1c88f-e098-4dce-a4a7-381d7a4d0d46">

## Notes

The code is fairly clunky as it is manually building the multiple rows that consist of multiple lables. I couldn't find a native way to do this in the UI library (`lipgloss`). If there's a cleaner way to achieve this outcome I would prefer that!