### PR TITLE
Fix nil pointer deref introduced in 4.6.0 by introducing guard around potentially `nil` currSection

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -546,7 +546,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case execProcessFinishedMsg, tea.FocusMsg:
-		cmds = append(cmds, currSection.FetchNextPageSectionRows()...)
+		if currSection != nil {
+			cmds = append(cmds, currSection.FetchNextPageSectionRows()...)
+		}
 
 	case tea.WindowSizeMsg:
 		m.onWindowSizeChanged(msg)


### PR DESCRIPTION
This addresses #475

# Summary

I get a runtime error: invalid memory address or nil pointer dereference on launching gh dash when the version is >= 4.6.0.

## How did you test this change?

1. `gh extension install dlvhdr/gh-dash`
2. `gh dash` 
3. See stack trace in #475
4. Remove extension
5. `gh extension install dlvhdr/gh-dash --pin v4.5.4`
6. `gh dash`
7. No crash
8. Remove extension
9. `gh extension install dlvhdr/gh-dash --pin v4.6.0`
10. Crash with stack trace equivalent to the one in #475 
11. `git clone` gh-dash
12. Apply this change
13. `go build` && `go install .`
14. `gh dash`
15. No crash ✅ 

## Images/Videos

![ezgif-5-74bd6d56f9](https://github.com/user-attachments/assets/bd98425e-a020-4798-bd49-2268c46631f0)


