### PR TITLE
fix date syntax in docs

### DIFF
--- a/docs/src/content/docs/configuration/issue-section.mdx
+++ b/docs/src/content/docs/configuration/issue-section.mdx
@@ -45,7 +45,7 @@ For example:
     is:open
     involves:@me
     -author:@me
-    updated>={{ nowModify "-2w" }}
+    updated:>={{ nowModify "-2w" }}
 ```
 
 For more information about writing filters for searching GitHub, see [Searching].

--- a/docs/src/content/docs/configuration/pr-section.mdx
+++ b/docs/src/content/docs/configuration/pr-section.mdx
@@ -45,7 +45,7 @@ For example:
     is:open
     involves:@me
     -author:@me
-    updated>={{ nowModify "-2w" }}
+    updated:>={{ nowModify "-2w" }}
 ```
 
 For more information about writing filters for searching GitHub, see [Searching].

--- a/docs/src/content/docs/configuration/searching.mdx
+++ b/docs/src/content/docs/configuration/searching.mdx
@@ -20,7 +20,7 @@ prsSections:
     filter: >-
       is:open
       -author:@me
-      updated>={{ nowModify "-2w" }}
+      updated:>={{ nowModify "-2w" }}
 ```
 
 Note: don't specify `is:pr` for this setting. The dashboard always adds that filter for PR
@@ -40,7 +40,7 @@ In addition to GitHub's filters, gh-dash adds templating functions.
 
 The `nowModify` function helps you calculate relative dates in the ISO-8601 format (which is what GitHub expects).
 
-Given the date today is 2025-02-02, a search filter of `updated>={{ nowModify "-1mo" }}` will output `updated>=2025-01-02`.
+Given the date today is 2025-02-02, a search filter of `updated:>={{ nowModify "-1mo" }}` will output `updated:>=2025-01-02`.
 
 A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as `1w`, `-8h` or `1mo2w`.
 

--- a/docs/src/data/schemas/issue-section.yaml
+++ b/docs/src/data/schemas/issue-section.yaml
@@ -59,7 +59,7 @@ properties:
             is:open
             involves:@me
             -author:@me
-            updated>={{ nowModify "-2w" }}
+            updated:>={{ nowModify "-2w" }}
         ```
 
         For more information about writing filters for searching GitHub, see [Searching].

--- a/docs/src/data/schemas/pr-section.yaml
+++ b/docs/src/data/schemas/pr-section.yaml
@@ -59,7 +59,7 @@ properties:
             is:open
             involves:@me
             -author:@me
-            updated>={{ nowModify "-2w" }}
+            updated:>={{ nowModify "-2w" }}
         ```
 
         For more information about writing filters for searching GitHub, see [Searching].


### PR DESCRIPTION
# Summary

The docs have several examples in the format `updated>=SOMEDATE`, but it should actually be `updated:>=SOMEDATE`.