### PR TITLE
feat: make column titles configurable

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -58,8 +58,9 @@ type PreviewConfig struct {
 }
 
 type ColumnConfig struct {
-	Width  *int  `yaml:"width,omitempty"  validate:"omitempty,gt=0"`
-	Hidden *bool `yaml:"hidden,omitempty"`
+	Width  *int    `yaml:"width,omitempty"  validate:"omitempty,gt=0"`
+	Hidden *bool   `yaml:"hidden,omitempty"`
+	Title  *string `yaml:"title,omitempty"`
 }
 
 type PrsLayoutConfig struct {
@@ -192,24 +193,43 @@ func (parser ConfigParser) getDefaultConfig() Config {
 			Layout: LayoutConfig{
 				Prs: PrsLayoutConfig{
 					UpdatedAt: ColumnConfig{
+						Title: utils.StringPtr(""),
 						Width: utils.IntPtr(lipgloss.Width("2mo ago")),
 					},
+					State: ColumnConfig{
+						Title: utils.StringPtr(""),
+					},
 					Repo: ColumnConfig{
+						Title: utils.StringPtr(""),
 						Width: utils.IntPtr(15),
 					},
+					Title: ColumnConfig{
+						Title: utils.StringPtr("Title"),
+					},
 					Author: ColumnConfig{
+						Title: utils.StringPtr("Author"),
 						Width: utils.IntPtr(15),
 					},
 					Assignees: ColumnConfig{
+						Title:  utils.StringPtr("Assignees"),
 						Width:  utils.IntPtr(20),
 						Hidden: utils.BoolPtr(true),
 					},
 					Base: ColumnConfig{
+						Title:  utils.StringPtr("Base"),
 						Width:  utils.IntPtr(15),
 						Hidden: utils.BoolPtr(true),
 					},
 					Lines: ColumnConfig{
+						Title: utils.StringPtr(""),
 						Width: utils.IntPtr(lipgloss.Width("123450 / -123450")),
+					},
+					ReviewStatus: ColumnConfig{
+						Title: utils.StringPtr("󰯢"),
+						Width: utils.IntPtr(4),
+					},
+					Ci: ColumnConfig{
+						Title: utils.StringPtr(""),
 					},
 				},
 				Issues: IssuesLayoutConfig{

--- a/config/utils.go
+++ b/config/utils.go
@@ -51,5 +51,8 @@ func MergeColumnConfigs(defaultCfg, sectionCfg ColumnConfig) ColumnConfig {
 	if sectionCfg.Hidden != nil {
 		colCfg.Hidden = sectionCfg.Hidden
 	}
+	if sectionCfg.Title != nil {
+		colCfg.Title = sectionCfg.Title
+	}
 	return colCfg
 }

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -179,6 +179,18 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 	return &m, tea.Batch(cmd, searchCmd, promptCmd)
 }
 
+func fromColumnConfig(config config.ColumnConfig) table.Column {
+	return withColumnConfig(table.Column{}, config)
+}
+
+func withColumnConfig(column table.Column, config config.ColumnConfig) table.Column {
+	column.Title = *config.Title
+	column.Width = config.Width
+	column.Hidden = config.Hidden
+
+	return column
+}
+
 func GetSectionColumns(
 	cfg config.PrsSectionConfig,
 	ctx *context.ProgramContext,
@@ -207,56 +219,16 @@ func GetSectionColumns(
 	linesLayout := config.MergeColumnConfigs(dLayout.Lines, sLayout.Lines)
 
 	return []table.Column{
-		{
-			Title:  "",
-			Width:  updatedAtLayout.Width,
-			Hidden: updatedAtLayout.Hidden,
-		},
-		{
-			Title:  "",
-			Hidden: stateLayout.Hidden,
-		},
-		{
-			Title:  "",
-			Width:  repoLayout.Width,
-			Hidden: repoLayout.Hidden,
-		},
-		{
-			Title:  "Title",
-			Grow:   utils.BoolPtr(true),
-			Hidden: titleLayout.Hidden,
-		},
-		{
-			Title:  "Author",
-			Width:  authorLayout.Width,
-			Hidden: authorLayout.Hidden,
-		},
-		{
-			Title:  "Assignees",
-			Width:  assigneesLayout.Width,
-			Hidden: assigneesLayout.Hidden,
-		},
-		{
-			Title:  "Base",
-			Width:  baseLayout.Width,
-			Hidden: baseLayout.Hidden,
-		},
-		{
-			Title:  "󰯢",
-			Width:  utils.IntPtr(4),
-			Hidden: reviewStatusLayout.Hidden,
-		},
-		{
-			Title:  "",
-			Width:  &ctx.Styles.PrSection.CiCellWidth,
-			Grow:   new(bool),
-			Hidden: ciLayout.Hidden,
-		},
-		{
-			Title:  "",
-			Width:  linesLayout.Width,
-			Hidden: linesLayout.Hidden,
-		},
+		fromColumnConfig(updatedAtLayout),
+		fromColumnConfig(stateLayout),
+		fromColumnConfig(repoLayout),
+		withColumnConfig(table.Column{Grow: utils.BoolPtr(true)}, titleLayout),
+		fromColumnConfig(authorLayout),
+		fromColumnConfig(assigneesLayout),
+		fromColumnConfig(baseLayout),
+		fromColumnConfig(reviewStatusLayout),
+		withColumnConfig(table.Column{Width: &ctx.Styles.PrSection.CiCellWidth, Grow: new(bool)}, ciLayout),
+		fromColumnConfig(linesLayout),
 	}
 }
 


### PR DESCRIPTION
Prior to this change, column titles were hard-coded.

This change allows column titles to be defined in configuration.

# Summary

The current behavior requires the use of a nerd-font, which the user may not have or want. This allows titles to be configured manually, which allows for natural language titles.

## How did you test this change?

Manual testing, using the following config section:

```yaml
prSections:
  - title: Mine
    filters: is:open author:@me
    layout:
      updatedAt:
        title: Age
      repo:
        title: Repo
      author:
        hidden: true
      lines:
        title: Lines
      ci:
        title: Checks
      reviewStatus:
        hidden: true
      state:
        hidden: true
```

## Images/Videos

<img width="1405" alt="Screenshot 2024-05-29 at 4 30 03 PM" src="https://github.com/dlvhdr/gh-dash/assets/436846/6e2e42fb-ed19-4a1f-bb80-e3c75a40b84c">
