### PR TITLE
Fix Number of Commits in PR Sidebar

### DIFF
--- a/data/prapi.go
+++ b/data/prapi.go
@@ -98,6 +98,7 @@ type Commits struct {
 			}
 		}
 	}
+	TotalCount int
 }
 
 type Comment struct {

--- a/ui/components/prsidebar/files.go
+++ b/ui/components/prsidebar/files.go
@@ -38,7 +38,7 @@ func (m *Model) renderChangesOverview() string {
 			commits.Render(
 				lipgloss.JoinHorizontal(lipgloss.Top,
 					lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render(" "),
-					fmt.Sprintf("%d commits", m.pr.Data.Files.TotalCount),
+					fmt.Sprintf("%d commits", m.pr.Data.Commits.TotalCount),
 					" ",
 					lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render(fmt.Sprintf("%s ago", time)),
 				),


### PR DESCRIPTION
# Summary

This PR fixes the shown number of commits in the sidebar of a Pull Request.

## How did you test this change?

I just tested this manually by running the following commands:

```
go build .
./gh-dash -c ~/.config/gh-dash/config.yml
```

## Images/Videos

Before

<img width="2848" height="1563" alt="Bildschirmfoto 2025-07-18 um 15 08 49" src="https://github.com/user-attachments/assets/37130f10-5efe-43ce-a834-7c3323fae7bd" />

After

<img width="2848" height="1563" alt="Bildschirmfoto 2025-07-18 um 15 08 01" src="https://github.com/user-attachments/assets/b51d2416-22ba-4295-b98d-16ac24ff5ee8" />
