### PR TITLE
feat: add merge queue status indicator for PRs

### DIFF
--- a/internal/data/prapi.go
+++ b/internal/data/prapi.go
@@ -95,6 +95,7 @@ type PullRequestData struct {
 	ReviewRequests   ReviewRequests `graphql:"reviewRequests(last: 5)"`
 	Files            ChangedFiles   `graphql:"files(first: 5)"`
 	IsDraft          bool
+	IsInMergeQueue   bool
 	Commits          Commits          `graphql:"commits(last: 1)"`
 	Labels           PRLabels         `graphql:"labels(first: 6)"`
 	MergeStateStatus MergeStateStatus `graphql:"mergeStateStatus"`

--- a/internal/tui/components/prrow/prrow.go
+++ b/internal/tui/components/prrow/prrow.go
@@ -75,6 +75,9 @@ func (pr *PullRequest) renderState() string {
 
 	switch pr.Data.Primary.State {
 	case "OPEN":
+		if pr.Data.Primary.IsInMergeQueue {
+			return mergeCellStyle.Foreground(pr.Ctx.Theme.WarningText).Render(constants.MergeQueueIcon)
+		}
 		if pr.Data.Primary.IsDraft {
 			return mergeCellStyle.Foreground(pr.Ctx.Theme.FaintText).Render(constants.DraftIcon)
 		} else {
@@ -288,6 +291,9 @@ func (pr *PullRequest) renderBaseName() string {
 func (pr *PullRequest) RenderState() string {
 	switch pr.Data.Primary.State {
 	case "OPEN":
+		if pr.Data.Primary.IsInMergeQueue {
+			return constants.MergeQueueIcon + " Queued"
+		}
 		if pr.Data.Primary.IsDraft {
 			return constants.DraftIcon + " Draft"
 		} else {

--- a/internal/tui/constants/constants.go
+++ b/internal/tui/constants/constants.go
@@ -52,6 +52,7 @@ const (
 	VerticalCommitIcon = "󰜘"
 	LabelsIcon         = "󰌖"
 	MergedIcon         = ""
+	MergeQueueIcon     = "" // \uf4db nf-oct-git_merge_queue
 	OpenIcon           = ""
 	SelectionIcon      = "❯"
 


### PR DESCRIPTION
# Summary

Display a yellow queue icon in the state column when a PR is in the merge queue.

## How did you test this change?

Ran unit tests and ran locally through using standalong `gh-dash` and gh extension `gh dash`

## Images/Videos
<img width="37" height="140" alt="image" src="https://github.com/user-attachments/assets/45eea6a4-949a-4b46-872d-030b5cb62735" />
<br>
<img width="150" height="45" alt="image" src="https://github.com/user-attachments/assets/b42952ab-1385-4926-b33a-341093cb50b9" />

