### PR TITLE
remove deprecated tap

### DIFF
--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -28,7 +28,7 @@ Get started using `dash` to review and manage your GitHub work items.
    select that font as your font for the terminal.
 
    ```bash
-    brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font
+    brew install --cask font-fira-code-nerd-font
    ```
 
 ---


### PR DESCRIPTION
# Summary
In macOS guide installation, the command `brew tap homebrew/cask-fonts` gives an error:
`Error: homebrew/cask-fonts was deprecated. This tap is now empty, and all its contents were either deleted or migrated.`

To install the Fira-Code Nerd font, it is only required to do:
`brew install --cask font-fira-code-nerd-font`

## How did you test this change?
Use `brew tap homebrew/cask-fonts && brew install --cask font-fira-code-nerd-font` and check if it gives the deprecation error on start.
Check if with only `brew install --cask font-fira-code-nerd-font` the font is successfully installed.

## Images/Videos
NA