### PR TITLE
docs: bump hugo and add instruction on how to run docs server locally

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.111.3
+      HUGO_VERSION: 0.120.4
     steps:
       - name: Install Hugo CLI
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,15 @@ import "log"
 log.Printf("Some message with a variable %v\n", someVariable)
 ```
 
+### Running the docs locally
+
+- Check the current Hugo version in the [workflow file](./.github/workflows/hugo.yaml)
+- Install correct Hugo Extended version using the [official installation guide](https://gohugo.io/getting-started/installing/)
+- Check the Hugo version using `hugo version`
+- Go to the `docs/` directory using `cd docs`
+- Install the Hugo mods using `hugo mod get`
+- Run the Hugo server using `hugo server`
+
 ### Your PR is merged!
 
 Congratulations :tada::tada:

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -3,6 +3,6 @@ module github.com/dlvhdr/gh-dash/docs
 go 1.19
 
 require (
-	github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196 // indirect
-	github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196 // indirect
+	github.com/platenio/platen/modules/platen v0.0.0-20231124141037-5a875309774c // indirect
+	github.com/platenio/platen/modules/schematize v0.0.0-20231124141037-5a875309774c // indirect
 )

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -8,6 +8,8 @@ github.com/platenio/platen/modules/platen v0.0.0-20230530030614-0a5bf77211cc h1:
 github.com/platenio/platen/modules/platen v0.0.0-20230530030614-0a5bf77211cc/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196 h1:rSOUejTdKH6VGNCMFn2ti9MhGOcFj+PvnDuYibJoakk=
 github.com/platenio/platen/modules/platen v0.0.0-20230614143927-dd048e2da196/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
+github.com/platenio/platen/modules/platen v0.0.0-20231124141037-5a875309774c h1:ftQLeFf3erlZrGq/3RGkwglSBT/sq9Xz8tYfi14LQdM=
+github.com/platenio/platen/modules/platen v0.0.0-20231124141037-5a875309774c/go.mod h1:7pfizXCKb4vonp6Og/3zkoy09YYsHip9/hXiT/pc3IM=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d h1:PhpSZzd1YFHCZzsJJinIHoMU3Bw/w/GPYkWXz/flnvU=
 github.com/platenio/platen/modules/schematize v0.0.0-20230417130935-f8a3fca1013d/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
 github.com/platenio/platen/modules/schematize v0.0.0-20230504053552-c70b34ba1161 h1:t0wxjK59xg5ggSEpWEZHtooO0COoV5oC/WFIPcJLhRM=
@@ -18,3 +20,5 @@ github.com/platenio/platen/modules/schematize v0.0.0-20230530030614-0a5bf77211cc
 github.com/platenio/platen/modules/schematize v0.0.0-20230530030614-0a5bf77211cc/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
 github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196 h1:p4GUmZTuMEdDkhLG8V7Eo+YY8DVWR4h872Ohd1HqPRI=
 github.com/platenio/platen/modules/schematize v0.0.0-20230614143927-dd048e2da196/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=
+github.com/platenio/platen/modules/schematize v0.0.0-20231124141037-5a875309774c h1:07Pq498bWcMqztKpHoo/fhst9QQeM/Qza6dySzhc9kU=
+github.com/platenio/platen/modules/schematize v0.0.0-20231124141037-5a875309774c/go.mod h1:0u7RXHeXIfNq9mAGzEu5T0UxdAa9D54y+ucI8oivs5M=


### PR DESCRIPTION
# Summary

While working on #471 I had some difficulties running the docs server due to an old version of Hugo.
I this PR I bumped it to the latest compatible version with platen ([commit](https://github.com/platenio/platen/pull/102/commits/a0d17cff85da2e97ed0df8fb9484a1a6b98bc4d9)). This version issue was noticeable in the CI logs ([here](https://github.com/dlvhdr/gh-dash/actions/workflows/hugo.yaml)).

## How did you test this change?

It works on my machine™

## Images/Videos
<img width="727" alt="image" src="https://github.com/user-attachments/assets/6113ea17-81aa-4937-a4d6-b0cb7307d5e6">

