### PR TITLE
feat: add android arm64 build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,8 +29,8 @@ builds:
       - arm
       - "386"
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
     ldflags:
       - -s -w
       - -X github.com/dlvhdr/gh-dash/cmd.Version={{.Version}}
@@ -53,7 +53,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
     flags:
       - -tags=nodbus
     goos:
+      - android
       - freebsd
       - linux
       - windows
@@ -36,6 +37,15 @@ builds:
       - -X github.com/dlvhdr/gh-dash/cmd.Commit={{.Commit}}
       - -X github.com/dlvhdr/gh-dash/cmd.Date={{.CommitDate}}
       - -X github.com/dlvhdr/gh-dash/cmd.BuiltBy=goreleaser
+    # Skipping builds for Android non-ARM64 architectures as they need CGO enabled
+    # https://goreleaser.com/limitations/cgo/
+    ignore:
+      - goos: android
+        goarch: "386"
+      - goos: android
+        goarch: amd64
+      - goos: android
+        goarch: arm
 
 archives:
   - format: binary


### PR DESCRIPTION
# Summary

Should fix #249, #304 and #468  🤞 

I also added in this PR two small fixes:
- YAML formatting due to the `schema.json` was complaining about `goarm` being a list of integer and not strings
- A deprecation notice regarding [snapshot.name_template](https://goreleaser.com/deprecations/#snapshotname_template)

<img width="424" alt="image" src="https://github.com/user-attachments/assets/b4be8404-6d75-43c6-8574-5d58f1d821ed">


## How did you test this change?

I cannot properly test it due to my OS/Arch, but feel free to do a pre-release and ask for feedback in those issues.

Build seems to work fine on my machine:
```
> goreleaser release --snapshot --clean
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=cbe0aef1d6c8bc8c331d8f6b4d8df554931a876d branch=feat/support-android-arm current_tag=v4.7.1 previous_tag=v4.7.0 dirty=true
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=4.7.2-next
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • checking go.mod
  • building binaries
    • building                                       binary=dist/gh-dash_linux_arm_7/gh-dash
    • building                                       binary=dist/gh-dash_freebsd_arm_7/gh-dash
    • building                                       binary=dist/gh-dash_freebsd_amd64_v1/gh-dash
    • building                                       binary=dist/gh-dash_freebsd_arm64_v8.0/gh-dash
    • building                                       binary=dist/gh-dash_freebsd_arm_6/gh-dash
    • building                                       binary=dist/gh-dash_android_arm64_v8.0/gh-dash
    • building                                       binary=dist/gh-dash_linux_arm_6/gh-dash
    • building                                       binary=dist/gh-dash_linux_arm64_v8.0/gh-dash
    • building                                       binary=dist/gh-dash_freebsd_386_sse2/gh-dash
    • building                                       binary=dist/gh-dash_linux_amd64_v1/gh-dash
    • building                                       binary=dist/gh-dash_linux_386_sse2/gh-dash
    • building                                       binary=dist/gh-dash_windows_amd64_v1/gh-dash.exe
    • building                                       binary=dist/gh-dash_windows_arm64_v8.0/gh-dash.exe
    • building                                       binary=dist/gh-dash_windows_arm_6/gh-dash.exe
    • building                                       binary=dist/gh-dash_windows_arm_7/gh-dash.exe
    • building                                       binary=dist/gh-dash_windows_386_sse2/gh-dash.exe
    • building                                       binary=dist/gh-dash_darwin_amd64_v1/gh-dash
    • building                                       binary=dist/gh-dash_darwin_arm64_v8.0/gh-dash
  • archives
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_freebsd-arm_6
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_linux-arm_6
    • skip archiving                                 binary=gh-dash.exe name=gh-dash_v4.7.1_windows-386.exe
    • skip archiving                                 binary=gh-dash.exe name=gh-dash_v4.7.1_windows-arm_6.exe
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_darwin-amd64
    • skip archiving                                 binary=gh-dash.exe name=gh-dash_v4.7.1_windows-arm_7.exe
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_freebsd-arm64
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_linux-arm_7
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_linux-amd64
    • skip archiving                                 binary=gh-dash.exe name=gh-dash_v4.7.1_windows-arm64.exe
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_android-arm64
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_freebsd-386
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_linux-arm64
    • skip archiving                                 binary=gh-dash.exe name=gh-dash_v4.7.1_windows-amd64.exe
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_freebsd-amd64
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_freebsd-arm_7
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_linux-386
    • skip archiving                                 binary=gh-dash name=gh-dash_v4.7.1_darwin-arm64
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 10s
  • thanks for using goreleaser!
```