### PR TITLE
fix: multiple crash-inducing bugs and resource leaks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,10 +92,10 @@ func createModel(location config.Location, debug bool) (tui.Model, *os.File) {
 
 	if debug {
 		var fileErr error
-		newConfigFile, fileErr := os.OpenFile("debug.log",
+		loggerFile, fileErr = os.OpenFile("debug.log",
 			os.O_RDWR|os.O_CREATE|os.O_APPEND, 0o666)
 		if fileErr == nil {
-			log.SetOutput(newConfigFile)
+			log.SetOutput(loggerFile)
 			log.SetTimeFormat(time.Kitchen)
 			log.SetReportCaller(true)
 			setDebugLogLevel()

--- a/internal/tui/components/branch/data.go
+++ b/internal/tui/components/branch/data.go
@@ -13,6 +13,9 @@ type BranchData struct {
 }
 
 func (b BranchData) GetRepoNameWithOwner() string {
+	if len(b.Data.Remotes) == 0 {
+		return ""
+	}
 	return b.Data.Remotes[0]
 }
 
@@ -35,5 +38,8 @@ func (b BranchData) GetUrl() string {
 }
 
 func (b BranchData) GetUpdatedAt() time.Time {
+	if b.Data.LastUpdatedAt == nil {
+		return time.Time{}
+	}
 	return *b.Data.LastUpdatedAt
 }

--- a/internal/tui/components/branch/data_test.go
+++ b/internal/tui/components/branch/data_test.go
@@ -1,0 +1,63 @@
+package branch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/git"
+)
+
+func TestBranchData_GetRepoNameWithOwner_EmptyRemotes(t *testing.T) {
+	// This test verifies that GetRepoNameWithOwner returns empty string
+	// when Remotes slice is empty, instead of panicking with index out of bounds.
+	b := BranchData{
+		Data: git.Branch{
+			Remotes: []string{}, // Empty remotes
+		},
+	}
+
+	result := b.GetRepoNameWithOwner()
+
+	require.Equal(t, "", result, "should return empty string for empty remotes")
+}
+
+func TestBranchData_GetRepoNameWithOwner_WithRemotes(t *testing.T) {
+	b := BranchData{
+		Data: git.Branch{
+			Remotes: []string{"origin/main", "upstream/main"},
+		},
+	}
+
+	result := b.GetRepoNameWithOwner()
+
+	require.Equal(t, "origin/main", result, "should return first remote")
+}
+
+func TestBranchData_GetUpdatedAt_NilLastUpdatedAt(t *testing.T) {
+	// This test verifies that GetUpdatedAt returns zero time
+	// when LastUpdatedAt is nil, instead of panicking with nil pointer dereference.
+	b := BranchData{
+		Data: git.Branch{
+			LastUpdatedAt: nil, // Nil pointer
+		},
+	}
+
+	result := b.GetUpdatedAt()
+
+	require.True(t, result.IsZero(), "should return zero time for nil LastUpdatedAt")
+}
+
+func TestBranchData_GetUpdatedAt_WithValue(t *testing.T) {
+	now := time.Now()
+	b := BranchData{
+		Data: git.Branch{
+			LastUpdatedAt: &now,
+		},
+	}
+
+	result := b.GetUpdatedAt()
+
+	require.Equal(t, now, result, "should return the actual time")
+}

--- a/internal/tui/components/issuessection/issuessection.go
+++ b/internal/tui/components/issuessection/issuessection.go
@@ -276,10 +276,11 @@ func (m *Model) NumRows() int {
 }
 
 func (m *Model) GetCurrRow() data.RowData {
-	if len(m.Issues) == 0 {
+	idx := m.Table.GetCurrItem()
+	if idx < 0 || idx >= len(m.Issues) {
 		return nil
 	}
-	issue := m.Issues[m.Table.GetCurrItem()]
+	issue := m.Issues[idx]
 	return &issue
 }
 

--- a/internal/tui/components/prssection/prssection.go
+++ b/internal/tui/components/prssection/prssection.go
@@ -408,10 +408,11 @@ type SectionPullRequestsFetchedMsg struct {
 }
 
 func (m *Model) GetCurrRow() data.RowData {
-	if len(m.Prs) == 0 {
+	idx := m.Table.GetCurrItem()
+	if idx < 0 || idx >= len(m.Prs) {
 		return nil
 	}
-	pr := m.Prs[m.Table.GetCurrItem()]
+	pr := m.Prs[idx]
 	return &pr
 }
 

--- a/internal/tui/components/prssection/watchChecks.go
+++ b/internal/tui/components/prssection/watchChecks.go
@@ -41,9 +41,9 @@ func (m *Model) watchChecks() tea.Cmd {
 			"checks",
 			"--watch",
 			"--fail-fast",
-			fmt.Sprint(m.GetCurrRow().GetNumber()),
+			fmt.Sprint(prNumber),
 			"-R",
-			m.GetCurrRow().GetRepoNameWithOwner(),
+			repoNameWithOwner,
 		)
 
 		var outb, errb bytes.Buffer

--- a/internal/tui/components/reposection/reposection.go
+++ b/internal/tui/components/reposection/reposection.go
@@ -442,17 +442,19 @@ type SectionPullRequestsFetchedMsg struct {
 }
 
 func (m *Model) getCurrBranch() *branch.Branch {
-	if len(m.repo.Branches) == 0 {
+	idx := m.Table.GetCurrItem()
+	if idx < 0 || idx >= len(m.Branches) {
 		return nil
 	}
-	return &m.Branches[m.Table.GetCurrItem()]
+	return &m.Branches[idx]
 }
 
 func (m *Model) GetCurrRow() data.RowData {
-	if len(m.repo.Branches) == 0 {
+	idx := m.Table.GetCurrItem()
+	if idx < 0 || idx >= len(m.repo.Branches) {
 		return nil
 	}
-	b := m.repo.Branches[m.Table.GetCurrItem()]
+	b := m.repo.Branches[idx]
 	pr := findPRForRef(m.Prs, b.Name)
 	return branch.BranchData{
 		Data: b,

--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -20,10 +20,19 @@ func InitializeMarkdownStyle(hasDarkBackground bool) {
 }
 
 func GetMarkdownRenderer(width int) glamour.TermRenderer {
-	markdownRenderer, _ := glamour.NewTermRenderer(
+	markdownRenderer, err := glamour.NewTermRenderer(
 		glamour.WithStyles(*markdownStyle),
 		glamour.WithWordWrap(width),
 	)
+	if err != nil || markdownRenderer == nil {
+		// Return a fallback renderer that just returns input unchanged
+		fallback, _ := glamour.NewTermRenderer(glamour.WithAutoStyle())
+		if fallback != nil {
+			return *fallback
+		}
+		// If even fallback fails, panic with helpful message
+		panic("failed to create markdown renderer: " + err.Error())
+	}
 
 	return *markdownRenderer
 }


### PR DESCRIPTION
# Summary

- BranchData.GetUpdatedAt(): add nil check for LastUpdatedAt pointer
- BranchData.GetRepoNameWithOwner(): add empty check for Remotes slice
- reposection/prssection/issuessection GetCurrRow(): validate GetCurrItem()
  index is within bounds before accessing slice
- cmd/root.go: fix file handle leak by assigning opened file to loggerFile
  so it gets returned and closed by caller
- watchChecks.go: use captured values instead of calling GetCurrRow() again
  inside goroutine (race condition)
- prapi.go: reuse cachedClient instead of creating new GraphQL client on
  every FetchPullRequest call (resource waste + variable shadowing)
- markdownRenderer.go: handle error from glamour.NewTermRenderer with
  fallback renderer instead of dereferencing nil pointer

## How did you test this change?

Added internal/tui/components/branch/data_test.go