### PR TITLE
feat: support git worktrees when checking out PRs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -75,6 +75,7 @@ export default defineConfig({
             "configuration/issue-section",
             "configuration/notification-section",
             "configuration/repo-paths",
+            "configuration/worktree-paths",
             "configuration/keybindings",
             "configuration/theme",
             "configuration/reusing",

--- a/docs/src/assets/custom-commands.yml
+++ b/docs/src/assets/custom-commands.yml
@@ -30,6 +30,7 @@ keybindings:
         '
 repoPaths:
   dlvhdr/*: ~/code/personal/*
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/assets/demo.yml
+++ b/docs/src/assets/demo.yml
@@ -25,6 +25,7 @@ defaults:
 keybindings:
   prs: []
 repoPaths: {}
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/assets/sections.yml
+++ b/docs/src/assets/sections.yml
@@ -19,6 +19,7 @@ defaults:
 keybindings:
   prs: []
 repoPaths: {}
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/assets/theme-catpuccin.yml
+++ b/docs/src/assets/theme-catpuccin.yml
@@ -19,6 +19,7 @@ defaults:
 keybindings:
   prs: []
 repoPaths: {}
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/assets/theme-gruvbox.yml
+++ b/docs/src/assets/theme-gruvbox.yml
@@ -19,6 +19,7 @@ defaults:
 keybindings:
   prs: []
 repoPaths: {}
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/assets/theme-tokyonight.yml
+++ b/docs/src/assets/theme-tokyonight.yml
@@ -19,6 +19,7 @@ defaults:
 keybindings:
   prs: []
 repoPaths: {}
+worktreePaths: {}
 pager:
   diff: diffnav
 theme:

--- a/docs/src/content/docs/configuration/worktree-paths.mdx
+++ b/docs/src/content/docs/configuration/worktree-paths.mdx
@@ -1,0 +1,165 @@
+---
+title: Worktree Paths
+---
+
+By default, pressing <kbd>C</kbd> or <kbd>Space</kbd> in dash switches [branches](https://git-scm.com/docs/gitglossary#def_branch) in a repo’s [clone directory](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-emltdirectorygtem) (i.e., a directory that was created by running `git clone`).
+
+If you work on or review multiple PRs at once, switching among branches means stashing or committing in-progress changes every time you switch. And if you need to build, it means completely rebuilding every time you switch.
+
+The `worktreePaths` setting enables instead what the git docs call [linked worktree](https://git-scm.com/docs/git-worktree) checkouts: Each PR gets its own linked worktree in a separate (sub)directory — so you can have multiple PRs checked out at once without interfering with each other.
+
+:::note
+The rest of the documentation in this section uses the word _worktree_ on its own to refer to what the git docs calls a _linked worktree_.
+:::
+
+You can easily and quickly switch among and run multiple builds from separate worktrees — without needing to rebuild each time you switch.
+
+## How it works
+
+Every git repo has exactly one **clone directory** (either a “normal” clone with a main branch checked out, or a [bare clone](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---bare)) and zero or more **worktrees**. `git worktree add` creates worktrees, and must be run from within the clone directory. That’s why two config settings are involved:
+
+- **`repoPaths`:** points to the **clone directory** where `git worktree add` gets run
+- **`worktreePaths`:** points to a **worktrees directory** where worktrees are created as subdirectories, one per PR branch
+
+:::note
+Your clone directory and worktrees directory may be the same directory.
+:::
+
+:::caution
+To use `worktreePaths` for a repository or for a template pattern, you _must_ also configure `repoPaths` for the same repository or template pattern. Without `repoPaths`, dash doesn’t know where the clone directory is and can’t create worktrees.
+:::
+
+Both settings use the same path-matching syntax: exact matches, wildcard matches (`owner/*`), and template matches (`:owner/:repo`). See [Repo Paths](/configuration/repo-paths).
+
+If a repository matches both `repoPaths` and `worktreePaths`, dash creates worktrees rather than switching branches in the clone directory.
+
+## Examples
+
+### Worktrees as direct subdirs inside clone dir
+
+```yaml
+repoPaths:
+  myorg/some-repo: ~/repos/some-repo
+
+worktreePaths:
+  myorg/some-repo: ~/repos/some-repo
+```
+
+Checking out a PR with branch `fix/memory-leak` creates a worktree at `~/repos/some-repo/fix/memory-leak`.
+
+### Worktrees in same subdir inside clone dir
+
+```yaml
+repoPaths:
+  myorg/some-repo: ~/repos/some-repo
+
+worktreePaths:
+  myorg/some-repo: ~/repos/some-repo/.worktrees
+```
+
+Checking out a PR with branch `fix/memory-leak` creates a worktree at `~/repos/some-repo/.worktrees/fix/memory-leak`.
+
+### Worktrees in “cousin” directory of clone dir
+
+```yaml
+repoPaths:
+  torvalds/*: ~/repos/torvalds/*
+
+worktreePaths:
+  torvalds/*: ~/worktrees/torvalds/*
+```
+
+Checking out a PR with branch `fix/memory-leak` from `torvalds/linux` creates a worktree at `~/worktrees/torvalds/linux/fix/memory-leak`. The clone directory at `~/repos/torvalds/linux` is unchanged.
+
+:::note
+Placing a project’s worktree directories outside the project’s clone directory is useful when you want clean separation — or when you _need_ it (for example, if the project code would otherwise not compile if you build from within a subdirectory).
+
+And if you follow a general policy of having a `~/repos/` (or whatever) tree that _only_ contains clones — and no worktrees — and a `~/worktrees/` (or whatever) directory that contains temporary PR checkouts, then:
+
+- that makes it easy to clean up your worktrees by just doing something like `rm -rf ~/worktrees/*` — without touching your clones
+- that lets you apply different backup or sync rules — since worktrees are essentially disposable
+
+:::
+
+### Mixed: some repos use worktrees, others don’t
+
+```yaml
+repoPaths:
+  myorg/some-repo: ~/repos/some-repo
+  myorg/lib-*: ~/repos/myorg/*
+
+worktreePaths:
+  myorg/lib-*: ~/worktrees/myorg/*
+```
+
+Here, `myorg/some-repo` uses regular checkout (switching branches in the clone directory), while any `myorg/lib-*` repository creates worktrees.
+
+### Inside-direct-subdirs template catch-all
+
+```yaml
+repoPaths:
+  :owner/:repo: ~/repos/:repo
+
+worktreePaths:
+  :owner/:repo: ~/repos/:repo
+```
+
+Any repository gets worktrees created under `~/repos/<repo>/<branch>`.
+
+### Inside-same-subdir template catch-all
+
+```yaml
+repoPaths:
+  :owner/:repo: ~/repos/:repo
+
+worktreePaths:
+  :owner/:repo: ~/repos/:repo/.worktrees
+```
+
+Any repository gets worktrees created under `~/repos/<repo>/.worktreess/<branch>`.
+
+### Bare-repository workflow
+
+Some people prefer to clone repos as [bare repos](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---bare), and create each branch (including the main branch) as a worktree — with a layout like this:
+
+```
+~/repos/gh-dash/
+  .bare/       # git clone --bare ... .bare
+  .git         # file containing: gitdir: .bare
+  main/        # worktree for the main branch
+  feat/thing/  # worktree for a feature branch
+```
+
+That works with dash as long as `repoPaths` points not to a `.bare` directory but to an actual clone directory (one containing a `.bare`/`.git` directory):
+
+```yaml
+repoPaths:
+  dlvhdr/gh-dash: ~/repos/gh-dash
+
+worktreePaths:
+  dlvhdr/gh-dash: ~/repos/gh-dash
+```
+
+Checking out a PR with branch `fix/memory-leak` creates a worktree at
+`~/repos/gh-dash/fix/memory-leak` — alongside the other worktrees.
+
+## Behavior details
+
+- **New PR:** Creates a worktree from a PR branch.
+- **Existing worktree:** Skips creation, copies the path to your clipboard.
+- **Checkout failure:** Auto-removes the partially-created worktree.
+- **Repo not cloned:** Shows error asking you to clone the repository first.
+- **Missing `repoPaths`:** Shows error explaining: both settings are required.
+
+On success, the path to the worktree is copied to your clipboard.
+
+## Cleaning up
+
+Git won’t let you delete a branch that’s checked out in a worktree. To clean up:
+
+```bash
+git worktree remove <path>   # remove the worktree
+git branch -D <branch>       # then delete the branch
+```
+
+If you’ve already deleted the directory manually, run `git worktree prune` before deleting the branch.

--- a/docs/src/content/docs/getting-started/keybindings/selected-pr.mdx
+++ b/docs/src/content/docs/getting-started/keybindings/selected-pr.mdx
@@ -49,14 +49,19 @@ To submit the comment on the PR, press <kbd>Ctrl</kbd>+<kbd>d</kbd>. To cancel t
 
 ## `C` - Checkout PR
 
-Press <kbd>C</kbd> to checkout the PR locally. The dashboard checks for the `repoPaths` key in your
-configuration to find the repository on your local filesystem.
+Press <kbd>C</kbd> to checkout the PR locally. The dashboard checks for the `worktreePaths` and
+`repoPaths` keys in your configuration to find the repository on your local filesystem.
+`worktreePaths` takes priority if the repository matches both.
 
-The dashboard errors if you haven't defined `repoPaths` in your configuration or if the dashboard
-can't determine where the repository for this PR is located using that setting.
+The dashboard errors if you haven't defined `repoPaths` or `worktreePaths` in your configuration
+or if the dashboard can't determine where the repository for this PR is located using those settings.
 
-If the dashboard is able to locate the repository for the PR on your local filesystem, it uses the
-`gh pr checkout` command to checkout the PR locally.
+If the repository matches a `worktreePaths` entry, the dashboard creates a
+[git worktree](https://git-scm.com/docs/git-worktree) for the PR branch and copies the path to
+your clipboard. See [Worktree Paths](/configuration/worktree-paths) for details.
+
+Otherwise, the dashboard uses the `gh pr checkout` command to checkout the PR locally in the
+directory specified by `repoPaths`.
 
 ## `d` - View PR Diff
 

--- a/docs/src/data/schemas/gh-dash.yaml
+++ b/docs/src/data/schemas/gh-dash.yaml
@@ -169,6 +169,63 @@ properties:
             If the key for an `repoPath` entry doesn't have a wildcard (`*`), its value must not
             have a wildcard. If a key ends without a wildcard but the value does, `gh-dash` won't
             be able to correctly map repositories to folders.
+  worktreePaths:
+    title: Worktree Path Map
+    description: Key-value pairs that match repositories to parent directories for linked worktree checkouts.
+    schematize:
+      weight: 5
+      details: |
+        You can use the `worktreePaths` setting to map repository names (as keys) to local
+        parent directories (as values) for linked worktree checkouts. When a repository
+        matches a `worktreePaths` entry, pressing checkout creates a linked worktree
+        (via `git worktree add`) named after the PR branch, instead of switching branches
+        in the main worktree.
+
+        The path mappings use the same syntax as `repoPaths`: exact matches, wildcard matches
+        (`owner/*`), and template matches (`:owner/:repo`).
+
+        `worktreePaths` requires `repoPaths` to also be configured for the same repository.
+        `repoPaths` points to the main worktree (the clone), which is where
+        `git worktree add` runs. `worktreePaths` specifies a parent directory where linked
+        worktrees are created as subdirectories.
+
+        If a repository matches both `repoPaths` and `worktreePaths`, the checkout creates
+        a linked worktree instead of switching branches in the main worktree.
+
+        The linked worktree-path is copied to the clipboard on success.
+      skip_schema_render: true
+      example_format: yaml
+    type: object
+    examples:
+      - schematize:
+          title: Worktree Paths
+          details: |
+            In this example, the first key uses a wildcard to create worktrees for any repository
+            in the `torvalds` namespace under `~/worktrees/torvalds/`. The second key uses the
+            `:owner/:repo` template as a catch-all for any repository.
+        torvalds/*: ~/worktrees/torvalds/*
+        :owner/:repo: ~/worktrees/:owner/:repo
+    patternProperties:
+      '\*$':
+        type: string
+        pattern: '\*$'
+        title: With a Wildcard
+        description: >-
+          If the repo name (key) includes an asterisk, the path (value) must too.
+        schematize:
+          href: worktree-ends-with-wildcard
+          no_pattern_in_heading: true
+          weight: 1
+      '^[^\*]+$':
+        type: string
+        pattern: '^[^\*]+$'
+        title: Without a Wildcard
+        description: >-
+          If the repo name (key) doesn't include an asterisk, the path (value) can't either.
+        schematize:
+          href: worktree-no-asterisks
+          no_pattern_in_heading: true
+          weight: 2
   keybindings:
     title: Keybindings
     description: Define keybindings to run shell commands.

--- a/docs/src/pages/schema.json.ts
+++ b/docs/src/pages/schema.json.ts
@@ -82,6 +82,34 @@ export function GET() {
             },
           },
         },
+        worktreePaths: {
+          title: "Worktree Path Map",
+          description:
+            "Key-value pairs that match repositories to parent directories for linked worktree checkouts. Requires repoPaths to also be configured.",
+          type: "object",
+          examples: [
+            {
+              "torvalds/*": "~/worktrees/torvalds/*",
+              ":owner/:repo": "~/worktrees/:owner/:repo",
+            },
+          ],
+          patternProperties: {
+            "\\*$": {
+              type: "string",
+              pattern: "\\*$",
+              title: "With a Wildcard",
+              description:
+                "If the repo name (key) includes an asterisk, the path (value) must too.",
+            },
+            "^[^\\*]+$": {
+              type: "string",
+              pattern: "^[^\\*]+$",
+              title: "Without a Wildcard",
+              description:
+                "If the repo name (key) doesn't include an asterisk, the path (value) can't either.",
+            },
+          },
+        },
         keybindings: {
           title: "Keybindings",
           description: "Define keybindings to run shell commands.",

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -323,6 +323,7 @@ type Config struct {
 	Defaults                 Defaults                     `yaml:"defaults"`
 	Keybindings              Keybindings                  `yaml:"keybindings"`
 	RepoPaths                map[string]string            `yaml:"repoPaths"`
+	WorktreePaths            map[string]string            `yaml:"worktreePaths"`
 	Theme                    *ThemeConfig                 `yaml:"theme,omitempty"           validate:"omitempty"`
 	Pager                    Pager                        `yaml:"pager"`
 	ConfirmQuit              bool                         `yaml:"confirmQuit"`
@@ -481,7 +482,8 @@ func (parser ConfigParser) getDefaultConfig() Config {
 			Issues:    []Keybinding{},
 			Prs:       []Keybinding{},
 		},
-		RepoPaths: map[string]string{},
+		RepoPaths:     map[string]string{},
+		WorktreePaths: map[string]string{},
 		Theme: &ThemeConfig{
 			Ui: UIThemeConfig{
 				SectionsShowCount: true,

--- a/internal/config/testdata/global-config.golden.yml
+++ b/internal/config/testdata/global-config.golden.yml
@@ -126,6 +126,7 @@ keybindings:
   branches: []
 repoPaths:
   dlvhdr/*: ~/code/personal/*
+worktreePaths: {}
 theme:
   ui:
     sectionsShowCount: true

--- a/internal/config/testdata/merged-config.golden.yml
+++ b/internal/config/testdata/merged-config.golden.yml
@@ -119,6 +119,7 @@ keybindings:
         gh issue open --repo {{.RepoName}} {{.PrNumber}}
 repoPaths:
   dlvhdr/*: ~/code/personal/*
+worktreePaths: {}
 theme:
   ui:
     sectionsShowCount: true

--- a/internal/tui/common/checkout.go
+++ b/internal/tui/common/checkout.go
@@ -1,0 +1,179 @@
+package common
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
+)
+
+// CheckoutTask mirrors the fields needed from context.Task to avoid
+// an import cycle (context already imports common).
+type CheckoutTask struct {
+	Id           string
+	StartText    string
+	FinishedText string
+}
+
+// CheckoutParams holds the parameters for a PR checkout.
+type CheckoutParams struct {
+	RepoPaths     map[string]string
+	WorktreePaths map[string]string
+	StartTask     func(task CheckoutTask) tea.Cmd
+	PRNumber      int
+	RepoName      string
+	BranchName    string
+}
+
+// RunCommandFunc is the function used to execute shell commands.
+// It is a variable so tests can override it.
+var RunCommandFunc = func(name string, args []string, dir string) error {
+	c := exec.Command(name, args...)
+	c.Dir = dir
+	var stderr bytes.Buffer
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+		return err
+	}
+	return nil
+}
+
+// ExpandTilde replaces a leading ~ with the user's home directory.
+func ExpandTilde(path string) string {
+	if strings.HasPrefix(path, "~") {
+		userHomeDir, _ := os.UserHomeDir()
+		return strings.Replace(path, "~", userHomeDir, 1)
+	}
+	return path
+}
+
+// CheckoutPR checks out a PR using either worktree or regular checkout,
+// depending on config.
+func CheckoutPR(params CheckoutParams) (tea.Cmd, error) {
+	// Check worktreePaths first (priority over repoPaths)
+	if wtParent, ok := GetRepoLocalPath(params.RepoName, params.WorktreePaths); ok {
+		// worktreePaths requires repoPaths to also be configured (for the repo root)
+		repoRoot, repoOk := GetRepoLocalPath(params.RepoName, params.RepoPaths)
+		if !repoOk {
+			return nil, errors.New(
+				"worktreePaths is configured but repoPaths is not; both are required for worktree checkout",
+			)
+		}
+		return checkoutWorktree(params, repoRoot, wtParent)
+	}
+
+	// Fall back to regular checkout via repoPaths
+	if repoPath, ok := GetRepoLocalPath(params.RepoName, params.RepoPaths); ok {
+		return checkoutRegular(params, repoPath)
+	}
+
+	return nil, errors.New(
+		"local path to repo not specified, set one in your config.yml under repoPaths or worktreePaths",
+	)
+}
+
+func checkoutRegular(params CheckoutParams, repoPath string) (tea.Cmd, error) {
+	taskId := fmt.Sprintf("checkout_%d", params.PRNumber)
+	task := CheckoutTask{
+		Id:           taskId,
+		StartText:    fmt.Sprintf("Checking out PR #%d", params.PRNumber),
+		FinishedText: fmt.Sprintf("PR #%d has been checked out at %s", params.PRNumber, repoPath),
+	}
+	startCmd := params.StartTask(task)
+	return tea.Batch(startCmd, func() tea.Msg {
+		expandedPath := ExpandTilde(repoPath)
+		err := RunCommandFunc(
+			"gh",
+			[]string{"pr", "checkout", fmt.Sprint(params.PRNumber)},
+			expandedPath,
+		)
+		return constants.TaskFinishedMsg{TaskId: taskId, Err: err}
+	}), nil
+}
+
+func checkoutWorktree(params CheckoutParams, repoRoot string, wtParent string) (tea.Cmd, error) {
+	expandedRoot := ExpandTilde(repoRoot)
+	expandedParent := ExpandTilde(wtParent)
+
+	// Verify the repo root is a git repo
+	gitDir := filepath.Join(expandedRoot, ".git")
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf(
+			"%s is not a git repository, clone it first", expandedRoot)
+	}
+
+	// Determine worktree directory name
+	dirName := params.BranchName
+	if dirName == "" {
+		dirName = fmt.Sprintf("pr-%d", params.PRNumber)
+	}
+	wtPath := filepath.Join(expandedParent, dirName)
+
+	taskId := fmt.Sprintf("checkout_worktree_%d", params.PRNumber)
+	task := CheckoutTask{
+		Id:        taskId,
+		StartText: fmt.Sprintf("Checking out PR #%d into worktree", params.PRNumber),
+		FinishedText: fmt.Sprintf(
+			"PR #%d checked out into worktree (path copied to clipboard)",
+			params.PRNumber,
+		),
+	}
+	startCmd := params.StartTask(task)
+
+	return tea.Batch(startCmd, func() tea.Msg {
+		// If worktree already exists, skip creation
+		if _, err := os.Stat(wtPath); err == nil {
+			_ = clipboard.WriteAll(wtPath)
+			return constants.TaskFinishedMsg{TaskId: taskId, Err: nil}
+		}
+
+		// Ensure the worktree parent directory exists
+		if err := os.MkdirAll(expandedParent, 0o755); err != nil {
+			return constants.TaskFinishedMsg{
+				TaskId: taskId,
+				Err:    fmt.Errorf("create worktree directory: %w", err),
+			}
+		}
+
+		// Create a detached worktree
+		err := RunCommandFunc(
+			"git",
+			[]string{"worktree", "add", "--detach", wtPath, "HEAD"},
+			expandedRoot,
+		)
+		if err != nil {
+			return constants.TaskFinishedMsg{
+				TaskId: taskId,
+				Err:    fmt.Errorf("git worktree add: %w", err),
+			}
+		}
+
+		// Check out the PR inside the new worktree
+		err = RunCommandFunc("gh", []string{"pr", "checkout", fmt.Sprint(params.PRNumber)}, wtPath)
+		if err != nil {
+			// Clean up the worktree on failure
+			_ = RunCommandFunc("git", []string{"worktree", "remove", wtPath}, expandedRoot)
+			return constants.TaskFinishedMsg{
+				TaskId: taskId,
+				Err:    fmt.Errorf("gh pr checkout: %w", err),
+			}
+		}
+
+		// Copy path to clipboard (ignore errors)
+		_ = clipboard.WriteAll(wtPath)
+
+		return constants.TaskFinishedMsg{TaskId: taskId, Err: nil}
+	}), nil
+}

--- a/internal/tui/common/checkout_test.go
+++ b/internal/tui/common/checkout_test.go
@@ -1,0 +1,361 @@
+package common_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/common"
+)
+
+func noopStartTask(_ common.CheckoutTask) tea.Cmd {
+	return nil
+}
+
+func TestCheckoutPR_RegularFlow(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    common.CheckoutParams
+		wantErr   bool
+		wantNil   bool
+		errSubstr string
+	}{
+		{
+			name: "returns error when no path configured",
+			params: common.CheckoutParams{
+				RepoPaths:     map[string]string{},
+				WorktreePaths: map[string]string{},
+				StartTask:     noopStartTask,
+				PRNumber:      123,
+				RepoName:      "owner/repo",
+				BranchName:    "fix/bug",
+			},
+			wantErr:   true,
+			wantNil:   true,
+			errSubstr: "repoPaths or worktreePaths",
+		},
+		{
+			name: "returns cmd when repoPaths configured",
+			params: common.CheckoutParams{
+				RepoPaths:     map[string]string{"owner/repo": "/path/to/repo"},
+				WorktreePaths: map[string]string{},
+				StartTask:     noopStartTask,
+				PRNumber:      123,
+				RepoName:      "owner/repo",
+				BranchName:    "fix/bug",
+			},
+			wantErr: false,
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, err := common.CheckoutPR(tt.params)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantNil && cmd != nil {
+				t.Error("expected nil cmd")
+			}
+			if !tt.wantNil && cmd == nil {
+				t.Error("expected non-nil cmd")
+			}
+		})
+	}
+}
+
+// executeBatchCmd calls the cmd and handles both BatchMsg (when startTask returns
+// a non-nil cmd) and direct TaskFinishedMsg (when startTask returns nil).
+func executeBatchCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	switch m := msg.(type) {
+	case tea.BatchMsg:
+		for _, c := range m {
+			if c != nil {
+				c()
+			}
+		}
+	default:
+		// Single cmd case (Batch optimized away nil startCmd)
+		_ = m
+	}
+}
+
+// makeRepoDir creates a temp directory with a .git subdirectory to simulate a git repo.
+func makeRepoDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestCheckoutPR_WorktreeFlow(t *testing.T) {
+	t.Run("creates worktree and checks out PR", func(t *testing.T) {
+		origRunCmd := common.RunCommandFunc
+		defer func() { common.RunCommandFunc = origRunCmd }()
+
+		repoDir := makeRepoDir(t)
+		wtParent := t.TempDir()
+
+		var commands []string
+		common.RunCommandFunc = func(name string, args []string, dir string) error {
+			commands = append(commands, name+" "+strings.Join(args, " ")+" ["+dir+"]")
+			return nil
+		}
+
+		cmd, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/cool",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cmd == nil {
+			t.Fatal("expected non-nil cmd")
+		}
+
+		executeBatchCmd(t, cmd)
+
+		expectedWtPath := filepath.Join(wtParent, "feat/cool")
+		if len(commands) < 2 {
+			t.Fatalf("expected at least 2 commands, got %d: %v", len(commands), commands)
+		}
+		// git worktree add should run from the repo root
+		if !strings.Contains(commands[0], "git worktree add --detach "+expectedWtPath+" HEAD") {
+			t.Errorf("first command should be git worktree add, got: %s", commands[0])
+		}
+		if !strings.Contains(commands[0], "["+repoDir+"]") {
+			t.Errorf("git worktree add should run in repo root %s, got: %s", repoDir, commands[0])
+		}
+		// gh pr checkout should run from the new worktree path
+		if !strings.Contains(commands[1], "gh pr checkout 42") {
+			t.Errorf("second command should be gh pr checkout, got: %s", commands[1])
+		}
+		if !strings.Contains(commands[1], "["+expectedWtPath+"]") {
+			t.Errorf(
+				"gh pr checkout should run in worktree %s, got: %s",
+				expectedWtPath,
+				commands[1],
+			)
+		}
+	})
+
+	t.Run("skips creation when worktree already exists", func(t *testing.T) {
+		origRunCmd := common.RunCommandFunc
+		defer func() { common.RunCommandFunc = origRunCmd }()
+
+		repoDir := makeRepoDir(t)
+		wtParent := t.TempDir()
+		// Pre-create the worktree directory
+		wtPath := filepath.Join(wtParent, "feat/existing")
+		if err := os.MkdirAll(wtPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		var commands []string
+		common.RunCommandFunc = func(name string, args []string, dir string) error {
+			commands = append(commands, name+" "+strings.Join(args, " "))
+			return nil
+		}
+
+		cmd, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/existing",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		executeBatchCmd(t, cmd)
+
+		for _, c := range commands {
+			if strings.Contains(c, "worktree add") {
+				t.Errorf("should not run git worktree add, but got: %s", c)
+			}
+		}
+	})
+
+	t.Run("errors when repo root is not a git repo", func(t *testing.T) {
+		repoDir := t.TempDir() // No .git directory
+		wtParent := t.TempDir()
+
+		_, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/cool",
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "clone it first") {
+			t.Errorf("error %q should contain %q", err.Error(), "clone it first")
+		}
+	})
+
+	t.Run("errors when worktreePaths set but repoPaths missing", func(t *testing.T) {
+		wtParent := t.TempDir()
+
+		_, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/cool",
+		})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "repoPaths is not") {
+			t.Errorf("error %q should mention repoPaths requirement", err.Error())
+		}
+	})
+
+	t.Run("cleans up worktree on gh pr checkout failure", func(t *testing.T) {
+		origRunCmd := common.RunCommandFunc
+		defer func() { common.RunCommandFunc = origRunCmd }()
+
+		repoDir := makeRepoDir(t)
+		wtParent := t.TempDir()
+
+		var commands []string
+		common.RunCommandFunc = func(name string, args []string, dir string) error {
+			cmd := name + " " + strings.Join(args, " ")
+			commands = append(commands, cmd)
+			// Fail the gh pr checkout command
+			if name == "gh" && len(args) > 0 && args[0] == "pr" {
+				return fmt.Errorf("checkout failed")
+			}
+			return nil
+		}
+
+		cmd, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/broken",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		executeBatchCmd(t, cmd)
+
+		foundRemove := false
+		for _, c := range commands {
+			if strings.Contains(c, "worktree remove") {
+				foundRemove = true
+				break
+			}
+		}
+		if !foundRemove {
+			t.Errorf("expected git worktree remove to be called, commands: %v", commands)
+		}
+	})
+
+	t.Run("worktreePaths takes priority over repoPaths", func(t *testing.T) {
+		origRunCmd := common.RunCommandFunc
+		defer func() { common.RunCommandFunc = origRunCmd }()
+
+		repoDir := makeRepoDir(t)
+		wtParent := t.TempDir()
+
+		var commands []string
+		common.RunCommandFunc = func(name string, args []string, dir string) error {
+			commands = append(commands, name+" "+strings.Join(args, " "))
+			return nil
+		}
+
+		cmd, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "feat/priority",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cmd == nil {
+			t.Fatal("expected non-nil cmd")
+		}
+
+		executeBatchCmd(t, cmd)
+
+		if len(commands) == 0 {
+			t.Fatal("expected commands to be run")
+		}
+		// Should use worktree flow (git worktree add), not regular flow (gh pr checkout directly)
+		if !strings.Contains(commands[0], "git worktree add") {
+			t.Errorf("expected worktree flow, got: %s", commands[0])
+		}
+	})
+
+	t.Run("falls back to pr-N when branch name empty", func(t *testing.T) {
+		origRunCmd := common.RunCommandFunc
+		defer func() { common.RunCommandFunc = origRunCmd }()
+
+		repoDir := makeRepoDir(t)
+		wtParent := t.TempDir()
+
+		var commands []string
+		common.RunCommandFunc = func(name string, args []string, dir string) error {
+			commands = append(commands, name+" "+strings.Join(args, " ")+" ["+dir+"]")
+			return nil
+		}
+
+		cmd, err := common.CheckoutPR(common.CheckoutParams{
+			RepoPaths:     map[string]string{"owner/repo": repoDir},
+			WorktreePaths: map[string]string{"owner/repo": wtParent},
+			StartTask:     noopStartTask,
+			PRNumber:      42,
+			RepoName:      "owner/repo",
+			BranchName:    "",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		executeBatchCmd(t, cmd)
+
+		expectedWtPath := filepath.Join(wtParent, "pr-42")
+		if len(commands) < 1 {
+			t.Fatal("expected at least 1 command")
+		}
+		if !strings.Contains(commands[0], expectedWtPath) {
+			t.Errorf("expected path containing %s, got: %s", expectedWtPath, commands[0])
+		}
+	})
+}

--- a/internal/tui/components/notificationssection/commands.go
+++ b/internal/tui/components/notificationssection/commands.go
@@ -1,11 +1,8 @@
 package notificationssection
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -264,37 +261,25 @@ func (m *Model) openInBrowser() tea.Cmd {
 
 // CheckoutPR checks out a PR. This is a standalone function that can be called
 // from ui.go with the PR details from the notification view.
-func CheckoutPR(ctx *context.ProgramContext, prNumber int, repoName string) (tea.Cmd, error) {
-	repoPath, ok := common.GetRepoLocalPath(repoName, ctx.Config.RepoPaths)
-	if !ok {
-		return nil, errors.New(
-			"local path to repo not specified, set one in your config.yml under repoPaths",
-		)
-	}
-
-	taskId := fmt.Sprintf("checkout_%d", prNumber)
-	task := context.Task{
-		Id:           taskId,
-		StartText:    fmt.Sprintf("Checking out PR #%d", prNumber),
-		FinishedText: fmt.Sprintf("PR #%d has been checked out at %s", prNumber, repoPath),
-		State:        context.TaskStart,
-		Error:        nil,
-	}
-	startCmd := ctx.StartTask(task)
-	return tea.Batch(startCmd, func() tea.Msg {
-		c := exec.Command(
-			"gh",
-			"pr",
-			"checkout",
-			fmt.Sprint(prNumber),
-		)
-		userHomeDir, _ := os.UserHomeDir()
-		if strings.HasPrefix(repoPath, "~") {
-			repoPath = strings.Replace(repoPath, "~", userHomeDir, 1)
-		}
-
-		c.Dir = repoPath
-		err := c.Run()
-		return constants.TaskFinishedMsg{TaskId: taskId, Err: err}
-	}), nil
+func CheckoutPR(
+	ctx *context.ProgramContext,
+	prNumber int,
+	repoName string,
+	branchName string,
+) (tea.Cmd, error) {
+	return common.CheckoutPR(common.CheckoutParams{
+		RepoPaths:     ctx.Config.RepoPaths,
+		WorktreePaths: ctx.Config.WorktreePaths,
+		StartTask: func(ct common.CheckoutTask) tea.Cmd {
+			return ctx.StartTask(context.Task{
+				Id:           ct.Id,
+				StartText:    ct.StartText,
+				FinishedText: ct.FinishedText,
+				State:        context.TaskStart,
+			})
+		},
+		PRNumber:   prNumber,
+		RepoName:   repoName,
+		BranchName: branchName,
+	})
 }

--- a/internal/tui/components/notificationssection/commands_test.go
+++ b/internal/tui/components/notificationssection/commands_test.go
@@ -75,7 +75,7 @@ func TestCheckoutPR(t *testing.T) {
 				StartTask: noopStartTask,
 			}
 
-			cmd, err := CheckoutPR(ctx, tt.prNumber, tt.repoName)
+			cmd, err := CheckoutPR(ctx, tt.prNumber, tt.repoName, "some-branch")
 
 			if tt.wantErr && err == nil {
 				t.Errorf("CheckoutPR() error = nil, want error")
@@ -101,13 +101,13 @@ func TestCheckoutPRErrorMessage(t *testing.T) {
 		StartTask: noopStartTask,
 	}
 
-	_, err := CheckoutPR(ctx, 123, "owner/repo")
+	_, err := CheckoutPR(ctx, 123, "owner/repo", "some-branch")
 
 	if err == nil {
 		t.Fatal("CheckoutPR() expected error, got nil")
 	}
 
-	expectedMsg := "local path to repo not specified, set one in your config.yml under repoPaths"
+	expectedMsg := "local path to repo not specified, set one in your config.yml under repoPaths or worktreePaths"
 	if err.Error() != expectedMsg {
 		t.Errorf("CheckoutPR() error = %q, want %q", err.Error(), expectedMsg)
 	}

--- a/internal/tui/components/prssection/checkout.go
+++ b/internal/tui/components/prssection/checkout.go
@@ -2,57 +2,38 @@ package prssection
 
 import (
 	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/common"
-	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prrow"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
 func (m *Model) checkout() (tea.Cmd, error) {
-	pr := m.GetCurrRow()
-	if pr == nil {
+	row := m.GetCurrRow()
+	if row == nil {
 		return nil, errors.New("no pr selected")
 	}
 
-	repoName := pr.GetRepoNameWithOwner()
-	repoPath, ok := common.GetRepoLocalPath(repoName, m.Ctx.Config.RepoPaths)
-
+	pr, ok := row.(*prrow.Data)
 	if !ok {
-		return nil, errors.New(
-			"local path to repo not specified, set one in your config.yml under repoPaths",
-		)
+		return nil, errors.New("unexpected row data type")
 	}
 
-	prNumber := pr.GetNumber()
-	taskId := fmt.Sprintf("checkout_%d", prNumber)
-	task := context.Task{
-		Id:           taskId,
-		StartText:    fmt.Sprintf("Checking out PR #%d", prNumber),
-		FinishedText: fmt.Sprintf("PR #%d has been checked out at %s", prNumber, repoPath),
-		State:        context.TaskStart,
-		Error:        nil,
-	}
-	startCmd := m.Ctx.StartTask(task)
-	return tea.Batch(startCmd, func() tea.Msg {
-		c := exec.Command(
-			"gh",
-			"pr",
-			"checkout",
-			fmt.Sprint(m.GetCurrRow().GetNumber()),
-		)
-		userHomeDir, _ := os.UserHomeDir()
-		if strings.HasPrefix(repoPath, "~") {
-			repoPath = strings.Replace(repoPath, "~", userHomeDir, 1)
-		}
-
-		c.Dir = repoPath
-		err := c.Run()
-		return constants.TaskFinishedMsg{TaskId: taskId, Err: err}
-	}), nil
+	return common.CheckoutPR(common.CheckoutParams{
+		RepoPaths:     m.Ctx.Config.RepoPaths,
+		WorktreePaths: m.Ctx.Config.WorktreePaths,
+		StartTask: func(ct common.CheckoutTask) tea.Cmd {
+			return m.Ctx.StartTask(context.Task{
+				Id:           ct.Id,
+				StartText:    ct.StartText,
+				FinishedText: ct.FinishedText,
+				State:        context.TaskStart,
+			})
+		},
+		PRNumber:   pr.GetNumber(),
+		RepoName:   pr.GetRepoNameWithOwner(),
+		BranchName: pr.Primary.HeadRefName,
+	})
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -518,7 +518,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						case prview.PRActionCheckout:
 							if pr := m.notificationView.GetSubjectPR(); pr != nil {
 								cmd, _ = notificationssection.CheckoutPR(
-									m.ctx, pr.GetNumber(), pr.GetRepoNameWithOwner())
+									m.ctx, pr.GetNumber(), pr.GetRepoNameWithOwner(),
+									pr.Primary.HeadRefName)
 							}
 							return m, cmd
 


### PR DESCRIPTION
Add a new `worktreePaths` config key that enables [linked worktree](https://git-scm.com/docs/git-worktree) checkouts. When a repository matches a `worktreePaths` entry, pressing <kbd>C</kbd> or <kbd>Space</kbd> (checkout) creates a linked worktree named after the PR branch — rather than switching branches in the clone directory. Fixes https://github.com/dlvhdr/gh-dash/issues/544.

### How it works

- **`repoPaths`** → the **clone directory** where `git worktree add` gets run
- **`worktreePaths`** → a **worktrees directory** where linked worktrees are created as subdirectories, one per PR branch

Both must be configured for the same repository or template pattern. Example:

```yaml
repoPaths:
  dlvhdr/gh-dash: ~/code/dlvhdr/gh-dash

worktreePaths:
  dlvhdr/gh-dash: ~/code/dlvhdr/gh-dash/.worktrees
```

### Behavior

- **New PR:** Creates a linked worktree and checks out the PR branch inside it
- **Existing worktree:** Skips creation, copies the path to the clipboard
- **Checkout failure:** Automatically cleans up the partially created worktree
- **Repo not cloned:** Shows an error asking to clone the repository first
- **Missing `repoPaths`:** Shows an error explaining that both settings are required
- **Command errors:** stderr is now captured and included in error messages (previously only showed “exit status 1”)

On success, the linked-worktree path is copied to the clipboard.

> [!NOTE]
> This all also works in **[bare repo](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---bare)** worktree workflows (where even the main branch is a linked worktree), as long as `repoPaths` points not to a `.bare` directory but to an actual clone directory _containing_ a `.bare`|`.git` directory.

### Code/test/docs/config notes

- Extracts checkout logic into a shared `common.CheckoutPR()` function used by both the PR and Notification dashboards (previously duplicated)
- Passes on, to the UI, more-detailed error messages from gh/git for checkout failures (`RunCommandFunc` now captures stderr from gh/git)
- Adds user docs, and updates the config parser, JSON/YAML schemas, example configs, and golden test files to add `worktreePaths`
- Adds test coverage for all the new behavior and possible error/failure scenarios