### PR TITLE
feat(config): Ensure that tests run locally skip any local user config

### DIFF
--- a/internal/tui/components/issueview/action_test.go
+++ b/internal/tui/components/issueview/action_test.go
@@ -17,7 +17,8 @@ import (
 func newTestModelForAction(t *testing.T) Model {
 	t.Helper()
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../../../config/testdata/test-config.yml",
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tui/components/prview/action_test.go
+++ b/internal/tui/components/prview/action_test.go
@@ -17,7 +17,8 @@ import (
 func newTestModelForAction(t *testing.T) Model {
 	t.Helper()
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../../../config/testdata/test-config.yml",
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tui/components/prview/reviewers_test.go
+++ b/internal/tui/components/prview/reviewers_test.go
@@ -21,7 +21,8 @@ func newTestModel(t *testing.T, prData *data.PullRequestData) Model {
 func newTestModelWithWidth(t *testing.T, prData *data.PullRequestData, width int) Model {
 	t.Helper()
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../../../config/testdata/test-config.yml",
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -326,7 +327,8 @@ func TestRenderRequestedReviewersWrapping(t *testing.T) {
 
 func TestRenderRequestedReviewersLoading(t *testing.T) {
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../../../config/testdata/test-config.yml",
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	require.NoError(t, err)
 
@@ -357,7 +359,8 @@ func TestRenderRequestedReviewersLoading(t *testing.T) {
 
 func TestRenderSuggestedReviewers(t *testing.T) {
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../../../config/testdata/test-config.yml",
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	require.NoError(t, err)
 

--- a/internal/tui/components/tabs/tabs_test.go
+++ b/internal/tui/components/tabs/tabs_test.go
@@ -25,7 +25,8 @@ func TestTabs(t *testing.T) {
 	t.Run("Should display loading tabs", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := config.ParseConfig(config.Location{
-			ConfigFlag: "../../../config/testdata/test-config.yml",
+			ConfigFlag:       "../../../config/testdata/test-config.yml",
+			SkipGlobalConfig: true,
 		})
 		if err != nil {
 			t.Error(err)
@@ -43,7 +44,8 @@ func TestTabs(t *testing.T) {
 	t.Run("Should display tab counts", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := config.ParseConfig(config.Location{
-			ConfigFlag: "../../../config/testdata/test-config.yml",
+			ConfigFlag:       "../../../config/testdata/test-config.yml",
+			SkipGlobalConfig: true,
 		})
 		if err != nil {
 			t.Error(err)
@@ -63,7 +65,8 @@ func TestTabs(t *testing.T) {
 	t.Run("Should allow setting new tabs", func(t *testing.T) {
 		t.Parallel()
 		cfg, err := config.ParseConfig(config.Location{
-			ConfigFlag: "../../../config/testdata/test-config.yml",
+			ConfigFlag:       "../../../config/testdata/test-config.yml",
+			SkipGlobalConfig: true,
 		})
 		if err != nil {
 			t.Error(err)
@@ -88,7 +91,8 @@ func TestTabs(t *testing.T) {
 		t.Parallel()
 
 		baseCfg, err := config.ParseConfig(config.Location{
-			ConfigFlag: "../../../config/testdata/test-config.yml",
+			ConfigFlag:       "../../../config/testdata/test-config.yml",
+			SkipGlobalConfig: true,
 		})
 		if err != nil {
 			t.Error(err)

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -174,7 +174,8 @@ func TestNotificationView_PRViewTabNavigation(t *testing.T) {
 	// (carousel.MoveLeft/MoveRight) doesn't return a command - it just updates state.
 	// The fix ensures we always sync sidebar and return after prView.Update().
 	cfg, err := config.ParseConfig(config.Location{
-		ConfigFlag: "../config/testdata/test-config.yml",
+		ConfigFlag:       "../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
# Summary

- Add a `SkipGlobalConfig` field to config.Location. That causes `ParseConfig` to load only a provided config file — without merging it with any local `~/.config/gh-dash/config.yml` user-config file.

- Update all existing test files to use `SkipGlobalConfig: true`.

Those changes are useful for local testing, where user-defined keybindings in a user’s config can “intercept” built-in keys — causing tests to pass locally but fail in CI, where no such local user config exists.

## How did you test this change?

Ran the test suite locally :)
