### PR TITLE
feat: Print full URL to PRs and issues

### DIFF
--- a/ui/components/issuesidebar/issuesidebar.go
+++ b/ui/components/issuesidebar/issuesidebar.go
@@ -131,6 +131,8 @@ func (m Model) View() string {
 
 	s.WriteString(m.renderFullNameAndNumber())
 	s.WriteString("\n")
+	s.WriteString(m.renderUrl())
+	s.WriteString("\n")
 
 	s.WriteString(m.renderTitle())
 	s.WriteString("\n\n")
@@ -158,6 +160,12 @@ func (m *Model) renderFullNameAndNumber() string {
 	return lipgloss.NewStyle().
 		Foreground(m.ctx.Theme.SecondaryText).
 		Render(fmt.Sprintf("#%d · %s", m.issue.Data.GetNumber(), m.issue.Data.GetRepoNameWithOwner()))
+}
+
+func (m *Model) renderUrl() string {
+	return lipgloss.NewStyle().
+		Foreground(m.ctx.Theme.SecondaryText).
+		Render(m.issue.Data.GetUrl())
 }
 
 func (m *Model) renderTitle() string {

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -154,6 +154,8 @@ func (m Model) View() string {
 
 	s.WriteString(m.renderFullNameAndNumber())
 	s.WriteString("\n")
+	s.WriteString(m.renderUrl())
+	s.WriteString("\n")
 
 	s.WriteString(m.renderTitle())
 	s.WriteString("\n")
@@ -186,6 +188,12 @@ func (m *Model) renderFullNameAndNumber() string {
 	return lipgloss.NewStyle().
 		Foreground(m.ctx.Theme.SecondaryText).
 		Render(fmt.Sprintf("#%d · %s", m.pr.Data.GetNumber(), m.pr.Data.GetRepoNameWithOwner()))
+}
+
+func (m *Model) renderUrl() string {
+	return lipgloss.NewStyle().
+		Foreground(m.ctx.Theme.SecondaryText).
+		Render(m.pr.Data.GetUrl())
 }
 
 func (m *Model) renderTitle() string {


### PR DESCRIPTION
# Summary
gh-dash already offers copying the URL ('Y') and opening the PR/issue in GitHub ('o'). When working with dash via an SSH session, none of those shortcuts work.

Improve usability by printing the full URL, making it easy to copy and/or click the link in such cases.

## How did you test this change?
Using dash in the gh-dash repository and navigating through issues/PRs.

## Images/Videos
Issue: 
![image](https://github.com/user-attachments/assets/326f5a62-5dfa-482b-8fbf-35057224935c)

PR:
![image](https://github.com/user-attachments/assets/3440d066-efae-4b14-aade-ae914c6d18eb)

