### PR TITLE
fix: use correct label for low filter in gh-dash.yml

### DIFF
--- a/.gh-dash.yml
+++ b/.gh-dash.yml
@@ -26,7 +26,7 @@ issuesSections:
   - title: Mid
     filters: repo:dlvhdr/gh-dash is:open sort:reactions label:mid-pri
   - title: Low
-    filters: repo:dlvhdr/gh-dash is:open sort:reactions label:mid-pri
+    filters: repo:dlvhdr/gh-dash is:open sort:reactions label:low-pri
   - title: Unlabeled
     filters: repo:dlvhdr/gh-dash is:open sort:reactions -label:bug -label:feat
   - title: All


### PR DESCRIPTION
# Summary

fixes #765 by replacing `label:mid-pri` with `label:low-pri` to correctly filter by `low-pri` label in Low view

## How did you test this change?

1. ran gh-dash
2. checked that Low section in issues contains issues with the `low-pri` label