### PR TITLE
fix: initial textinput size

### DIFF
--- a/ui/components/search/search.go
+++ b/ui/components/search/search.go
@@ -27,7 +27,7 @@ func NewModel(ctx *context.ProgramContext, opts SearchOptions) Model {
 	ti := textinput.New()
 	ti.Placeholder = opts.Placeholder
 	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(ctx.Theme.FaintText)
-	ti.Width = 0
+	ti.Width = ctx.MainContentWidth - lipgloss.Width(prompt) - 6
 	ti.PromptStyle = ti.PromptStyle.Foreground(ctx.Theme.SecondaryText)
 	ti.Prompt = prompt
 	ti.TextStyle = ti.TextStyle.Faint(true)


### PR DESCRIPTION
# Summary

When the `filters` are too long, the TextInput wraps into a new line with a visual artifact.
This might be an issue with BubbleTea itself, but let me know if I should try to fix it here or in BubbleTea.

I reused the same values as `getInputWidth`.

> Note: This is my first Go and BubbleTea contribution 🎉 

## How did you test this change?

I reproduce the issue locally with the following settings:
```yml
prSections:
  - title: Very long PR filter
    filters: is:open very very very very very very very very very very very very very very very very very long review:required sort:created-asc

issuesSections:
  - title: Very long Issue filter
    filters: is:open very very very very very very very very very very very very very very very very very long review:required sort:created-asc
 ```

I tested the changes with both focusing on the search and without. Seems to work as expected.

## Video
### Before

https://github.com/user-attachments/assets/bce99238-8fa1-4e6b-a10b-f792e402cd1a

### After
https://github.com/user-attachments/assets/c2ebbd07-a349-45c7-9e22-0ea248462b57