### PR TITLE
ci: bump actions to latest versions

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -44,14 +44,14 @@ jobs:
         run: sudo snap install dart-sass-embedded
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
@@ -73,7 +73,7 @@ jobs:
         working-directory: ./docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/public
 
@@ -82,10 +82,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Summary

In CI there was a lot of deprecation warnings, a bump for each of the deprecated actions should fix it for now.

TLDR of the major bumps
- [actions/checkout](https://github.com/actions/checkout/releases/tag/v4.0.0): Node 20
- [actions/configure-pages](https://github.com/actions/configure-pages/releases): Node 20 and Next.js relating things
- [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact/releases): New Github Artifacts API
- [actions/deploy-pages](https://github.com/actions/deploy-pages/releases): Uses  `actions/upload-pages-artifact` v3 or newer

With the new Github Artifacts API, the page URL is not needed anymore and retrieved through the Artifact id.

## How did you test this change?

Tested it on my fork [here](https://github.com/alcpereira/gh-dash/actions/runs/11714252937)