### PR TITLE
fix: stop compiling static regex in hot path, compile once globally

### DIFF
--- a/ui/components/issuesidebar/activity.go
+++ b/ui/components/issuesidebar/activity.go
@@ -1,7 +1,6 @@
 package issuesidebar
 
 import (
-	"regexp"
 	"sort"
 	"time"
 
@@ -71,8 +70,7 @@ func (m *Model) renderComment(comment data.IssueComment, markdownRenderer glamou
 		lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render(utils.TimeElapsed(comment.UpdatedAt)),
 	)
 
-	regex := regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
-	body := regex.ReplaceAllString(comment.Body, "")
+	body := lineCleanupRegex.ReplaceAllString(comment.Body, "")
 	body, err := markdownRenderer.Render(body)
 
 	return lipgloss.JoinVertical(

--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -17,6 +17,11 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/ui/markdown"
 )
 
+var (
+	htmlCommentRegex = regexp.MustCompile("(?U)<!--(.|[[:space:]])*-->")
+	lineCleanupRegex = regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
+)
+
 type Model struct {
 	ctx       *context.ProgramContext
 	issue     *issue.Issue
@@ -179,11 +184,9 @@ func (m *Model) renderStatusPill() string {
 
 func (m *Model) renderBody() string {
 	width := m.getIndentedContentWidth()
-	regex := regexp.MustCompile("(?U)<!--(.|[[:space:]])*-->")
-	body := regex.ReplaceAllString(m.issue.Data.Body, "")
-
-	regex = regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
-	body = regex.ReplaceAllString(body, "")
+	// Strip HTML comments from body and cleanup body.
+	body := htmlCommentRegex.ReplaceAllString(m.issue.Data.Body, "")
+	body = lineCleanupRegex.ReplaceAllString(body, "")
 
 	body = strings.TrimSpace(body)
 	if body == "" {

--- a/ui/components/prsidebar/activity.go
+++ b/ui/components/prsidebar/activity.go
@@ -2,7 +2,6 @@ package prsidebar
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"time"
 
@@ -134,8 +133,7 @@ func (m *Model) renderComment(comment comment, markdownRenderer glamour.TermRend
 		header = authorAndTime
 	}
 
-	regex := regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
-	body := regex.ReplaceAllString(comment.Body, "")
+	body := lineCleanupRegex.ReplaceAllString(comment.Body, "")
 	body, err := markdownRenderer.Render(body)
 
 	return lipgloss.JoinVertical(

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -17,6 +17,11 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/ui/markdown"
 )
 
+var (
+	htmlCommentRegex = regexp.MustCompile("(?U)<!--(.|[[:space:]])*-->")
+	lineCleanupRegex = regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
+)
+
 type Model struct {
 	ctx       *context.ProgramContext
 	sectionId int
@@ -288,11 +293,9 @@ func (m *Model) renderLabels() string {
 
 func (m *Model) renderDescription() string {
 	width := m.getIndentedContentWidth()
-	regex := regexp.MustCompile("(?U)<!--(.|[[:space:]])*-->")
-	body := regex.ReplaceAllString(m.pr.Data.Body, "")
-
-	regex = regexp.MustCompile(`((\n)+|^)([^\r\n]*\|[^\r\n]*(\n)?)+`)
-	body = regex.ReplaceAllString(body, "")
+	// Strip HTML comments from body and cleanup body.
+	body := htmlCommentRegex.ReplaceAllString(m.pr.Data.Body, "")
+	body = lineCleanupRegex.ReplaceAllString(body, "")
 
 	body = strings.TrimSpace(body)
 	if body == "" {


### PR DESCRIPTION
Previously, these static regexs were being compiled each time the
function is called. The regexs are static, so there's no need to
re-compile them everytime; instead, compile them once globally per
package, and then re-use them when needed. This
reduces the number of allocations made over the life span of the
program; resulting in less active memory use in general, as well as less
garbage collection. Local profiling with parca and a shimmed in pprof
web server show me approx ~20% less in use memory, going from `~8-10MB`
-> `~6-8MB` after changes.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
