### PR TITLE
Enable approving a PR without entering a comment

### DIFF
--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -79,9 +79,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			switch msg.Type {
 
 			case tea.KeyCtrlD:
+				comment := ""
 				if len(strings.Trim(m.inputBox.Value(), " ")) != 0 {
-					cmd = m.approve(m.inputBox.Value())
+					comment = m.inputBox.Value()
 				}
+				cmd = m.approve(comment)
 				m.inputBox.Blur()
 				m.isApproving = false
 				return m, cmd


### PR DESCRIPTION
# Summary

This is a follow-up to https://github.com/dlvhdr/gh-dash/pull/399 to address https://github.com/dlvhdr/gh-dash/pull/399#pullrequestreview-2239389841

That PR added support for approving PRs. However, the code was requiring that a comment be entered, or else the approval wouldn't occur. This seemed unintended because the implementation of the `approve` method had some code to explicitly handle the case where the comment was empty:
https://github.com/dlvhdr/gh-dash/blob/d9033f7855730e536f5a3ecfbd8cb8e9f4c9268b/ui/components/prsidebar/approve.go#L33-L35

It was likely just a copy-paste mistake - the code for leaving a regular comment was aborting if the comment was empty (or only whitespace), which makes sense (but doesn't apply for approvals).

## How did you test this change?

I built this branch locally and ran it and used it to approve a PR without a comment:

![image](https://github.com/user-attachments/assets/ce40876f-d69b-4bb9-9687-5d76b92e46a6)