### PR TITLE
Change to csv

### DIFF
--- a/internal/tui/components/issueview/issueview.go
+++ b/internal/tui/components/issueview/issueview.go
@@ -348,7 +348,7 @@ func (m *Model) SetIsLabeling(isLabeling bool) tea.Cmd {
 	for _, label := range m.issue.Data.Labels.Nodes {
 		labels = append(labels, label.Name)
 	}
-	m.inputBox.SetValue(strings.Join(labels, " "))
+	m.inputBox.SetValue(strings.Join(labels, ", "))
 
 	if isLabeling {
 		return tea.Sequence(textarea.Blink, m.inputBox.Focus())


### PR DESCRIPTION
Fixes [#717](https://github.com/dlvhdr/gh-dash/issues/717)

# Summary
Using whitespace to separate labels causes incorrect parsing of labels with spaces in them like "state:needs repro". Changing to comma separated adds support for labels with white space.

## How did you test this change?
I built the extension and ran it directly. Once running, I added labels to an issue where the labels had white space.

## Images/Videos
<video src="https://github.com/user-attachments/assets/4227945e-91fb-42f3-a677-907364e48b43">Video failed to load</video>

