### PR TITLE
fix(prs): Make r/R refresh properly update reviewer status as expected

### DIFF
--- a/internal/data/issueapi.go
+++ b/internal/data/issueapi.go
@@ -150,8 +150,8 @@ type IssuesResponse struct {
 // FetchIssue fetches a single issue by its GitHub URL
 func FetchIssue(issueUrl string) (IssueData, error) {
 	var err error
-	if cachedClient == nil {
-		cachedClient, err = gh.NewGraphQLClient(gh.ClientOptions{EnableCache: true, CacheTTL: 5 * time.Minute})
+	if client == nil {
+		client, err = gh.DefaultGraphQLClient()
 		if err != nil {
 			return IssueData{}, err
 		}
@@ -170,7 +170,7 @@ func FetchIssue(issueUrl string) (IssueData, error) {
 		"url": githubv4.URI{URL: parsedUrl},
 	}
 	log.Debug("Fetching Issue", "url", issueUrl)
-	err = cachedClient.Query("FetchIssue", &queryResult, variables)
+	err = client.Query("FetchIssue", &queryResult, variables)
 	if err != nil {
 		return IssueData{}, err
 	}

--- a/internal/data/prapi.go
+++ b/internal/data/prapi.go
@@ -439,14 +439,10 @@ type PullRequestsResponse struct {
 	PageInfo   PageInfo
 }
 
-var (
-	client       *gh.GraphQLClient
-	cachedClient *gh.GraphQLClient
-)
+var client *gh.GraphQLClient
 
 func SetClient(c *gh.GraphQLClient) {
 	client = c
-	cachedClient = c
 }
 
 func FetchPullRequests(query string, limit int, pageInfo *PageInfo) (PullRequestsResponse, error) {
@@ -504,8 +500,8 @@ func FetchPullRequests(query string, limit int, pageInfo *PageInfo) (PullRequest
 
 func FetchPullRequest(prUrl string) (EnrichedPullRequestData, error) {
 	var err error
-	if cachedClient == nil {
-		cachedClient, err = gh.NewGraphQLClient(gh.ClientOptions{EnableCache: true, CacheTTL: 5 * time.Minute})
+	if client == nil {
+		client, err = gh.DefaultGraphQLClient()
 		if err != nil {
 			return EnrichedPullRequestData{}, err
 		}
@@ -524,7 +520,7 @@ func FetchPullRequest(prUrl string) (EnrichedPullRequestData, error) {
 		"url": githubv4.URI{URL: parsedUrl},
 	}
 	log.Debug("Fetching PR", "url", prUrl)
-	err = cachedClient.Query("FetchPullRequest", &queryResult, variables)
+	err = client.Query("FetchPullRequest", &queryResult, variables)
 	if err != nil {
 		return EnrichedPullRequestData{}, err
 	}

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -252,6 +252,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.syncMainContentWidth()
 
 		case key.Matches(msg, m.keys.Refresh):
+			data.ClearLabelCache()
 			currSection.ResetFilters()
 			currSection.ResetRows()
 			m.syncSidebar()
@@ -259,6 +260,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, currSection.FetchNextPageSectionRows()...)
 
 		case key.Matches(msg, m.keys.RefreshAll):
+			data.ClearLabelCache()
 			newSections, fetchSectionsCmds := m.fetchAllViewSections()
 			m.setCurrentViewSections(newSections)
 			cmds = append(cmds, fetchSectionsCmds)


### PR DESCRIPTION
## Summary

Previously, `FetchPullRequest` and `FetchIssue` used a separate `cachedClient` with a 5-minute GraphQL cache TTL. That meant that after someone approved a PR, pressing “r” or “R” to refresh in gh-dash wouldn’t update the reviewer status — the enriched PR data was still being served from cache.

This PR fixes the problem by removing the `cachedClient` entirely and having `FetchPullRequest` and `FetchIssue` use the same shared `client` as the list-fetch functions (`FetchPullRequests`/`FetchIssues`). Each call now gets fresh data from GitHub.

Fixes https://github.com/dlvhdr/gh-dash/issues/745

## How did you test this change?

`go test ./...` passes
