### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ builds:
         goarch: arm
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: "gh-dash_{{ .Tag }}_{{ .Os }}-{{ .Arch }}{{if .Arm}}_{{.Arm}}{{end}}"
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
# Summary
This small PR updates the GoReleaser configuration to resolve the following warning which you can find in the [CI logs](https://github.com/dlvhdr/gh-dash/actions/runs/15363253048/job/43232945167#step:4:23): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

## How did you test this change?

## Images/Videos
