### PR TITLE
feat: set proper inputbox limit (pr/issue)

### DIFF
--- a/ui/components/inputbox/inputbox.go
+++ b/ui/components/inputbox/inputbox.go
@@ -28,6 +28,7 @@ func NewModel(ctx *context.ProgramContext) Model {
 	ta := textarea.New()
 	ta.ShowLineNumbers = true
 	ta.Prompt = ""
+        ta.CharLimit = 65536
 	ta.FocusedStyle.Base = lipgloss.NewStyle()
 	ta.FocusedStyle.CursorLine = lipgloss.NewStyle().
 		Background(ctx.Theme.FaintBorder).


### PR DESCRIPTION
# Summary

This PR sets the character limit for all text boxes in gh-dash to 65536 characters.
While it is possible to set this field (CharLimit) to unlimited (-1), 65536 seems like a sensible default: on GitHub, (almost) all text content supplied through their API is limited by 65536 characters.

Currently, the limit for all textboxes in gh-dash is 400 characters. 
This may seem like a bit of a nitpick, though I've run into the issue myself where I was typing away and ran out of space, only to submit the comment, open the issue/pr in the browser and finish my comment by editing it. This is bad UX IMO.

Closes #517
See: https://github.com/orgs/community/discussions/27190
