### PR TITLE
feat: show custom keybindings in the help menu

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -119,12 +119,17 @@ type Keybinding struct {
 	Key     string `yaml:"key"`
 	Command string `yaml:"command"`
 	Builtin string `yaml:"builtin"`
+	Name    string `yaml:"name,omitempty"`
 }
 
 func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
 	helpDesc := ""
 	if previous != nil {
 		helpDesc = previous.Help().Desc
+	}
+
+	if kb.Name != "" {
+		helpDesc = kb.Name
 	}
 
 	return key.NewBinding(

--- a/config/utils.go
+++ b/config/utils.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 func (cfg Config) GetFullScreenDiffPagerEnv() []string {
@@ -53,4 +54,12 @@ func MergeColumnConfigs(defaultCfg, sectionCfg ColumnConfig) ColumnConfig {
 		colCfg.Hidden = sectionCfg.Hidden
 	}
 	return colCfg
+}
+
+func TruncateCommand(cmd string) string {
+	cmd = strings.ReplaceAll(cmd, "\n", "")
+	if len(cmd) > 30 {
+		return cmd[:30] + "..."
+	}
+	return cmd
 }

--- a/ui/common/styles.go
+++ b/ui/common/styles.go
@@ -10,7 +10,7 @@ import (
 var (
 	SearchHeight       = 3
 	FooterHeight       = 1
-	ExpandedHelpHeight = 15
+	ExpandedHelpHeight = 17
 	InputBoxHeight     = 8
 	SingleRuneWidth    = 4
 	MainContentPadding = 1

--- a/ui/keys/branchKeys.go
+++ b/ui/keys/branchKeys.go
@@ -82,9 +82,9 @@ func rebindBranchKeys(keys []config.Keybinding) error {
 		if branchKey.Builtin == "" {
 			// Handle custom commands
 			if branchKey.Command != "" {
-				name := branchKey.Command
-				if branchKey.Name != "" {
-					name = branchKey.Name
+				name := branchKey.Name
+				if branchKey.Name == "" {
+					name = config.TruncateCommand(branchKey.Command)
 				}
 
 				customBinding := key.NewBinding(

--- a/ui/keys/branchKeys.go
+++ b/ui/keys/branchKeys.go
@@ -75,8 +75,25 @@ func BranchFullHelp() []key.Binding {
 }
 
 func rebindBranchKeys(keys []config.Keybinding) error {
+	CustomBranchBindings = []key.Binding{}
+
 	for _, branchKey := range keys {
+
 		if branchKey.Builtin == "" {
+			// Handle custom commands
+			if branchKey.Command != "" {
+				name := branchKey.Command
+				if branchKey.Name != "" {
+					name = branchKey.Name
+				}
+
+				customBinding := key.NewBinding(
+					key.WithKeys(branchKey.Key),
+					key.WithHelp(branchKey.Key, name),
+				)
+
+				CustomBranchBindings = append(CustomBranchBindings, customBinding)
+			}
 			continue
 		}
 
@@ -108,7 +125,12 @@ func rebindBranchKeys(keys []config.Keybinding) error {
 		}
 
 		key.SetKeys(branchKey.Key)
-		key.SetHelp(branchKey.Key, key.Help().Desc)
+
+		helpDesc := key.Help().Desc
+		if branchKey.Name != "" {
+			helpDesc = branchKey.Name
+		}
+		key.SetHelp(branchKey.Key, helpDesc)
 	}
 
 	return nil

--- a/ui/keys/issueKeys.go
+++ b/ui/keys/issueKeys.go
@@ -63,8 +63,24 @@ func IssueFullHelp() []key.Binding {
 }
 
 func rebindIssueKeys(keys []config.Keybinding) error {
+	CustomIssueBindings = []key.Binding{}
+
 	for _, issueKey := range keys {
 		if issueKey.Builtin == "" {
+			// Handle custom commands
+			if issueKey.Command != "" {
+				name := issueKey.Command
+				if issueKey.Name != "" {
+					name = issueKey.Name
+				}
+
+				customBinding := key.NewBinding(
+					key.WithKeys(issueKey.Key),
+					key.WithHelp(issueKey.Key, name),
+				)
+
+				CustomIssueBindings = append(CustomIssueBindings, customBinding)
+			}
 			continue
 		}
 
@@ -90,7 +106,12 @@ func rebindIssueKeys(keys []config.Keybinding) error {
 		}
 
 		key.SetKeys(issueKey.Key)
-		key.SetHelp(issueKey.Key, key.Help().Desc)
+
+		helpDesc := key.Help().Desc
+		if issueKey.Name != "" {
+			helpDesc = issueKey.Name
+		}
+		key.SetHelp(issueKey.Key, helpDesc)
 	}
 
 	return nil

--- a/ui/keys/issueKeys.go
+++ b/ui/keys/issueKeys.go
@@ -69,9 +69,9 @@ func rebindIssueKeys(keys []config.Keybinding) error {
 		if issueKey.Builtin == "" {
 			// Handle custom commands
 			if issueKey.Command != "" {
-				name := issueKey.Command
-				if issueKey.Name != "" {
-					name = issueKey.Name
+				name := issueKey.Name
+				if issueKey.Name == "" {
+					name = config.TruncateCommand(issueKey.Command)
 				}
 
 				customBinding := key.NewBinding(

--- a/ui/keys/keys.go
+++ b/ui/keys/keys.go
@@ -211,9 +211,9 @@ func rebindUniversal(universal []config.Keybinding) error {
 		if kb.Builtin == "" {
 			// Handle custom commands
 			if kb.Command != "" {
-				name := kb.Command
-				if kb.Name != "" {
-					name = kb.Name
+				name := kb.Name
+				if kb.Name == "" {
+					name = config.TruncateCommand(kb.Command)
 				}
 
 				customBinding := key.NewBinding(

--- a/ui/keys/keys.go
+++ b/ui/keys/keys.go
@@ -44,19 +44,19 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	var additionalKeys []key.Binding
 	var customKeys []key.Binding
 
-	if k.viewType == config.PRsView {
-		additionalKeys = PRFullHelp()
-		customKeys = CustomPRBindings
-	} else if k.viewType == config.RepoView {
-		additionalKeys = BranchFullHelp()
-		customKeys = CustomBranchBindings
-	} else {
-		additionalKeys = IssueFullHelp()
-		customKeys = CustomIssueBindings
-	}
-
 	if len(CustomUniversalBindings) > 0 {
 		customKeys = append(customKeys, CustomUniversalBindings...)
+	}
+
+	if k.viewType == config.PRsView {
+		additionalKeys = PRFullHelp()
+		customKeys = append(customKeys, CustomPRBindings...)
+	} else if k.viewType == config.RepoView {
+		additionalKeys = BranchFullHelp()
+		customKeys = append(customKeys, CustomBranchBindings...)
+	} else {
+		additionalKeys = IssueFullHelp()
+		customKeys = append(customKeys, CustomIssueBindings...)
 	}
 
 	sections := [][]key.Binding{
@@ -274,6 +274,8 @@ func rebindUniversal(universal []config.Keybinding) error {
 		helpDesc := key.Help().Desc
 		if kb.Name != "" {
 			helpDesc = kb.Name
+		} else if kb.Command != "" {
+			helpDesc = kb.Command
 		}
 		key.SetHelp(kb.Key, helpDesc)
 	}

--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -123,9 +123,9 @@ func rebindPRKeys(keys []config.Keybinding) error {
 		if prKey.Builtin == "" {
 			// Handle custom commands
 			if prKey.Command != "" {
-				name := prKey.Command
-				if prKey.Name != "" {
-					name = prKey.Name
+				name := prKey.Name
+				if prKey.Name == "" {
+					name = config.TruncateCommand(prKey.Command)
 				}
 
 				customBinding := key.NewBinding(

--- a/ui/keys/prKeys.go
+++ b/ui/keys/prKeys.go
@@ -117,8 +117,24 @@ func PRFullHelp() []key.Binding {
 }
 
 func rebindPRKeys(keys []config.Keybinding) error {
+	CustomPRBindings = []key.Binding{}
+
 	for _, prKey := range keys {
 		if prKey.Builtin == "" {
+			// Handle custom commands
+			if prKey.Command != "" {
+				name := prKey.Command
+				if prKey.Name != "" {
+					name = prKey.Name
+				}
+
+				customBinding := key.NewBinding(
+					key.WithKeys(prKey.Key),
+					key.WithHelp(prKey.Key, name),
+				)
+
+				CustomPRBindings = append(CustomPRBindings, customBinding)
+			}
 			continue
 		}
 
@@ -162,7 +178,12 @@ func rebindPRKeys(keys []config.Keybinding) error {
 		}
 
 		key.SetKeys(prKey.Key)
-		key.SetHelp(prKey.Key, key.Help().Desc)
+
+		helpDesc := key.Help().Desc
+		if prKey.Name != "" {
+			helpDesc = prKey.Name
+		}
+		key.SetHelp(prKey.Key, helpDesc)
 	}
 
 	return nil


### PR DESCRIPTION
This adds the feature of showing the custom keybindings in the help menu. When the custom keybinding is extended with a `name` key, it will render that, otherwise it will use the command itself.

Example:
```yaml
    - key: g
      command: >
        cd {{.RepoPath}} && lazygit
      name: lazygit
```

![CleanShot 2025-03-05 at 17 54 54@2x](https://github.com/user-attachments/assets/a7b97293-67a8-4caa-8dab-a390f9af32c1)
