### PR TITLE
feat: make PR approve comment configurable

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -102,6 +102,7 @@ type LayoutConfig struct {
 type Defaults struct {
 	Preview                PreviewConfig `yaml:"preview"`
 	PrsLimit               int           `yaml:"prsLimit"`
+	PrApproveComment       string        `yaml:"prApproveComment,omitempty"`
 	IssuesLimit            int           `yaml:"issuesLimit"`
 	View                   ViewType      `yaml:"view"`
 	Layout                 LayoutConfig  `yaml:"layout,omitempty"`
@@ -244,6 +245,7 @@ func (parser ConfigParser) getDefaultConfig() Config {
 				Width: 50,
 			},
 			PrsLimit:               20,
+			PrApproveComment:       "LGTM",
 			IssuesLimit:            20,
 			View:                   PRsView,
 			RefetchIntervalMinutes: 30,

--- a/docs/content/getting-started/keybindings/selected-pr.md
+++ b/docs/content/getting-started/keybindings/selected-pr.md
@@ -103,7 +103,8 @@ Press ![kbd:`u`]() to update the PR branch. When you do, the dashboard uses the
 ## `v` - Approve PR { #approve-pr}
 
 Press ![kbd:`v`]() to approve the PR. When you do, the dashboard uses the
-`gh pr review --approve` command to approve the PR. This will prompt you to add an optional comment to the approval.
+`gh pr review --approve` command to approve the PR. This will prompt you to add an optional comment to the approval. The comment prompt will be prefilled with 
+`defaults.prApproveComment` if it is set in your configuration, which defaults to "LGTM".
 
 ## `w` - Watch PR checks { #watch-pr-checks}
 

--- a/docs/data/schemas/defaults.yaml
+++ b/docs/data/schemas/defaults.yaml
@@ -29,6 +29,7 @@ default:
     open: true
     width: 50
   prsLimit: 20
+  prApproveComment: LGTM
   issuesLimit: 20
   view: prs
   refetchIntervalMinutes: 30
@@ -190,3 +191,17 @@ properties:
       - issues
       - prs
     default: prs
+  prApproveComment:
+    title: PR Approve Comment
+    description: The default comment prefilled when approving a PR.
+    schematize:
+      weight: 6
+      details: |
+        This setting defines the default comment used as a starting point when [approving a PR].
+        This can be set as an empty string to not prefill a comment.
+
+        By default, the comment is "LGTM".
+
+        [approving a PR]: /getting-started/keybindings/selected-pr/#approve-pr
+    type: string
+    default: LGTM

--- a/ui/components/prsidebar/prsidebar.go
+++ b/ui/components/prsidebar/prsidebar.go
@@ -361,7 +361,7 @@ func (m *Model) SetIsApproving(isApproving bool) tea.Cmd {
 	}
 	m.isApproving = isApproving
 	m.inputBox.SetPrompt(approvalPrompt)
-	m.inputBox.SetValue("LGTM")
+	m.inputBox.SetValue(m.ctx.Config.Defaults.PrApproveComment)
 
 	if isApproving {
 		return tea.Sequence(textarea.Blink, m.inputBox.Focus())


### PR DESCRIPTION
# Summary

This change makes it possible to configure the prefilled message used when approving a pull request. This was raised in this discussion post: https://github.com/dlvhdr/gh-dash/discussions/512

## How did you test this change?

Running locally with `make run`, I configured the `.gh-dash.yaml` in this repo to use different values of `defaults.prApproveComment` and observed the prefilled message in the GitHub UI (or lack of one when `defaults.prApproveComment` was set to empty string).

## Images/Videos

![CleanShot 2025-03-12 at 00 07 25@2x](https://github.com/user-attachments/assets/d19d5e90-430e-447b-84b3-7726da38bcc6)
