### PR TITLE
fix: adjust ExpandedHelpHeight to prevent screen corruption

### DIFF
--- a/ui/common/styles.go
+++ b/ui/common/styles.go
@@ -10,7 +10,7 @@ import (
 var (
 	SearchHeight       = 3
 	FooterHeight       = 1
-	ExpandedHelpHeight = 11
+	ExpandedHelpHeight = 12
 	InputBoxHeight     = 8
 	SingleRuneWidth    = 4
 	MainContentPadding = 1


### PR DESCRIPTION
# Summary
resolve: #384 

In PR #366, the layout of the items displayed in the full help view in the PRs screen was changed. As a result, the height of the help view was altered.

This caused the height of the help view to differ from the expected value, leading to layout corruption when toggling the help view.

To address this issue, I have adjusted the height to match the current actual height of the help view.

## How did you test this change?
I manually tested the change and confirmed that the help view is now displaying correctly.

## Images/Videos

https://github.com/dlvhdr/gh-dash/assets/27483768/b494b6dd-5de6-463e-98ae-ea30fe12960c

