### PR TITLE
feat: smart filtering of PRs/issues to remote tracked by current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Check out this 10/10 video by [charm.sh ✨](https://charm.sh) explaining how gh
 - 🔭 view details about a pr/issue with a detailed sidebar
 - 🪟 write multiple configuration files to easily switch between completely different dashboards
 - ♻️ set an interval for auto refreshing the dashboard
+- 📁 smart filtering - auto-filter pr/issue lists to the remote tracked by the current directory
 
 ## 📦 Installation
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -82,16 +82,16 @@ type PrsLayoutConfig struct {
 }
 
 type IssuesLayoutConfig struct {
-	UpdatedAt     ColumnConfig `yaml:"updatedAt,omitempty"`
-	CreatedAt     ColumnConfig `yaml:"createdAt,omitempty"`
-	State         ColumnConfig `yaml:"state,omitempty"`
-	Repo          ColumnConfig `yaml:"repo,omitempty"`
-	Title         ColumnConfig `yaml:"title,omitempty"`
-	Creator       ColumnConfig `yaml:"creator,omitempty"`
-	CreatorIcon   ColumnConfig `yaml:"creatorIcon,omitempty"`
-	Assignees     ColumnConfig `yaml:"assignees,omitempty"`
-	Comments      ColumnConfig `yaml:"comments,omitempty"`
-	Reactions     ColumnConfig `yaml:"reactions,omitempty"`
+	UpdatedAt   ColumnConfig `yaml:"updatedAt,omitempty"`
+	CreatedAt   ColumnConfig `yaml:"createdAt,omitempty"`
+	State       ColumnConfig `yaml:"state,omitempty"`
+	Repo        ColumnConfig `yaml:"repo,omitempty"`
+	Title       ColumnConfig `yaml:"title,omitempty"`
+	Creator     ColumnConfig `yaml:"creator,omitempty"`
+	CreatorIcon ColumnConfig `yaml:"creatorIcon,omitempty"`
+	Assignees   ColumnConfig `yaml:"assignees,omitempty"`
+	Comments    ColumnConfig `yaml:"comments,omitempty"`
+	Reactions   ColumnConfig `yaml:"reactions,omitempty"`
 }
 
 type LayoutConfig struct {
@@ -215,16 +215,17 @@ type ThemeConfig struct {
 }
 
 type Config struct {
-	PRSections      []PrsSectionConfig    `yaml:"prSections"`
-	IssuesSections  []IssuesSectionConfig `yaml:"issuesSections"`
-	Repo            RepoConfig            `yaml:"repo"`
-	Defaults        Defaults              `yaml:"defaults"`
-	Keybindings     Keybindings           `yaml:"keybindings"`
-	RepoPaths       map[string]string     `yaml:"repoPaths"`
-	Theme           *ThemeConfig          `yaml:"theme,omitempty" validate:"omitempty"`
-	Pager           Pager                 `yaml:"pager"`
-	ConfirmQuit     bool                  `yaml:"confirmQuit"`
-	ShowAuthorIcons bool                  `yaml:"showAuthorIcons"`
+	PRSections             []PrsSectionConfig    `yaml:"prSections"`
+	IssuesSections         []IssuesSectionConfig `yaml:"issuesSections"`
+	Repo                   RepoConfig            `yaml:"repo"`
+	Defaults               Defaults              `yaml:"defaults"`
+	Keybindings            Keybindings           `yaml:"keybindings"`
+	RepoPaths              map[string]string     `yaml:"repoPaths"`
+	Theme                  *ThemeConfig          `yaml:"theme,omitempty" validate:"omitempty"`
+	Pager                  Pager                 `yaml:"pager"`
+	ConfirmQuit            bool                  `yaml:"confirmQuit"`
+	ShowAuthorIcons        bool                  `yaml:"showAuthorIcons"`
+	SmartFilteringAtLaunch bool                  `yaml:"smartFilteringAtLaunch" default:"true"`
 }
 
 type configError struct {
@@ -345,8 +346,9 @@ func (parser ConfigParser) getDefaultConfig() Config {
 				},
 			},
 		},
-		ConfirmQuit: false,
-		ShowAuthorIcons: true,
+		ConfirmQuit:            false,
+		ShowAuthorIcons:        true,
+		SmartFilteringAtLaunch: true,
 	}
 }
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -23,6 +23,7 @@ and **issues** by filters you care about.
 - ![icon:layout-dashboard](lucide)&nbsp;write multiple configuration files to easily switch between
   completely different dashboards
 - ![icon:recycle](lucide)&nbsp;set an interval for auto refreshing the dashboard
+- ![icon:folder-git](lucide)&nbsp;[smart filtering](/getting-started/smartfiltering) - auto-filter prs/issues to the remote tracked by the current directory
 
 <!-- Link reference definitions -->
 [shield-release]: https://img.shields.io/github/release/dlvhdr/gh-dash.svg

