### PR TITLE
fix: issue assign keybinding

### DIFF
--- a/internal/tui/components/issueview/action_test.go
+++ b/internal/tui/components/issueview/action_test.go
@@ -46,7 +46,7 @@ func TestUpdateReturnsCorrectActions(t *testing.T) {
 		expectedAction IssueActionType
 	}{
 		{"label key", "L", IssueActionLabel},
-		// Note: IssueKeys.Assign has no default binding in issueKeys.go
+		{"assign key", "a", IssueActionAssign},
 		{"unassign key", "A", IssueActionUnassign},
 		{"comment key", "c", IssueActionComment},
 		{"close key", "x", IssueActionClose},

--- a/internal/tui/keys/issueKeys.go
+++ b/internal/tui/keys/issueKeys.go
@@ -25,6 +25,10 @@ var IssueKeys = IssueKeyMap{
 		key.WithKeys("L"),
 		key.WithHelp("L", "label"),
 	),
+	Assign: key.NewBinding(
+		key.WithKeys("a"),
+		key.WithHelp("a", "assign"),
+	),
 	Unassign: key.NewBinding(
 		key.WithKeys("A"),
 		key.WithHelp("A", "unassign"),


### PR DESCRIPTION
# Summary

It seems a past code change inadvertently removed the `Assign` keybinding. Documentation describes teh `a` keybinding to assign an issue. 

## How did you test this change?

build, test, lint + manual verification of behavior

## Images/Videos

Fixes #748 
