### PR TITLE
fix: prevent “strings: negative Repeat count” panic when sidebar is narrow

### DIFF
--- a/internal/tui/components/prview/checks.go
+++ b/internal/tui/components/prview/checks.go
@@ -280,6 +280,9 @@ func (m *Model) viewChecksBar() string {
 	}
 	// subtract number of spacers
 	w -= numSections - 1
+	if w < 0 {
+		w = 0
+	}
 
 	sections := make([]string, 0)
 	if stats.failed > 0 {

--- a/internal/tui/components/prview/checks_test.go
+++ b/internal/tui/components/prview/checks_test.go
@@ -498,3 +498,32 @@ func TestGetChecksStats_Mixed(t *testing.T) {
 	require.Equal(t, 2, stats.inProgress,
 		"expected 2 in progress, got: %d", stats.inProgress)
 }
+
+func TestViewChecksBar_NarrowWidth_NoPanic(t *testing.T) {
+	// Regression test for https://github.com/dlvhdr/gh-dash/issues/795
+	// When the sidebar is very narrow, viewChecksBar() computes a negative
+	// width for strings.Repeat, which panics.
+	opts := checksTestOptions{
+		checkSuites: data.CheckSuites{
+			TotalCount: 0,
+			Nodes:      []data.CheckSuiteNode{},
+		},
+		checkRuns: []data.CheckRun{
+			makeCheckRun("build", "COMPLETED", "FAILURE"),
+			makeCheckRun("lint", "COMPLETED", "SUCCESS"),
+			makeCheckRun("test", "IN_PROGRESS", ""),
+		},
+		rollupState: "FAILURE",
+	}
+
+	m := newTestModelForChecks(t, opts)
+
+	// Simulate a very narrow sidebar that would make w negative
+	for _, width := range []int{0, 1, 5, 10} {
+		m.width = width
+		// Should not panic
+		require.NotPanics(t, func() {
+			m.viewChecksBar()
+		}, "viewChecksBar panicked with width=%d", width)
+	}
+}


### PR DESCRIPTION
Bug: dash panics with “strings: negative Repeat count”

Cause: With a narrow-enough sidebar, viewChecksBar() computes a negative width for the progress-bar sections. That negative value gets passed to strings.Repeat(), which panics with “strings: negative Repeat count”.

Fix: Clamp the available width to zero, so when the sidebar is narrow, the bar just renders as empty — rather than causing a panic. Fixes https://github.com/dlvhdr/gh-dash/issues/795