### PR TITLE
fix: use Repository.HtmlUrl for notification URLs instead of hardcoding github.com

### DIFF
--- a/internal/data/notificationapi.go
+++ b/internal/data/notificationapi.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -78,9 +79,9 @@ func (n NotificationData) GetNumber() int {
 }
 
 func (n NotificationData) GetUrl() string {
-	// Convert API URL to HTML URL
-	// API URL: https://api.github.com/repos/owner/repo/pulls/123
-	// HTML URL: https://github.com/owner/repo/pull/123
+	if n.Repository.HtmlUrl != "" {
+		return strings.TrimRight(n.Repository.HtmlUrl, "/")
+	}
 	return fmt.Sprintf("https://github.com/%s", n.Repository.FullName)
 }
 

--- a/internal/data/notificationapi_test.go
+++ b/internal/data/notificationapi_test.go
@@ -109,3 +109,61 @@ func TestFindBestWorkflowRunMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestNotificationDataGetUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     NotificationData
+		expected string
+	}{
+		{
+			name: "uses HtmlUrl from repository",
+			data: NotificationData{
+				Repository: NotificationRepository{
+					FullName: "owner/repo",
+					HtmlUrl:  "https://github.com/owner/repo",
+				},
+			},
+			expected: "https://github.com/owner/repo",
+		},
+		{
+			name: "uses GHE host from HtmlUrl",
+			data: NotificationData{
+				Repository: NotificationRepository{
+					FullName: "org/repo",
+					HtmlUrl:  "https://ghe.company.com/org/repo",
+				},
+			},
+			expected: "https://ghe.company.com/org/repo",
+		},
+		{
+			name: "trims trailing slash from HtmlUrl",
+			data: NotificationData{
+				Repository: NotificationRepository{
+					FullName: "org/repo",
+					HtmlUrl:  "https://ghe.company.com/org/repo/",
+				},
+			},
+			expected: "https://ghe.company.com/org/repo",
+		},
+		{
+			name: "falls back to github.com when HtmlUrl is empty",
+			data: NotificationData{
+				Repository: NotificationRepository{
+					FullName: "owner/repo",
+					HtmlUrl:  "",
+				},
+			},
+			expected: "https://github.com/owner/repo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.data.GetUrl()
+			if result != tt.expected {
+				t.Errorf("GetUrl() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/tui/components/notificationrow/data_test.go
+++ b/internal/tui/components/notificationrow/data_test.go
@@ -170,6 +170,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -185,6 +186,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -200,6 +202,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -215,6 +218,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -230,6 +234,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -245,6 +250,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -256,10 +262,11 @@ func TestGetUrl(t *testing.T) {
 				Notification: data.NotificationData{
 					Subject: data.NotificationSubject{
 						Type: "CheckSuite",
-						Url:  "", // GitHub API returns null for CheckSuite subject.url
+						Url:  "",
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -271,10 +278,11 @@ func TestGetUrl(t *testing.T) {
 				Notification: data.NotificationData{
 					Subject: data.NotificationSubject{
 						Type: "CheckSuite",
-						Url:  "", // GitHub API returns null for CheckSuite subject.url
+						Url:  "",
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 				ResolvedUrl: "https://github.com/owner/repo/actions/runs/12345678",
@@ -291,6 +299,7 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "owner/repo",
+						HtmlUrl:  "https://github.com/owner/repo",
 					},
 				},
 			},
@@ -306,10 +315,109 @@ func TestGetUrl(t *testing.T) {
 					},
 					Repository: data.NotificationRepository{
 						FullName: "my-org/my-repo",
+						HtmlUrl:  "https://github.com/my-org/my-repo",
 					},
 				},
 			},
 			expected: "https://github.com/my-org/my-repo/pull/1",
+		},
+		// GitHub Enterprise tests
+		{
+			name: "GHE: PullRequest uses enterprise host",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "PullRequest",
+						Url:  "https://ghe.company.com/api/v3/repos/org/repo/pulls/42",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "org/repo",
+						HtmlUrl:  "https://ghe.company.com/org/repo",
+					},
+				},
+			},
+			expected: "https://ghe.company.com/org/repo/pull/42",
+		},
+		{
+			name: "GHE: Issue uses enterprise host",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "Issue",
+						Url:  "https://ghe.company.com/api/v3/repos/org/repo/issues/99",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "org/repo",
+						HtmlUrl:  "https://ghe.company.com/org/repo",
+					},
+				},
+			},
+			expected: "https://ghe.company.com/org/repo/issues/99",
+		},
+		{
+			name: "GHE: CheckSuite uses enterprise host",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "CheckSuite",
+						Url:  "",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "org/repo",
+						HtmlUrl:  "https://ghe.company.com/org/repo",
+					},
+				},
+			},
+			expected: "https://ghe.company.com/org/repo/actions",
+		},
+		{
+			name: "GHE: unknown type falls back to enterprise repo URL",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "UnknownType",
+						Url:  "",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "org/repo",
+						HtmlUrl:  "https://ghe.company.com/org/repo",
+					},
+				},
+			},
+			expected: "https://ghe.company.com/org/repo",
+		},
+		{
+			name: "GHE: HtmlUrl with trailing slash is trimmed",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "PullRequest",
+						Url:  "https://ghe.company.com/api/v3/repos/org/repo/pulls/1",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "org/repo",
+						HtmlUrl:  "https://ghe.company.com/org/repo/",
+					},
+				},
+			},
+			expected: "https://ghe.company.com/org/repo/pull/1",
+		},
+		// Fallback when HtmlUrl is empty
+		{
+			name: "empty HtmlUrl falls back to github.com",
+			data: Data{
+				Notification: data.NotificationData{
+					Subject: data.NotificationSubject{
+						Type: "PullRequest",
+						Url:  "https://api.github.com/repos/owner/repo/pulls/7",
+					},
+					Repository: data.NotificationRepository{
+						FullName: "owner/repo",
+						HtmlUrl:  "",
+					},
+				},
+			},
+			expected: "https://github.com/owner/repo/pull/7",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Use `Repository.HtmlUrl` from the GitHub API as the base for notification URLs instead of hardcoding `https://github.com`, fixing “open in browser” on GitHub Enterprise instances
- Fall back to `https://github.com/<FullName>` if `HtmlUrl` is empty (defensive, shouldn't happen in practice)
- Add GHE-specific test cases and tests for `NotificationData.GetUrl()`

Fixes https://github.com/dlvhdr/gh-dash/issues/778