### PR TITLE
Feat: added '-u` to update PR from base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ keybindings:
 The list of available builtin commands are:
 
 1. `universal`: up, down, firstLine, lastLine, togglePreview, openGithub, refresh, refreshAll, pageDown, pageUp, nextSection, prevSection, search, copyurl, copyNumber, help, quit
-2. `prs`: approve, assign, unassign, comment, diff, checkout, close, ready, reopen, merge, watchChecks, viewIssues
+2. `prs`: approve, assign, unassign, comment, diff, checkout, close, ready, reopen, merge, update, watchChecks, viewIssues
 3. `Issues`: assign, unassign, comment, close, reopen, viewPrs
 
 #### Defining custom keybindings

--- a/config/parser.go
+++ b/config/parser.go
@@ -148,6 +148,7 @@ type ColorThemeText struct {
 	Faint     HexColor `yaml:"faint"     validate:"hexcolor"`
 	Warning   HexColor `yaml:"warning"   validate:"hexcolor"`
 	Success   HexColor `yaml:"success"   validate:"hexcolor"`
+	Error     HexColor `yaml:"error"     validate:"hexcolor"`
 }
 
 type ColorThemeBorder struct {

--- a/data/prapi.go
+++ b/data/prapi.go
@@ -33,14 +33,15 @@ type PullRequestData struct {
 	HeadRef struct {
 		Name string
 	}
-	Repository    Repository
-	Assignees     Assignees     `graphql:"assignees(first: 3)"`
-	Comments      Comments      `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
-	LatestReviews Reviews       `graphql:"latestReviews(last: 3)"`
-	ReviewThreads ReviewThreads `graphql:"reviewThreads(last: 20)"`
-	IsDraft       bool
-	Commits       Commits  `graphql:"commits(last: 1)"`
-	Labels        PRLabels `graphql:"labels(first: 3)"`
+	Repository       Repository
+	Assignees        Assignees     `graphql:"assignees(first: 3)"`
+	Comments         Comments      `graphql:"comments(last: 5, orderBy: { field: UPDATED_AT, direction: DESC })"`
+	LatestReviews    Reviews       `graphql:"latestReviews(last: 3)"`
+	ReviewThreads    ReviewThreads `graphql:"reviewThreads(last: 20)"`
+	IsDraft          bool
+	Commits          Commits          `graphql:"commits(last: 1)"`
+	Labels           PRLabels         `graphql:"labels(first: 3)"`
+	MergeStateStatus MergeStateStatus `graphql:"mergeStateStatus"`
 }
 
 type CheckRun struct {
@@ -151,6 +152,8 @@ type PRLabel struct {
 type PRLabels struct {
 	Nodes []Label
 }
+
+type MergeStateStatus string
 
 type PageInfo struct {
 	HasNextPage bool

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -283,6 +283,19 @@ func (pr *PullRequest) RenderState() string {
 	}
 }
 
+func (pr *PullRequest) RenderMergeStateStatus() string {
+	switch pr.Data.MergeStateStatus {
+	case "CLEAN":
+		return constants.SuccessIcon + " Upto-date"
+	case "BLOCKED":
+		return constants.BlockedIcon + " Blocked"
+	case "BEHIND":
+		return constants.BehindIcon + " Behind"
+	default:
+		return ""
+	}
+}
+
 func (pr *PullRequest) ToTableRow(isSelected bool) table.Row {
 	if !pr.Ctx.Config.Theme.Ui.Table.Compact {
 		return table.Row{

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -286,7 +286,7 @@ func (pr *PullRequest) RenderState() string {
 func (pr *PullRequest) RenderMergeStateStatus() string {
 	switch pr.Data.MergeStateStatus {
 	case "CLEAN":
-		return constants.SuccessIcon + " Upto-date"
+		return constants.SuccessIcon + \" Up-to-date\"
 	case "BLOCKED":
 		return constants.BlockedIcon + " Blocked"
 	case "BEHIND":

--- a/ui/components/pr/pr.go
+++ b/ui/components/pr/pr.go
@@ -286,7 +286,7 @@ func (pr *PullRequest) RenderState() string {
 func (pr *PullRequest) RenderMergeStateStatus() string {
 	switch pr.Data.MergeStateStatus {
 	case "CLEAN":
-		return constants.SuccessIcon + \" Up-to-date\"
+		return constants.SuccessIcon + " Up-to-date"
 	case "BLOCKED":
 		return constants.BlockedIcon + " Blocked"
 	case "BEHIND":

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -234,7 +234,7 @@ func (m *Model) renderMergeStateStatusPill() string {
 	if status == "CLEAN" {
 		return m.ctx.Styles.PrSidebar.PillStyle.
 			Background(m.ctx.Theme.SuccessText).
-			Render(\" Branch Up-To-Date\")
+			Render("󰄬 Branch Up-To-Date")
 	} else if status == "BLOCKED" {
 		return m.ctx.Styles.PrSidebar.PillStyle.
 			Background(m.ctx.Theme.ErrorText).

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -223,9 +223,27 @@ func (m *Model) renderMergeablePill() string {
 	} else if status == "MERGEABLE" {
 		return m.ctx.Styles.PrSidebar.PillStyle.
 			Background(m.ctx.Theme.SuccessText).
-			Render("󰃸 Mergeable")
+			Render("󰃸 No Merge Conflicts")
 	}
 
+	return ""
+}
+
+func (m *Model) renderMergeStateStatusPill() string {
+	status := m.pr.Data.MergeStateStatus
+	if status == "CLEAN" {
+		return m.ctx.Styles.PrSidebar.PillStyle.
+			Background(m.ctx.Theme.SuccessText).
+			Render(" Branch UpTo Date")
+	} else if status == "BLOCKED" {
+		return m.ctx.Styles.PrSidebar.PillStyle.
+			Background(m.ctx.Theme.ErrorText).
+			Render("󰅖 Branch Blocked")
+	} else if status == "BEHIND" {
+		return m.ctx.Styles.PrSidebar.PillStyle.
+			Background(m.ctx.Theme.WarningText).
+			Render(" Branch Behind")
+	}
 	return ""
 }
 
@@ -236,7 +254,7 @@ func (m *Model) renderChecksPill() string {
 	status := m.pr.GetStatusChecksRollup()
 	if status == "FAILURE" {
 		return s.
-			Background(t.WarningText).
+			Background(t.ErrorText).
 			Render("󰅖 Checks")
 	} else if status == "PENDING" {
 		return s.
@@ -256,7 +274,8 @@ func (m *Model) renderPills() string {
 	statusPill := m.renderStatusPill()
 	mergeablePill := m.renderMergeablePill()
 	checksPill := m.renderChecksPill()
-	return lipgloss.JoinHorizontal(lipgloss.Top, statusPill, " ", mergeablePill, " ", checksPill)
+	uptoDatePill := m.renderMergeStateStatusPill()
+	return lipgloss.JoinHorizontal(lipgloss.Top, statusPill, " ", mergeablePill, " ", checksPill, " ", uptoDatePill)
 }
 
 func (m *Model) renderLabels() string {

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -234,7 +234,7 @@ func (m *Model) renderMergeStateStatusPill() string {
 	if status == "CLEAN" {
 		return m.ctx.Styles.PrSidebar.PillStyle.
 			Background(m.ctx.Theme.SuccessText).
-			Render(" Branch UpTo Date")
+			Render(\" Branch Up-To-Date\")
 	} else if status == "BLOCKED" {
 		return m.ctx.Styles.PrSidebar.PillStyle.
 			Background(m.ctx.Theme.ErrorText).

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -99,6 +99,8 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 						cmd = tasks.PRReady(m.Ctx, sid, pr)
 					case "merge":
 						cmd = tasks.MergePR(m.Ctx, sid, pr)
+					case "update":
+						cmd = tasks.UpdatePR(m.Ctx, sid, pr)
 					}
 				}
 

--- a/ui/components/reposection/reposection.go
+++ b/ui/components/reposection/reposection.go
@@ -124,6 +124,8 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 							cmd = tasks.PRReady(m.Ctx, sid, pr)
 						case "merge":
 							cmd = tasks.MergePR(m.Ctx, sid, pr)
+						case "update":
+							cmd = tasks.UpdatePR(m.Ctx, sid, pr)
 						}
 					}
 				}

--- a/ui/components/section/section.go
+++ b/ui/components/section/section.go
@@ -346,6 +346,9 @@ func (m *BaseModel) GetPromptConfirmation() string {
 		case m.PromptConfirmationAction == "merge" && m.Ctx.View == config.PRsView:
 			prompt = "Are you sure you want to merge this PR? (Y/n) "
 
+		case m.PromptConfirmationAction == "update" && m.Ctx.View == config.PRsView:
+			prompt = "Are you sure you want to update this PR? (Y/n) "
+
 		case m.PromptConfirmationAction == "close" && m.Ctx.View == config.IssuesView:
 			prompt = "Are you sure you want to close this issue? (Y/n) "
 

--- a/ui/components/tasks/pr.go
+++ b/ui/components/tasks/pr.go
@@ -238,3 +238,26 @@ func CreatePR(ctx *context.ProgramContext, section SectionIdentifer, branchName 
 		}
 	}))
 }
+
+func UpdatePR(ctx *context.ProgramContext, section SectionIdentifer, pr data.RowData) tea.Cmd {
+	prNumber := pr.GetNumber()
+	return fireTask(ctx, GitHubTask{
+		Id: buildTaskId("pr_update", prNumber),
+		Args: []string{
+			"pr",
+			"update-branch",
+			fmt.Sprint(prNumber),
+			"-R",
+			pr.GetRepoNameWithOwner(),
+		},
+		Section:      section,
+		StartText:    fmt.Sprintf("Updating PR #%d", prNumber),
+		FinishedText: fmt.Sprintf("PR #%d has been updated", prNumber),
+		Msg: func(c *exec.Cmd, err error) tea.Msg {
+			return UpdatePRMsg{
+				PrNumber: prNumber,
+				IsClosed: utils.BoolPtr(true),
+			}
+		},
+	})
+}

--- a/ui/constants/constants.go
+++ b/ui/constants/constants.go
@@ -30,8 +30,10 @@ const (
 	FailureIcon = "󰅙"
 	SuccessIcon = ""
 
-	DraftIcon  = ""
-	MergedIcon = ""
-	OpenIcon   = ""
-	ClosedIcon = ""
+	DraftIcon   = ""
+	BehindIcon  = "󰇮"
+	BlockedIcon = ""
+	MergedIcon  = ""
+	OpenIcon    = ""
+	ClosedIcon  = ""
 )

--- a/ui/keys/branchKeys.go
+++ b/ui/keys/branchKeys.go
@@ -17,6 +17,7 @@ type BranchKeyMap struct {
 	Push        key.Binding
 	ForcePush   key.Binding
 	Delete      key.Binding
+	UpdatePr    key.Binding
 	ViewPRs     key.Binding
 }
 
@@ -49,6 +50,10 @@ var BranchKeys = BranchKeyMap{
 		key.WithKeys("d", "backspace"),
 		key.WithHelp("d/backspace", "delete"),
 	),
+	UpdatePr: key.NewBinding(
+		key.WithKeys("u"),
+		key.WithHelp("u", "update PR"),
+	),
 	ViewPRs: key.NewBinding(
 		key.WithKeys("s"),
 		key.WithHelp("s", "Switch to PRs"),
@@ -64,6 +69,7 @@ func BranchFullHelp() []key.Binding {
 		BranchKeys.New,
 		BranchKeys.CreatePr,
 		BranchKeys.Delete,
+		BranchKeys.UpdatePr,
 		BranchKeys.ViewPRs,
 	}
 }
@@ -95,6 +101,8 @@ func rebindBranchKeys(keys []config.Keybinding) error {
 			key = &BranchKeys.Checkout
 		case "viewPRs":
 			key = &BranchKeys.ViewPRs
+		case "updatePr":
+			key = &BranchKeys.UpdatePr
 		default:
 			return fmt.Errorf("unknown built-in branch key: '%s'", branchKey.Builtin)
 		}

--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -20,6 +20,7 @@ type PRKeyMap struct {
 	Ready       key.Binding
 	Reopen      key.Binding
 	Merge       key.Binding
+	Update      key.Binding
 	WatchChecks key.Binding
 	ViewIssues  key.Binding
 }
@@ -65,6 +66,10 @@ var PRKeys = PRKeyMap{
 		key.WithKeys("m"),
 		key.WithHelp("m", "merge"),
 	),
+	Update: key.NewBinding(
+		key.WithKeys("u"),
+		key.WithHelp("u", "update pr from base branch"),
+	),
 	WatchChecks: key.NewBinding(
 		key.WithKeys("w"),
 		key.WithHelp("w", "Watch checks"),
@@ -87,6 +92,7 @@ func PRFullHelp() []key.Binding {
 		PRKeys.Ready,
 		PRKeys.Reopen,
 		PRKeys.Merge,
+		PRKeys.Update,
 		PRKeys.WatchChecks,
 		PRKeys.ViewIssues,
 	}
@@ -123,6 +129,8 @@ func rebindPRKeys(keys []config.Keybinding) error {
 			key = &PRKeys.Reopen
 		case "merge":
 			key = &PRKeys.Merge
+		case "update":
+			key = &PRKeys.Update
 		case "watchChecks":
 			key = &PRKeys.WatchChecks
 		case "viewIssues":

--- a/ui/theme/theme.go
+++ b/ui/theme/theme.go
@@ -17,6 +17,7 @@ type Theme struct {
 	InvertedText       lipgloss.AdaptiveColor // config.Theme.Colors.Text.Inverted
 	SuccessText        lipgloss.AdaptiveColor // config.Theme.Colors.Text.Success
 	WarningText        lipgloss.AdaptiveColor // config.Theme.Colors.Text.Warning
+	ErrorText          lipgloss.AdaptiveColor // config.Theme.Colors.Text.Error
 }
 
 var DefaultTheme = &Theme{
@@ -29,7 +30,8 @@ var DefaultTheme = &Theme{
 	FaintText:          lipgloss.AdaptiveColor{Light: "007", Dark: "245"},
 	InvertedText:       lipgloss.AdaptiveColor{Light: "015", Dark: "236"},
 	SuccessText:        lipgloss.AdaptiveColor{Light: "002", Dark: "002"},
-	WarningText:        lipgloss.AdaptiveColor{Light: "001", Dark: "001"},
+	WarningText:        lipgloss.AdaptiveColor{Light: "003", Dark: "003"},
+	ErrorText:          lipgloss.AdaptiveColor{Light: "001", Dark: "001"},
 }
 
 func ParseTheme(cfg *config.Config) Theme {
@@ -57,6 +59,7 @@ func ParseTheme(cfg *config.Config) Theme {
 			InvertedText: _shimHex(cfg.Theme.Colors.Inline.Text.Inverted),
 			SuccessText:  _shimHex(cfg.Theme.Colors.Inline.Text.Success),
 			WarningText:  _shimHex(cfg.Theme.Colors.Inline.Text.Warning),
+			ErrorText:    _shimHex(cfg.Theme.Colors.Inline.Text.Error),
 		}
 	}
 

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -396,6 +396,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, cmd
 
+			case key.Matches(msg, keys.PRKeys.Update):
+				if currSection != nil {
+					currSection.SetPromptConfirmationAction("update")
+					cmd = currSection.SetIsPromptConfirmationShown(true)
+				}
+				return m, cmd
+
 			case key.Matches(msg, keys.PRKeys.ViewIssues):
 				m.ctx.View = m.switchSelectedView()
 				m.syncMainContentWidth()


### PR DESCRIPTION
# Summary
Added `-u` to update a PR from a base branch
Added a mergeStateStatuspill
Added a error theme colour
Changed warning colour to yellow from red

## How did you test this change?
1. built repo locally
2. ran with `--debug`
3. verified via debug that it was calling the function
```
8:56AM DEBU <ui/ui.go:163> Key pressed key=u
8:56AM DEBU <ui/ui.go:163> Key pressed key=y
8:56AM DEBU <ui/ui.go:163> Key pressed key=enter
8:56AM DEBU <tasks/pr.go:244> Updating PR prNumber=xxx
8:56AM DEBU <ui/ui.go:69> Starting task id=pr_update_xxx
8:56AM DEBU <tasks/pr.go:62> Running task cmd="gh pr update-branch xxx -R xxx/xxx"
8:56AM DEBU <ui/ui.go:505> Task finished id=pr_update_xxx
```

4. verified PR in the UI was also updated
5. verified the Pills in the UI changed as they are updated

## Images

![image](https://github.com/user-attachments/assets/922a0a1e-2775-4a62-9274-0246776b0449)
![image](https://github.com/user-attachments/assets/4e3ee586-09bc-48bd-8871-81a03a66d4e5)
![image](https://github.com/user-attachments/assets/84b64930-b811-4fb6-ab46-689816102f54)
![image](https://github.com/user-attachments/assets/738d6678-0ba6-4950-b9b6-57fedbabd78f)
![image](https://github.com/user-attachments/assets/aff07472-bf84-4fb4-b9fd-b4a271a8dfe8)




