### PR TITLE
Support multiple keys for key bindings

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -111,7 +111,7 @@ type RepoConfig struct {
 }
 
 type Keybinding struct {
-	Key     string `yaml:"key"`
+	Key     []string `yaml:"key"`
 	Command string `yaml:"command"`
 	Builtin string `yaml:"builtin"`
 }
@@ -122,10 +122,9 @@ func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
 		helpDesc = previous.Help().Desc
 	}
 
-	keys := strings.Split(kb.Key, "/")
 	return key.NewBinding(
-		key.WithKeys(keys...),
-		key.WithHelp(kb.Key, helpDesc),
+		key.WithKeys(kb.Key...),
+		key.WithHelp(strings.Join(kb.Key, "/"), helpDesc),
 	)
 }
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -122,8 +122,9 @@ func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
 		helpDesc = previous.Help().Desc
 	}
 
+    	keys := strings.Split(kb.Key, "/")
 	return key.NewBinding(
-		key.WithKeys(kb.Key),
+		key.WithKeys(keys...),
 		key.WithHelp(kb.Key, helpDesc),
 	)
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -122,7 +122,7 @@ func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
 		helpDesc = previous.Help().Desc
 	}
 
-    	keys := strings.Split(kb.Key, "/")
+	keys := strings.Split(kb.Key, "/")
 	return key.NewBinding(
 		key.WithKeys(keys...),
 		key.WithHelp(kb.Key, helpDesc),

--- a/config/parser.go
+++ b/config/parser.go
@@ -28,6 +28,8 @@ var validate *validator.Validate
 
 type ViewType string
 
+type KeyList []string
+
 const (
 	PRsView    ViewType = "prs"
 	IssuesView ViewType = "issues"
@@ -111,7 +113,7 @@ type RepoConfig struct {
 }
 
 type Keybinding struct {
-	Key     []string `yaml:"key"`
+	Key     KeyList `yaml:"key"`
 	Command string `yaml:"command"`
 	Builtin string `yaml:"builtin"`
 }
@@ -485,4 +487,23 @@ func ParseConfig(path string, repoPath *string) (Config, error) {
 	}
 
 	return config, nil
+}
+
+func (kl *KeyList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Try unmarshaling into a []string first
+	var list []string
+	if err := unmarshal(&list); err == nil {
+		*kl = list
+		return nil
+	}
+
+	// If that fails, try unmarshaling into a single string
+	var single string
+	if err := unmarshal(&single); err == nil {
+		*kl = []string{single}
+		return nil
+	}
+
+	// If both attempts fail, return an error
+	return fmt.Errorf("key must be either a string or a list of strings")
 }


### PR DESCRIPTION
# Summary

Adds support for multiple keys for key bindings by allowing specifying a list or a string

Fixes: https://github.com/dlvhdr/gh-dash/issues/504

## How did you test this change?

I have not tested. I am not a go programmer so this is just an implementation suggestion to maybe make it easier for whoever is more familiar with this than me.