### PR TITLE
fix: crash when switching to RepoView before data is loaded

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -867,6 +867,9 @@ func (m *Model) fetchAllViewSections() ([]section.Section, tea.Cmd) {
 func (m *Model) getCurrentViewSections() []section.Section {
 	switch m.ctx.View {
 	case config.RepoView:
+		if m.repo == nil {
+			return []section.Section{}
+		}
 		return []section.Section{m.repo}
 	case config.PRsView:
 		return m.prs

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -15,9 +15,11 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	gh "github.com/cli/go-gh/v2/pkg/api"
 	zone "github.com/lrstanley/bubblezone"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/markdown"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/testutils"
 )
@@ -135,4 +137,21 @@ func setMockClient(t *testing.T) {
 		t.Errorf("failed creating gh client %v", err)
 	}
 	data.SetClient(client)
+}
+
+func TestGetCurrentViewSections_RepoViewWithNilRepo(t *testing.T) {
+	// This test verifies that getCurrentViewSections returns an empty slice
+	// when in RepoView but m.repo is nil (before data is loaded).
+	// Previously this would return []section.Section{nil} which caused a panic.
+	m := Model{
+		ctx: &context.ProgramContext{
+			View: config.RepoView,
+		},
+		repo: nil,
+	}
+
+	sections := m.getCurrentViewSections()
+
+	require.NotNil(t, sections, "sections should not be nil")
+	require.Empty(t, sections, "sections should be empty when repo is nil")
 }


### PR DESCRIPTION
# Summary

When `m.repo` hasn't been initialized yet, return an empty slice – rather than a slice containing nil. That prevents a nil-pointer dereference when calling `GetId()` on the section – which in turn prevents dash from crashing on you when you try to switch into the Branch/Repo view.

## How did you test this change?

Added a `TestGetCurrentViewSections_RepoViewWithNilRepo` test in `internal/tui/ui_test.go`