### PR TITLE
docs: fix config loading order documentation to match implemen…

### DIFF
--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -22,11 +22,13 @@ configuration file depends on your system:
 
 1. If `$GH_DASH_CONFIG` is a non-empty string, `gh-dash` will use this file for
     its configuration.
-1. If `$GH_DASH_CONFIG` isn't set and `$XDG_CONFIG_HOME` is a non-empty string,
-    the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
-1. If neither `$GH_DASH_CONFIG` or `$XDG_CONFIG_HOME` are set, then:
-   - On Linux and macOS systems, the default path is `$HOME/gh-dash/config.yml`.
-   - On Windows systems, the default path is `%USERPROFILE%\gh-dash\config.yml`.
+2. If `$GH_DASH_CONFIG` isn't set and you're in a git repository, it will look for `.gh-dash.yml` or `.gh-dash.yaml` 
+    in the repository root.
+3. If neither of the above applies, then:
+   - If `$XDG_CONFIG_HOME` is a non-empty string, the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
+   - If `$XDG_CONFIG_HOME` isn't set, then:
+     - On Linux and macOS systems, the default path is `$HOME/.config/gh-dash/config.yml`.
+     - On Windows systems, the default path is `%USERPROFILE%\.config\gh-dash\config.yml`.
 
 After `gh-dash` creates the default configuration, you can edit it.
 

--- a/docs/content/getting-started/usage.md
+++ b/docs/content/getting-started/usage.md
@@ -45,14 +45,15 @@ gh dash --config path/to/configuration/file.yml
 
 If you don't specify this flag, `gh-dash` uses the default configuration. If the file doesn't exist, gh-dash will create it. The location of the default configuration file depends on your system:
 
-1. If Inside a git repo, `gh-dash` will look for a `.gh-dash.yml` file in the root of the repo.
-2. If `$GH_DASH_CONFIG` is a non-empty string, `gh-dash` will use this file for
+1. If `$GH_DASH_CONFIG` is a non-empty string, `gh-dash` will use this file for
     its configuration.
-3. If `$GH_DASH_CONFIG` isn't set and `$XDG_CONFIG_HOME` is a non-empty string,
-    the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
-4. If neither `$GH_DASH_CONFIG` or `$XDG_CONFIG_HOME` are set, then:
-   - On Linux and macOS systems, the default path is `$HOME/gh-dash/config.yml`.
-   - On Windows systems, the default path is `%USERPROFILE%\gh-dash\config.yml`.
+2. If `$GH_DASH_CONFIG` isn't set and you're in a git repository, it will look for `.gh-dash.yml` or `.gh-dash.yaml` 
+    in the repository root.
+3. If neither of the above applies, then:
+   - If `$XDG_CONFIG_HOME` is a non-empty string, the default path is `$XDG_CONFIG_HOME/gh-dash/config.yml`.
+   - If `$XDG_CONFIG_HOME` isn't set, then:
+     - On Linux and macOS systems, the default path is `$HOME/.config/gh-dash/config.yml`.
+     - On Windows systems, the default path is `%USERPROFILE%\.config\gh-dash\config.yml`.
 
 For more information about authoring configurations, see [Configuration][02].
 


### PR DESCRIPTION
# Documentation Fix for Configuration Loading Order

This PR updates the documentation to accurately reflect the actual configuration loading order as implemented in the code.

## Issue

The documentation incorrectly described the configuration loading order, particularly omitting the repository-specific config file lookup and incorrectly stating the default path when no environment variables are set.

## Changes

Updated documentation to match the actual implementation in [`config/parser.go`](https://github.com/dlvhdr/gh-dash/blob/main/config/parser.go#L418-L471):

```go
func (parser ConfigParser) getDefaultConfigFileOrCreateIfMissing(repoPath string) (string, error) {
	var configFilePath string
	ghDashConfig := os.Getenv("GH_DASH_CONFIG")

	// First try GH_DASH_CONFIG
	if ghDashConfig != "" {
		configFilePath = ghDashConfig
	// Then try to see if we're currently in a git repo
	} else if repoPath != "" {
		basename := repoPath + "/." + DashDir
		repoConfigYml := basename + ".yml"
		repoConfigYaml := basename + ".yaml"
		if _, err := os.Stat(repoConfigYml); err == nil {
			configFilePath = repoConfigYml
		} else if _, err := os.Stat(repoConfigYaml); err == nil {
			configFilePath = repoConfigYaml
		}
		if configFilePath != "" {
			return configFilePath, nil
		}
	}

	// Then fallback to global config
	if configFilePath == "" {
		configDir := os.Getenv("XDG_CONFIG_HOME")
		if configDir == "" {
			homeDir, err := os.UserHomeDir()
			if err != nil {
				return "", err
			}
			configDir = filepath.Join(homeDir, DEFAULT_XDG_CONFIG_DIRNAME)
		}

		dashConfigDir := filepath.Join(configDir, DashDir)
		configFilePath = filepath.Join(dashConfigDir, ConfigYmlFileName)
	}
	...
}
```

The loading order is now documented as:

1. Check `$GH_DASH_CONFIG` environment variable first
2. If in a git repository, look for `.gh-dash.yml` or `.gh-dash.yaml` in the repo root
3. If neither of the above applies:
   - Use `$XDG_CONFIG_HOME/gh-dash/config.yml` if XDG_CONFIG_HOME is set
   - Otherwise, use `$HOME/.config/gh-dash/config.yml` on Linux/macOS or `%USERPROFILE%\.config\gh-dash\config.yml` on Windows
