### PR TITLE
fix: ensure marked-as-Done notifications don’t unexpectedly resurface

### DIFF
--- a/internal/data/donestore.go
+++ b/internal/data/donestore.go
@@ -86,10 +86,10 @@ func (s *DoneStore) load() error {
 	return nil
 }
 
-// prune removes stale entries on load. It deletes entries older than 14 days
+// prune removes stale entries on load. It deletes entries older than 90 days
 // and zero-time entries (legacy format with no timestamp).
 func (s *DoneStore) prune() {
-	cutoff := time.Now().Add(-14 * 24 * time.Hour)
+	cutoff := time.Now().Add(-90 * 24 * time.Hour)
 	for id, t := range s.entries {
 		if t.IsZero() || t.Before(cutoff) {
 			delete(s.entries, id)

--- a/internal/data/donestore_test.go
+++ b/internal/data/donestore_test.go
@@ -292,7 +292,7 @@ func TestDoneStore(t *testing.T) {
 		}
 	})
 
-	t.Run("prune removes entries older than 14 days", func(t *testing.T) {
+	t.Run("prune removes entries older than 90 days", func(t *testing.T) {
 		pruneFile := filepath.Join(tempDir, "prune.json")
 		now := time.Now().UTC().Truncate(time.Second)
 
@@ -302,11 +302,11 @@ func TestDoneStore(t *testing.T) {
 		}
 
 		// Entries at various ages
-		store.entries["fresh"] = now.Add(-1 * 24 * time.Hour)    // 1 day old
-		store.entries["border"] = now.Add(-13 * 24 * time.Hour)  // 13 days old
-		store.entries["expired"] = now.Add(-15 * 24 * time.Hour) // 15 days old
-		store.entries["ancient"] = now.Add(-30 * 24 * time.Hour) // 30 days old
-		store.entries["legacy"] = time.Time{}                    // zero time (legacy)
+		store.entries["fresh"] = now.Add(-1 * 24 * time.Hour)     // 1 day old
+		store.entries["border"] = now.Add(-89 * 24 * time.Hour)   // 89 days old
+		store.entries["expired"] = now.Add(-91 * 24 * time.Hour)  // 91 days old
+		store.entries["ancient"] = now.Add(-180 * 24 * time.Hour) // 180 days old
+		store.entries["legacy"] = time.Time{}                     // zero time (legacy)
 
 		if err := store.Flush(); err != nil {
 			t.Fatalf("Flush failed: %v", err)
@@ -326,15 +326,15 @@ func TestDoneStore(t *testing.T) {
 			t.Error("1-day-old entry should be kept")
 		}
 		if _, ok := store2.entries["border"]; !ok {
-			t.Error("13-day-old entry should be kept")
+			t.Error("89-day-old entry should be kept")
 		}
 
 		// Expired entries should be pruned
 		if _, ok := store2.entries["expired"]; ok {
-			t.Error("15-day-old entry should be pruned")
+			t.Error("91-day-old entry should be pruned")
 		}
 		if _, ok := store2.entries["ancient"]; ok {
-			t.Error("30-day-old entry should be pruned")
+			t.Error("180-day-old entry should be pruned")
 		}
 
 		// Legacy (zero-time) entries should be pruned

--- a/internal/data/donestore_testing.go
+++ b/internal/data/donestore_testing.go
@@ -1,0 +1,23 @@
+package data
+
+import (
+	"time"
+)
+
+// NewDoneStoreForTesting creates a DoneStore backed by the given file path.
+func NewDoneStoreForTesting(filePath string) *DoneStore {
+	return &DoneStore{
+		entries:  make(map[string]time.Time),
+		filePath: filePath,
+	}
+}
+
+// OverrideDoneStoreForTesting replaces the singleton DoneStore with the given
+// store. It returns a function that restores the original store.
+func OverrideDoneStoreForTesting(store *DoneStore) func() {
+	// Ensure the singleton is initialized so sync.Once has fired.
+	GetDoneStore()
+	old := doneStore
+	doneStore = store
+	return func() { doneStore = old }
+}

--- a/internal/tui/components/notificationssection/DESIGN.md
+++ b/internal/tui/components/notificationssection/DESIGN.md
@@ -14,7 +14,8 @@ internal/
 │   ├── notificationapi.go       # GitHub API interactions for notifications
 │   ├── bookmarks.go             # Local bookmark storage (singleton)
 │   ├── donestore.go             # Timestamp-based Done tracking (singleton)
-│   └── donestore_test.go        # Tests for Done store
+│   ├── donestore_test.go        # Tests for Done store
+│   └── donestore_testing.go     # Test helpers (create/override DoneStore)
 ├── tui/
 │   ├── keys/
 │   │   └── notificationKeys.go  # Key bindings specific to notifications
@@ -187,7 +188,7 @@ When marking a notification as Done, the store records the notification’s curr
 - Backward-compatible: loads the legacy format (plain JSON array of IDs) used by older versions; legacy entries are assigned the zero time and pruned on load
 - Persists across sessions and application restarts
 
-**Pruning:** On load, the DoneStore removes stale entries, to prevent the file from growing indefinitely. GitHub only retains Done-marked notifications for about 1 week, so entries older than 14 days (1 week + 1 week safety margin) are dead weight — the API won’t return those notifications anymore. Zero-time entries (from the legacy format) are also pruned, since removing them from the store has the same effect as keeping them: `IsDone` returns false either way, so active notifications still resurface.
+**Pruning:** On load, the DoneStore removes stale entries, to prevent the file from growing indefinitely. Entries older than 90 days are pruned — because those are unlikely to still appear in API responses. Zero-time entries (from the legacy format) are also pruned, since removing them from the store has the same effect as keeping them: `IsDone` returns false either way, so active notifications still resurface.
 
 **Pagination with local filtering:** Because Done notifications are filtered out locally after fetching from the API, a single page of results may yield very few visible notifications. To handle this, the fetch logic automatically requests additional pages from the API until the requested limit is reached or all pages are exhausted. This ensures users see a full page of results even when many notifications have been marked as Done.
 
@@ -219,7 +220,7 @@ The `UpdateNotificationMsg` and `UpdateNotificationReadStateMsg` types propagate
 Notification commands are organized in `commands.go`, following the pattern established by `prssection` (which has `checkout.go`, `diff.go`). Commands fall into two categories:
 
 **Section methods** — Commands that operate on section state and are invoked via key handling in the section's `Update` method:
-- `markAsDone()` — Marks the current notification as Done (persists ID + `updated_at` timestamp to DoneStore)
+- `markAsDone()` — Marks the current notification as Done (persists ID + `updated_at` timestamp to DoneStore). Important: This captures `updatedAt` _by value before_ the closure — because `GetCurrNotification()` returns a pointer into the `Notifications` slice, which may shift when other notifications are removed concurrently.
 - `markAllAsDone()` — Marks all visible notifications as Done (persists each ID + `updated_at` to DoneStore)
 - `markAsRead()` — Marks the current notification as read
 - `markAllAsRead()` — Marks all notifications as read
@@ -450,5 +451,5 @@ This async resolution uses the existing `UpdateNotificationUrlMsg` message type,
 - **Mark as Unread**: GitHub's REST API does not support marking notifications as unread, so this feature is not available. Bookmarks provide a workaround by keeping items visible in the inbox.
 - **Discussion/Release Content**: Only PR and Issue notifications can display detailed content in the sidebar; other types open directly in the browser.
 - **Local State Persistence**: Bookmarks and Done status are stored locally (`~/.local/state/gh-dash/`) and are not synced across machines or with GitHub.
-- **Done Notifications in API**: GitHub’s “mark as Done” doesn’t delete notifications — they still appear in API responses with `all=true`. We track Done IDs with timestamps locally to filter them out and detect new activity. Entries older than 14 days are pruned on startup.
+- **Done Notifications in API**: GitHub’s “mark as Done” doesn’t delete notifications — they still appear in API responses with `all=true`. We track Done IDs with timestamps locally to filter them out and detect new activity. Entries older than 90 days are pruned on startup.
 - **Server-Side Reason Filtering**: GitHub's notification API does not support filtering by reason on the server side. Reason filters are applied client-side after fetching notifications, which means all notifications are fetched before filtering.

--- a/internal/tui/components/notificationssection/commands.go
+++ b/internal/tui/components/notificationssection/commands.go
@@ -17,6 +17,10 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
+// markNotificationDoneFunc is the function used to mark a notification as done
+// via the GitHub API. It is a variable so tests can override it.
+var markNotificationDoneFunc = data.MarkNotificationDone
+
 func (m *Model) markAsDone() tea.Cmd {
 	notification := m.GetCurrNotification()
 	if notification == nil {
@@ -24,6 +28,7 @@ func (m *Model) markAsDone() tea.Cmd {
 	}
 
 	notificationId := notification.GetId()
+	updatedAt := notification.Notification.UpdatedAt
 	taskId := fmt.Sprintf("notification_done_%s", notificationId)
 	task := context.Task{
 		Id:           taskId,
@@ -34,10 +39,10 @@ func (m *Model) markAsDone() tea.Cmd {
 	}
 	startCmd := m.Ctx.StartTask(task)
 	return tea.Batch(startCmd, func() tea.Msg {
-		err := data.MarkNotificationDone(notificationId)
+		err := markNotificationDoneFunc(notificationId)
 		if err == nil {
 			// Persist to done store so it stays hidden across sessions
-			data.GetDoneStore().MarkDone(notificationId, notification.Notification.UpdatedAt)
+			data.GetDoneStore().MarkDone(notificationId, updatedAt)
 		}
 		return constants.TaskFinishedMsg{
 			SectionId:   m.Id,

--- a/internal/tui/components/notificationssection/commands_test.go
+++ b/internal/tui/components/notificationssection/commands_test.go
@@ -1,11 +1,16 @@
 package notificationssection
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
@@ -106,4 +111,94 @@ func TestCheckoutPRErrorMessage(t *testing.T) {
 	if err.Error() != expectedMsg {
 		t.Errorf("CheckoutPR() error = %q, want %q", err.Error(), expectedMsg)
 	}
+}
+
+// TestMarkAsDoneStoresCorrectTimestamp is a regression test for a
+// pointer-aliasing bug that occurred in markAsDone().
+//
+// GetCurrNotification() returns &m.Notifications[idx], a pointer into the
+// Notifications slice. When the closure later dereferences this pointer to
+// read UpdatedAt, the slice may have been modified (element removed via
+// append), causing the pointer to reference a different notification's data.
+//
+// The fix captures UpdatedAt by value before the closure. This test verifies
+// that the correct timestamp reaches the DoneStore even when the slice is
+// modified between command creation and execution.
+func TestMarkAsDoneStoresCorrectTimestamp(t *testing.T) {
+	// Mock the API call to succeed without network access.
+	origFunc := markNotificationDoneFunc
+	markNotificationDoneFunc = func(string) error { return nil }
+	defer func() { markNotificationDoneFunc = origFunc }()
+
+	// Set up a DoneStore backed by a temp file so we don't touch real state.
+	tempDir, err := os.MkdirTemp("", "gh-dash-markdone-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	store := data.NewDoneStoreForTesting(filepath.Join(tempDir, "done.json"))
+	restoreStore := data.OverrideDoneStoreForTesting(store)
+	defer restoreStore()
+
+	t1 := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 20, 15, 30, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 8, 0, 0, 0, time.UTC)
+
+	// Build a minimal Model. A zero-value Table has cursor at index 0,
+	// so GetCurrNotification() returns &m.Notifications[0].
+	m := Model{
+		Notifications: []notificationrow.Data{
+			{Notification: data.NotificationData{Id: "notif-A", UpdatedAt: t1}},
+			{Notification: data.NotificationData{Id: "notif-B", UpdatedAt: t2}},
+			{Notification: data.NotificationData{Id: "notif-C", UpdatedAt: t3}},
+		},
+		sessionMarkedDone: make(map[string]bool),
+		sessionMarkedRead: make(map[string]bool),
+	}
+	m.Ctx = &context.ProgramContext{
+		StartTask: noopStartTask,
+	}
+
+	// Step 1: Call markAsDone(). This captures notif-A's ID and UpdatedAt
+	// by value, before the closure.
+	cmd := m.markAsDone()
+	if cmd == nil {
+		t.Fatal("markAsDone() returned nil cmd")
+	}
+
+	// Step 2: Simulate the race — remove notif-A from the slice.
+	// This shifts notif-B into position 0 and notif-C into position 1.
+	// If the closure had captured a pointer instead of a value, it would
+	// now read notif-B's UpdatedAt (t2) instead of notif-A's (t1).
+	m.Notifications = append(m.Notifications[:0], m.Notifications[1:]...)
+
+	// Step 3: Execute the command. tea.Batch returns a BatchMsg containing
+	// the inner cmds; execute each one.
+	batchMsg := cmd()
+	if cmds, ok := batchMsg.(tea.BatchMsg); ok {
+		for _, c := range cmds {
+			if c != nil {
+				c()
+			}
+		}
+	}
+
+	// Step 4: Verify the DoneStore received notif-A's original timestamp (t1),
+	// not notif-B's (t2), which is what the shifted pointer would have read.
+	if !store.IsDone("notif-A", t1) {
+		t.Error("DoneStore should have notif-A marked done at t1")
+	}
+	// If the bug were present, t2 would have been stored instead of t1.
+	// In that case, IsDone("notif-A", t1) would still return true (t1 <= t2),
+	// but IsDone with a time between t1 and t2 would incorrectly return true.
+	// Use a more precise check: mark done at t1 means t1+1s should resurface
+	// only if the stored timestamp is exactly t1.
+	justAfterT1 := t1.Add(1 * time.Second)
+	if store.IsDone("notif-A", justAfterT1) {
+		t.Error("notif-A should resurface for activity after t1 (stored timestamp should be exactly t1)")
+	}
+	// That is the critical assertion: if the pointer-aliasing bug were present,
+	// t2 would be stored, and activity at justAfterT1 would _not_ resurface
+	// (because justAfterT1 < t2). The test would fail here.
 }


### PR DESCRIPTION
**Bug:** Notifications resurface immediately after being marked as Done.

**Cause:** The `markAsDone` closure captured the notification pointer returned by `GetCurrNotification()`, which points into the `Notifications` slice. When multiple mark-as-Done operations run concurrently, the `TaskFinishedMsg` handler removes notifications from the slice via `append` — shifting elements, and causing the pointer to reference a _different_ notification's data. That resulted in wrong `UpdatedAt` timestamps being stored in the Done store.

**Fix:** Capture `UpdatedAt` as a `time.Time value` (copied by value) _before_ the closure — matching how `notificationId` is already captured.

Also increases the DoneStore pruning cutoff from 14 days to 90 days. GitHub can retain Done-marked notifications for much longer than the previously assumed ~1 week, so entries were being pruned on startup and then resurfacing.