### PR TITLE
fix: remove ESC key from quit keybinding

### DIFF
--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -171,7 +171,7 @@ var Keys = &KeyMap{
 		key.WithHelp("?", "help"),
 	),
 	Quit: key.NewBinding(
-		key.WithKeys("q", "esc", "ctrl+c"),
+		key.WithKeys("q", "ctrl+c"),
 		key.WithHelp("q", "quit"),
 	),
 }


### PR DESCRIPTION
Fixes #702

## Changes
- Removed ESC key from the Quit keybinding, keeping only q and ctrl+c