--- a/docs/content/getting-started/smartfiltering.md
+++ b/docs/content/getting-started/smartfiltering.md
@@ -1,0 +1,37 @@
+---
+title: About Smart Filtering
+linkTitle: >-
+  ![icon:folder-git](lucide)&nbsp;About Smart Filtering
+summary: >-
+  About the Smart Filtering feature
+weight: 3
+---
+
+By default, if the directory you launch `gh-dash` from is a clone of a remote GitHub repo (or if you
+have the `GH_REPO` environment variable set to a particular remote), then for any of your PR
+sections and issue sections with `filters` values in your [configuration](/configuration) that don’t
+have an explicit `repo:` field, `gh-dash` adds a `repo:<RepoName>` field to the search-bar value for
+them (where _`<RepoName>`_ is the name of the remote repo).
+
+That is, `gh-dash` further filters those sections down to only the PRs/issues for the GitHub
+repo name specified in your `GH_REPO` environment variable — or else the repo name of the remote
+tracked by the clone directory from which `gh-dash` launched.
+
+For that, `gh-dash` first checks and uses the repo name in the `GH_REPO` environment variable (if
+you have that set). If `gh-dash` doesn’t find that, then it next checks for the value of the remote
+repo name tracked by the clone directory from which you launched `gh-dash` — by looking through all
+GitHub remotes configured for that clone in the following order:
+
+1. `upstream`
+2. `github`
+3. `origin`
+
+…and, otherwise, if `gh-dash` finds no remotes with any of those names, then it uses the repo name
+for the first remote in the output that `git remote` shows.
+
+To disable Smart Filtering at launch, set [`smartFilteringAtLaunch`](/configuration/gh-dash/#smartfilteringatlaunch)
+to `false` in your [configuration](/configuration).
+
+To toggle Smart Filtering on or off for the current section you’re currently viewing, either use the
+`t` key — or else use whatever custom keybinding you have set for the `togglesearch` builtin in the
+`keybindings` section of your [configuration](/configuration).

--- a/docs/data/schemas/gh-dash.yaml
+++ b/docs/data/schemas/gh-dash.yaml
@@ -250,3 +250,10 @@ properties:
     type: boolean
     schematize:
       weight: 8
+  smartFilteringAtLaunch:
+    title: Smart Filtering At Launch
+    description: |
+      Set this to `false` to disable [Smart Filtering](/getting-started/smartfiltering) at `gh-dash` launch.
+    type: boolean
+    schematize:
+      weight: 8

--- a/ui/common/styles.go
+++ b/ui/common/styles.go
@@ -10,7 +10,7 @@ import (
 var (
 	SearchHeight       = 3
 	FooterHeight       = 1
-	ExpandedHelpHeight = 14
+	ExpandedHelpHeight = 15
 	InputBoxHeight     = 8
 	SingleRuneWidth    = 4
 	MainContentPadding = 1

--- a/ui/components/issuessection/issuessection.go
+++ b/ui/components/issuessection/issuessection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/dlvhdr/gh-dash/v4/config"
@@ -13,6 +14,7 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/ui/components/table"
 	"github.com/dlvhdr/gh-dash/v4/ui/constants"
 	"github.com/dlvhdr/gh-dash/v4/ui/context"
+	"github.com/dlvhdr/gh-dash/v4/ui/keys"
 	"github.com/dlvhdr/gh-dash/v4/utils"
 )
 
@@ -101,6 +103,23 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				return &m, tea.Batch(cmd, blinkCmd)
 			}
 			break
+		}
+
+		switch {
+
+		case key.Matches(msg, keys.IssueKeys.ToggleSmartFiltering):
+			if !m.HasRepoNameInConfiguredFilter() {
+				m.IsFilteredByCurrentRemote = !m.IsFilteredByCurrentRemote
+			}
+			searchValue := m.GetSearchValue()
+			if m.SearchValue != searchValue {
+				m.SearchValue = searchValue
+				m.SearchBar.SetValue(searchValue)
+				m.SetIsSearching(false)
+				m.ResetRows()
+				return &m, tea.Batch(m.FetchNextPageSectionRows()...)
+			}
+
 		}
 
 	case UpdateIssueMsg:

