### PR TITLE
docs: fix ready for review shortcut W instead of w

### DIFF
--- a/docs/content/getting-started/keybindings/selected-pr.md
+++ b/docs/content/getting-started/keybindings/selected-pr.md
@@ -95,9 +95,9 @@ merge the PR.
 merges the PR only after you approve the action.
 ```
 
-## `w` - Mark PR as Ready for Review { #mark-pr-as-ready-for-review}
+## `W` - Mark PR as Ready for Review { #mark-pr-as-ready-for-review}
 
-Press ![kbd:`w`]() to mark the PR as ready for review. When you do, the dashboard uses the
+Press ![kbd:`W`]() to mark the PR as ready for review. When you do, the dashboard uses the
 `gh pr ready` command to convert the PR from draft status to ready for review.
 
 ## `x` - Close PR { #close-pr }


### PR DESCRIPTION
# Summary

The docs were incorrectly mapping `w` as the Ready for review shortcut. The correct one is `W` (uppercase).

## How did you test this change?

Haven't succeed yet to build the docs locally, should we update to the latest Hugo version? And also the `CONTRIBUTING.md` on how to build the docs.