### PR TITLE
fix: crash when pressing “w” to watch checks

### DIFF
--- a/internal/tui/components/prrow/prrow.go
+++ b/internal/tui/components/prrow/prrow.go
@@ -92,6 +92,9 @@ func (pr *PullRequest) renderState() string {
 }
 
 func (pr *PullRequest) GetStatusChecksRollup() checks.CommitState {
+	if pr.Data == nil || pr.Data.Primary == nil {
+		return checks.CommitStateUnknown
+	}
 	commits := pr.Data.Primary.Commits.Nodes
 	if len(commits) == 0 {
 		return checks.CommitStateUnknown

--- a/internal/tui/components/prrow/prrow_test.go
+++ b/internal/tui/components/prrow/prrow_test.go
@@ -1,0 +1,158 @@
+package prrow
+
+import (
+	"testing"
+
+	graphql "github.com/cli/shurcooL-graphql"
+	checks "github.com/dlvhdr/x/gh-checks"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+)
+
+func TestGetStatusChecksRollup(t *testing.T) {
+	tests := []struct {
+		name     string
+		pr       *PullRequest
+		expected checks.CommitState
+	}{
+		{
+			name:     "nil Data returns Unknown",
+			pr:       &PullRequest{Data: nil},
+			expected: checks.CommitStateUnknown,
+		},
+		{
+			name:     "nil Primary returns Unknown",
+			pr:       &PullRequest{Data: &Data{Primary: nil}},
+			expected: checks.CommitStateUnknown,
+		},
+		{
+			name: "empty Commits returns Unknown",
+			pr: &PullRequest{
+				Data: &Data{
+					Primary: &data.PullRequestData{
+						Commits: data.Commits{
+							Nodes: []struct {
+								Commit struct {
+									Deployments struct {
+										Nodes []struct {
+											Task        graphql.String
+											Description graphql.String
+										}
+									} `graphql:"deployments(last: 10)"`
+									CommitUrl         graphql.String
+									StatusCheckRollup struct {
+										State graphql.String
+									}
+								}
+							}{},
+						},
+					},
+				},
+			},
+			expected: checks.CommitStateUnknown,
+		},
+		{
+			name: "SUCCESS state returns Success",
+			pr: &PullRequest{
+				Data: &Data{
+					Primary: &data.PullRequestData{
+						Commits: data.Commits{
+							Nodes: []struct {
+								Commit struct {
+									Deployments struct {
+										Nodes []struct {
+											Task        graphql.String
+											Description graphql.String
+										}
+									} `graphql:"deployments(last: 10)"`
+									CommitUrl         graphql.String
+									StatusCheckRollup struct {
+										State graphql.String
+									}
+								}
+							}{
+								{
+									Commit: struct {
+										Deployments struct {
+											Nodes []struct {
+												Task        graphql.String
+												Description graphql.String
+											}
+										} `graphql:"deployments(last: 10)"`
+										CommitUrl         graphql.String
+										StatusCheckRollup struct {
+											State graphql.String
+										}
+									}{
+										StatusCheckRollup: struct {
+											State graphql.String
+										}{
+											State: "SUCCESS",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: checks.CommitStateSuccess,
+		},
+		{
+			name: "FAILURE state returns Failure",
+			pr: &PullRequest{
+				Data: &Data{
+					Primary: &data.PullRequestData{
+						Commits: data.Commits{
+							Nodes: []struct {
+								Commit struct {
+									Deployments struct {
+										Nodes []struct {
+											Task        graphql.String
+											Description graphql.String
+										}
+									} `graphql:"deployments(last: 10)"`
+									CommitUrl         graphql.String
+									StatusCheckRollup struct {
+										State graphql.String
+									}
+								}
+							}{
+								{
+									Commit: struct {
+										Deployments struct {
+											Nodes []struct {
+												Task        graphql.String
+												Description graphql.String
+											}
+										} `graphql:"deployments(last: 10)"`
+										CommitUrl         graphql.String
+										StatusCheckRollup struct {
+											State graphql.String
+										}
+									}{
+										StatusCheckRollup: struct {
+											State graphql.String
+										}{
+											State: "FAILURE",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: checks.CommitStateFailure,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.pr.GetStatusChecksRollup()
+			if result != tt.expected {
+				t.Errorf("GetStatusChecksRollup() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/components/prssection/watchChecks.go
+++ b/internal/tui/components/prssection/watchChecks.go
@@ -23,8 +23,8 @@ func (m *Model) watchChecks() tea.Cmd {
 
 	prNumber := pr.GetNumber()
 	title := pr.GetTitle()
-	url := pr.GetUrl()
 	repoNameWithOwner := pr.GetRepoNameWithOwner()
+	prData := pr.(*prrow.Data)
 	taskId := fmt.Sprintf("pr_reopen_%d", prNumber)
 	task := context.Task{
 		Id:           taskId,
@@ -58,13 +58,7 @@ func (m *Model) watchChecks() tea.Cmd {
 					"stderr", errb.String(), "stdout", outb.String())
 			}
 
-			// TODO: check for installation of terminal-notifier or alternative as logo isn't supported
-			// updatedPr, err := data.FetchPullRequest(url)
-			if err != nil {
-				log.Error("Error fetching updated PR details", "url", url, "err", err)
-			}
-
-			renderedPr := prrow.PullRequest{Ctx: m.Ctx, Data: &prrow.Data{}}
+			renderedPr := prrow.PullRequest{Ctx: m.Ctx, Data: prData}
 			checksRollup := " Checks are pending"
 			switch renderedPr.GetStatusChecksRollup() {
 			case "SUCCESS":


### PR DESCRIPTION
# Summary

This change fixes a case where the `watchChecks` function was creating an empty `prrow.Data{}` struct, and calling `GetStatusChecksRollup()` on it – which led to a nil-pointer dereference when accessing `pr.Data.Primary.Commits.Nodes`.

The change fixes that by not doing the empty-`prrow.Data{}`-struct thing — and instead, switching to using the actual PR data from the current row. It also adds a nil check to `GetStatusChecksRollup()`, for further safety.

Fixes https://github.com/dlvhdr/gh-dash/issues/718

## How did you test this change?

Added unit tests for `GetStatusChecksRollup()`.