--- a/ui/components/prssection/prssection.go
+++ b/ui/components/prssection/prssection.go
@@ -120,6 +120,19 @@ func (m Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 		case key.Matches(msg, keys.PRKeys.Diff):
 			cmd = m.diff()
 
+		case key.Matches(msg, keys.PRKeys.ToggleSmartFiltering):
+			if !m.HasRepoNameInConfiguredFilter() {
+				m.IsFilteredByCurrentRemote = !m.IsFilteredByCurrentRemote
+			}
+			searchValue := m.GetSearchValue()
+			if m.SearchValue != searchValue {
+				m.SearchValue = searchValue
+				m.SearchBar.SetValue(searchValue)
+				m.SetIsSearching(false)
+				m.ResetRows()
+				return &m, tea.Batch(m.FetchNextPageSectionRows()...)
+			}
+
 		case key.Matches(msg, keys.PRKeys.Checkout):
 			cmd, err = m.checkout()
 			if err != nil {

--- a/ui/keys/issueKeys.go
+++ b/ui/keys/issueKeys.go
@@ -10,12 +10,13 @@ import (
 )
 
 type IssueKeyMap struct {
-	Assign   key.Binding
-	Unassign key.Binding
-	Comment  key.Binding
-	Close    key.Binding
-	Reopen   key.Binding
-	ViewPRs  key.Binding
+	Assign               key.Binding
+	Unassign             key.Binding
+	Comment              key.Binding
+	Close                key.Binding
+	Reopen               key.Binding
+	ToggleSmartFiltering key.Binding
+	ViewPRs              key.Binding
 }
 
 var IssueKeys = IssueKeyMap{
@@ -39,6 +40,10 @@ var IssueKeys = IssueKeyMap{
 		key.WithKeys("X"),
 		key.WithHelp("X", "reopen"),
 	),
+	ToggleSmartFiltering: key.NewBinding(
+		key.WithKeys("t"),
+		key.WithHelp("t", "toggle smart filtering"),
+	),
 	ViewPRs: key.NewBinding(
 		key.WithKeys("s"),
 		key.WithHelp("s", "switch to PRs"),
@@ -52,6 +57,7 @@ func IssueFullHelp() []key.Binding {
 		IssueKeys.Comment,
 		IssueKeys.Close,
 		IssueKeys.Reopen,
+		IssueKeys.ToggleSmartFiltering,
 		IssueKeys.ViewPRs,
 	}
 }

--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -10,19 +10,20 @@ import (
 )
 
 type PRKeyMap struct {
-	Approve     key.Binding
-	Assign      key.Binding
-	Unassign    key.Binding
-	Comment     key.Binding
-	Diff        key.Binding
-	Checkout    key.Binding
-	Close       key.Binding
-	Ready       key.Binding
-	Reopen      key.Binding
-	Merge       key.Binding
-	Update      key.Binding
-	WatchChecks key.Binding
-	ViewIssues  key.Binding
+	Approve              key.Binding
+	Assign               key.Binding
+	Unassign             key.Binding
+	Comment              key.Binding
+	Diff                 key.Binding
+	Checkout             key.Binding
+	Close                key.Binding
+	Ready                key.Binding
+	Reopen               key.Binding
+	Merge                key.Binding
+	Update               key.Binding
+	WatchChecks          key.Binding
+	ToggleSmartFiltering key.Binding
+	ViewIssues           key.Binding
 }
 
 var PRKeys = PRKeyMap{
@@ -74,6 +75,10 @@ var PRKeys = PRKeyMap{
 		key.WithKeys("w"),
 		key.WithHelp("w", "watch checks"),
 	),
+	ToggleSmartFiltering: key.NewBinding(
+		key.WithKeys("t"),
+		key.WithHelp("t", "toggle smart filtering"),
+	),
 	ViewIssues: key.NewBinding(
 		key.WithKeys("s"),
 		key.WithHelp("s", "switch to issues"),
@@ -94,6 +99,7 @@ func PRFullHelp() []key.Binding {
 		PRKeys.Merge,
 		PRKeys.Update,
 		PRKeys.WatchChecks,
+		PRKeys.ToggleSmartFiltering,
 		PRKeys.ViewIssues,
 	}
 }


### PR DESCRIPTION
# Summary

If the current directory from which you launched `gh-dash` is a clone of a GitHub repo, this change causes your PR/issue sections to be further “smartly” auto-filtered down to only the PRs/issues for the remote repo tracked by the clone directory from which you launched `gh-dash`.

Implements what’s proposed in https://github.com/dlvhdr/gh-dash/discussions/309.

## Details

In more detail, here’s how it works:

By default, if the directory you launch `gh-dash` from is a clone of a remote GitHub repo (or if you have the `GH_REPO` environment variable set to a particular remote), then for any of your PR sections and issue sections with `filters` values in your configuration that don’t have an explicit `repo:` field, `gh-dash` adds a `repo:<RepoName>` field to the search-bar value for them (where _`<RepoName>`_ is the name of the remote repo).

That is, `gh-dash` further filters those sections down to only the PRs/issues for the GitHub repo name in your `GH_REPO` environment variable — or else the repo name of the remote tracked by the clone directory from which `gh-dash` launched.

For that, `gh-dash` first checks and uses the repo name in the `GH_REPO` environment variable (if you have that set). If `gh-dash` doesn’t find that, then it next checks for the value of the remote repo name tracked by the clone directory from which you launched `gh-dash` — by looking through all GitHub remotes configured for that clone in the following order:

1. `upstream`
2. `github`
3. `origin`

…and, otherwise, if `gh-dash` finds no remotes with any of those names, then it uses the repo name for the first remote in the output that `git remote` shows.

To disable Smart Filtering at launch, set `smartFilteringAtLaunch` to `false` in your configuration.

To toggle Smart Filtering on or off for the current section you’re currently viewing, either use the `t` key — or else use whatever custom keybinding you have set for the `togglesearch` builtin in the `keybindings` section of your configuration.

## How did you test this change?

_[I’ll update this PR description later, to add the test steps]_
