### PR TITLE
fix: Add placeholder suggestions

### DIFF
--- a/internal/tui/components/autocomplete/autocomplete.go
+++ b/internal/tui/components/autocomplete/autocomplete.go
@@ -268,6 +268,16 @@ func (m *Model) View() string {
 func (m *Model) SetFetchLoading() tea.Cmd {
 	m.fetchState = FetchStateLoading
 	m.fetchError = nil
+
+	placeholders := make([]string, 0, m.maxVisible)
+	for i := 0; i < m.maxVisible; i++ {
+		placeholders = append(placeholders, "")
+	}
+	m.filtered = placeholders
+	m.selected = 0
+
+	m.UpdateVisible()
+
 	return m.spinner.Tick
 }
 


### PR DESCRIPTION
# Summary
Add placeholders when fetching begins so the popup has the correct height when the labeling inputbox is rendered.

## How did you test this change?
I ran `go build` and then opened a long issue. Finally, open the label inputbox.

## Images/Videos
<img width="3228" height="1920" alt="CleanShot 2026-01-06 at 07 09 57@2x" src="https://github.com/user-attachments/assets/64d1062a-2e20-4820-b0cb-5f0d4da9f5c5" />
