### PR TITLE
docs: consistent formatting in builtin description

### DIFF
--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -72,11 +72,11 @@ var PRKeys = PRKeyMap{
 	),
 	WatchChecks: key.NewBinding(
 		key.WithKeys("w"),
-		key.WithHelp("w", "Watch checks"),
+		key.WithHelp("w", "watch checks"),
 	),
 	ViewIssues: key.NewBinding(
 		key.WithKeys("s"),
-		key.WithHelp("s", "Switch to issues"),
+		key.WithHelp("s", "switch to issues"),
 	),
 }
 


### PR DESCRIPTION
# Summary

While working on the docs of some undocumented features/shortcuts, I noticed that the `?` command helper has some inconsistencies with two of the commands.

I updated the 2 commands descriptions that used capital letters to be all lower case like the other descriptions.

## How did you test this change?

Tested it locally

## Images/Videos

<img width="331" alt="image" src="https://github.com/user-attachments/assets/55d442f8-664c-4179-b219-8432ad4f1232">

