### PR TITLE
docs: Adding error property to theme example;

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ theme:
       faint: "#3E4057"
       warning: "#F23D5C"
       success: "#3DF294"
+      error: "#D20F39"
     background:
       selected: "#39386B"
     border:


### PR DESCRIPTION
# Summary

With the additional property of `error` added to theme color in the
dlvhdr/gh-dash#458, the configuration of themes break if this property is
missing. This patch then adds it to the example to help users understand what's
required for theming `gh-dash`.

## How did you test this change?

If the `~/.config/gh-dash/config.yml` contains a reference to a `theme:colors`
stanza but the `text` stanza doesn't contain an `error` property, you will see
the following error.

```sh
2024-10-30T12:24:29-05:00 FATA <ui/ui.go:107> Reading config file: failed parsing config file location="" err="failed parsing config.yml: Key: 'Config.theme.colors.Inline.text.error' Error:Field validation for 'error' failed on the 'hexcolor' tag"
```

And it breaks the rest of your shell session as well. It's probably a good idea
to fix that error with some defaults. But for now, I think we can avoid the
issue by updating the documentation.

## Images/Videos

n/a
