### PR TITLE
feat: add option to copy using osc52

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 require (
 	github.com/alecthomas/chroma/v2 v2.19.0 // indirect
 	github.com/aymanbagabas/git-module v1.8.4-0.20231101154130-8d27204ac6d2
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/cli/browser v1.3.0 // indirect

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -325,6 +325,7 @@ type Config struct {
 	Theme                    *ThemeConfig                 `yaml:"theme,omitempty" validate:"omitempty"`
 	Pager                    Pager                        `yaml:"pager"`
 	ConfirmQuit              bool                         `yaml:"confirmQuit"`
+	OscClipboard             bool                         `yaml:"oscClipboard"`
 	ShowAuthorIcons          bool                         `yaml:"showAuthorIcons,omitempty"`
 	SmartFilteringAtLaunch   bool                         `yaml:"smartFilteringAtLaunch" default:"true"`
 	IncludeReadNotifications bool                         `yaml:"includeReadNotifications" default:"true"`

--- a/internal/tui/modelUtils.go
+++ b/internal/tui/modelUtils.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/aymanbagabas/go-osc52/v2"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	log "github.com/charmbracelet/log"
@@ -25,6 +26,19 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/markdown"
 )
+
+func oscCopy(text string) error {
+	s := osc52.New(text)
+
+	if _, ok := os.LookupEnv("TMUX"); ok {
+		s = s.Tmux()
+	} else if _, ok := os.LookupEnv("STY"); ok {
+		s = s.Screen()
+	}
+
+	_, err := s.WriteTo(os.Stdout)
+	return err
+}
 
 func (m *Model) getCurrSection() section.Section {
 	sections := m.getCurrentViewSections()

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -304,7 +304,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			}
 			number := fmt.Sprint(currRowData.GetNumber())
-			err := clipboard.WriteAll(number)
+			var err error
+			if m.ctx.Config.OscClipboard {
+				err = oscCopy(number)
+			} else {
+				err = clipboard.WriteAll(number)
+			}
 			if err != nil {
 				cmd = m.notifyErr(fmt.Sprintf("Failed copying to clipboard %v", err))
 			} else {
@@ -319,7 +324,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, cmd
 			}
 			url := currRowData.GetUrl()
-			err := clipboard.WriteAll(url)
+			var err error
+			if m.ctx.Config.OscClipboard {
+				err = oscCopy(url)
+			} else {
+				err = clipboard.WriteAll(url)
+			}
 			if err != nil {
 				cmd = m.notifyErr(fmt.Sprintf("Failed copying to clipboard %v", err))
 			} else {


### PR DESCRIPTION
# Summary
  - Add \`oscClipboard\` config option to enable OSC 52 clipboard support for headless/remote machines
  - When enabled, the copy number (y) and copy url (Y) keybindings use OSC 52 escape sequences instead of system clipboard
  - Supports tmux and screen terminal multiplexers

  Fixes #559

  ## How did you test this change?
  - [x] Enabled \`oscClipboard: true\` in config
  - [x] Verified copying works via tmux/screen to local clipboard
  - [x] Verified default behavior still uses system clipboard

# Images/Screenshots
N/A