### PR TITLE
feat: add redraw, default to Ctrl-L

### DIFF
--- a/ui/constants/constants.go
+++ b/ui/constants/constants.go
@@ -12,6 +12,7 @@ type KeyMap struct {
 	TogglePreview key.Binding
 	OpenGithub    key.Binding
 	Refresh       key.Binding
+	Redraw        key.Binding
 	PageDown      key.Binding
 	PageUp        key.Binding
 	NextSection   key.Binding

--- a/ui/keys/keys.go
+++ b/ui/keys/keys.go
@@ -18,6 +18,7 @@ type KeyMap struct {
 	LastLine      key.Binding
 	TogglePreview key.Binding
 	OpenGithub    key.Binding
+	Redraw        key.Binding
 	Refresh       key.Binding
 	RefreshAll    key.Binding
 	PageDown      key.Binding
@@ -91,6 +92,7 @@ func (k KeyMap) AppKeys() []key.Binding {
 	return []key.Binding{
 		k.Refresh,
 		k.RefreshAll,
+		k.Redraw,
 		k.TogglePreview,
 		k.OpenGithub,
 		k.CopyNumber,
@@ -135,6 +137,10 @@ var Keys = &KeyMap{
 	RefreshAll: key.NewBinding(
 		key.WithKeys("R"),
 		key.WithHelp("R", "refresh all"),
+	),
+	Redraw: key.NewBinding(
+		key.WithKeys("ctrl+l"),
+		key.WithHelp("Ctrl+l", "redraw display"),
 	),
 	PageDown: key.NewBinding(
 		key.WithKeys("ctrl+d"),
@@ -247,6 +253,8 @@ func rebindUniversal(universal []config.Keybinding) error {
 			key = &Keys.Refresh
 		case "refreshAll":
 			key = &Keys.RefreshAll
+		case "redraw":
+			key = &Keys.Redraw
 		case "pageDown":
 			key = &Keys.PageDown
 		case "pageUp":

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -246,6 +246,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setCurrentViewSections(newSections)
 			cmds = append(cmds, fetchSectionsCmds)
 
+		case key.Matches(msg, m.keys.Redraw):
+			// can't find a way to just ask to send bubbletea's internal repaintMsg{},
+			// so this seems like the lightest-weight alternative
+			return m, tea.Batch(tea.ExitAltScreen, tea.EnterAltScreen)
+
 		case key.Matches(msg, m.keys.Search):
 			if currSection != nil {
 				cmd = currSection.SetIsSearching(true)


### PR DESCRIPTION
# Summary

When opening a browser, GNOME things have a tendency to spew messages to stderr which corrupts the gh-dash display.  Nothing made it possible to get a display which then restored the output, the entry area, etc.

A screen redraw command is useful for "something has happened, it shouldn't have, we know it shouldn't have, but that's life, go ahead and redraw please".  This has traditionally been bound to Ctrl-L, so that's what I picked here.

The bubbletea internals appear to have a `repaintMsg{}` but I couldn't figure out how to just send that.  The lightest-weight option I found was to batch together `ExitAltScreen` and `EnterAltScreen`.  This causes a very brief flicker which ... is also traditional and I'm accepting it as "shows positive feedback that the keystroke was acted upon" rather than a bug.

With this, `gh-dash` can be safely used to `o`pen issues in a browser without then needing to quit and restart, because it offers a recovery mechanism.

## How did you test this change?

Pressed `o` on an issue, returned to the dashboard, typed `Ctrl-L` and got a working display once more.

## Images/Videos

Here's a view of a public PR which I've just pressed `o` on, and then returned to my terminal window; look at the bottom and see the mis-display:

![screenshot_gh-dash_opened-issue](https://github.com/user-attachments/assets/0208352a-0486-4f19-949c-1af27e14de23)

The effect is worse with a screen-full of issues, as everything gets scrolled up, and the search/query bar gets scrolled up too, never to be redrawn.

And here it is after I've pressed `Ctrl-L` with this feature built:

![screenshot_gh-dash_redrawn](https://github.com/user-attachments/assets/1fb3cb54-70e9-4054-a82c-23fc1a09c9fc)
