### PR TITLE
Add a description of confirmation prompts introduced in v3.10.0

### DIFF
--- a/docs/content/getting-started/keybindings/selected-issue.md
+++ b/docs/content/getting-started/keybindings/selected-issue.md
@@ -57,9 +57,12 @@ to close the issue.
 ---
 variant: warning
 ---
-When you use this command, the dashboard closes the issue immediately and
+**Prior to v3.10.0:** When you use this command, the dashboard closes the issue immediately and
 without prompting for confirmation. Only use this command when you're sure you
 want to close the issue.
+
+**Since v3.10.0:** When you use this command, the dashboard displays a confirmation prompt and
+closes the issue only after you approve the action.
 
 This command doesn't support closing the issue with a comment. If you want to
 add a comment that explains why you're closing the issue, use the
@@ -75,7 +78,10 @@ command to reopen the issue.
 ---
 variant: warning
 ---
-When you use this command, the dashboard reopens the issue immediately and
+**Prior to v3.10.0:** When you use this command, the dashboard reopens the issue immediately and
 without prompting for confirmation. Only use this command when you're sure you
 want to reopen the closed issue.
+
+**Since v3.10.0:** When you use this command, the dashboard displays a confirmation prompt and
+reopens the issue only after you approve the action.
 ```

--- a/docs/content/getting-started/keybindings/selected-pr.md
+++ b/docs/content/getting-started/keybindings/selected-pr.md
@@ -87,9 +87,12 @@ merge the PR.
 ---
 variant: danger
 ---
-When you use this command, the dashboard merges the PR immediately and without
+**Prior to v3.10.0:** When you use this command, the dashboard merges the PR immediately and without
 prompting for confirmation. Only use this command when you're sure you want to
 merge the PR.
+
+**Since v3.10.0:** When you use this command, the dashboard displays a confirmation prompt and
+merges the PR only after you approve the action.
 ```
 
 ## `w` - Mark PR as Ready for Review { #mark-pr-as-ready-for-review}
@@ -106,9 +109,12 @@ close the PR.
 ---
 variant: warning
 ---
-When you use this command, the dashboard closes the PR immediately and without
+**Prior to v3.10.0:** When you use this command, the dashboard closes the PR immediately and without
 prompting for confirmation. Only use this command when you're sure you want to
 close the PR.
+
+**Since v3.10.0:** When you use this command, the dashboard displays a confirmation prompt and
+closes the PR only after you approve the action.
 
 This command doesn't support closing the PR with a comment. If you want to add
 a comment that explains why you're closing the PR, use the
@@ -124,7 +130,10 @@ command to reopen the PR.
 ---
 variant: warning
 ---
-When you use this command, the dashboard reopens the PR immediately and without
+**Prior to v3.10.0:** When you use this command, the dashboard reopens the PR immediately and without
 prompting for confirmation. Only use this command when you're sure you want to
 reopen the closed PR.
+
+**Since v3.10.0:** When you use this command, the dashboard displays a confirmation prompt and
+reopens the PR only after you approve the action.
 ```


### PR DESCRIPTION
# Summary

https://github.com/dlvhdr/gh-dash/pull/293 added confirmation prompts before performing some `gh` actions, but the docs were not updated. This PR adds a description of the confirmation prompts to reflect the latest behavior of `gh-dash` in the docs.

## How did you test this change?

I built the site locally, and checked the changes were reflected in the built site.

## Images/Videos

![localhost_1313_getting-started_keybindings_selected-issue_](https://github.com/user-attachments/assets/ee7d9093-4693-40ee-a58e-3a702cfdc2b4)

![localhost_1313_getting-started_keybindings_selected-pr_](https://github.com/user-attachments/assets/daa5252f-0c36-4a5d-a48b-f9930f688b45)
