### PR TITLE
fix: prevent panic when preview.open is false

### DIFF
--- a/internal/tui/components/sidebar/sidebar.go
+++ b/internal/tui/components/sidebar/sidebar.go
@@ -82,7 +82,7 @@ func (m *Model) GetSidebarContentWidth() int {
 	if m.ctx == nil || m.ctx.Config == nil {
 		return 0
 	}
-	return m.ctx.DynamicPreviewWidth - m.ctx.Styles.Sidebar.BorderWidth
+	return max(0, m.ctx.DynamicPreviewWidth-m.ctx.Styles.Sidebar.BorderWidth)
 }
 
 func (m *Model) ScrollToTop() {

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -1041,6 +1041,10 @@ func (m *Model) promptConfirmation(currSection section.Section, action string) t
 }
 
 func (m *Model) syncSidebar() tea.Cmd {
+	if !m.sidebar.IsOpen {
+		return nil
+	}
+
 	currRowData := m.getCurrRowData()
 	width := m.sidebar.GetSidebarContentWidth()
 	var cmd tea.Cmd

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -833,6 +833,74 @@ func TestSyncMainContentWidth(t *testing.T) {
 	}
 }
 
+func TestSyncSidebar_NoOpWhenSidebarClosed(t *testing.T) {
+	// Regression test for https://github.com/dlvhdr/gh-dash/issues/798
+	// When preview.open is false, DynamicPreviewWidth is 0, so
+	// GetSidebarContentWidth() returns 0. If syncSidebar() proceeds to
+	// render the PR view with that zero width, layout breaks.
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+	cfg.Defaults.Preview.Open = false
+
+	ctx := &context.ProgramContext{
+		Config:      &cfg,
+		ScreenWidth: 100,
+		View:        config.PRsView,
+		StartTask:   func(task context.Task) tea.Cmd { return nil },
+	}
+	ctx.Theme = theme.ParseTheme(ctx.Config)
+	ctx.Styles = context.InitStyles(ctx.Theme)
+
+	prSection := prssection.NewModel(
+		0,
+		ctx,
+		config.PrsSectionConfig{
+			Title:   "Test",
+			Filters: "is:open",
+		},
+		time.Now(),
+		time.Now(),
+	)
+	// Add a PR so getCurrRowData() returns non-nil, exercising the
+	// code path that would use the negative width without the guard.
+	prSection.Prs = []prrow.Data{
+		{Primary: &data.PullRequestData{Title: "test", State: "OPEN"}},
+	}
+
+	m := Model{
+		ctx:              ctx,
+		keys:             keys.Keys,
+		prs:              []section.Section{&prSection},
+		sidebar:          sidebar.NewModel(),
+		footer:           footer.NewModel(ctx),
+		tabs:             tabs.NewModel(ctx),
+		prView:           prview.NewModel(ctx),
+		issueSidebar:     issueview.NewModel(ctx),
+		branchSidebar:    branchsidebar.NewModel(ctx),
+		notificationView: notificationview.NewModel(ctx),
+	}
+
+	// sidebar.IsOpen defaults to false from NewModel(), matching preview.open: false
+	require.False(t, m.sidebar.IsOpen)
+	m.sidebar.UpdateProgramContext(ctx)
+
+	// Confirm the precondition: DynamicPreviewWidth is 0, so
+	// GetSidebarContentWidth returns 0 (no usable width).
+	require.Equal(t, 0, m.ctx.DynamicPreviewWidth)
+	require.Equal(t, 0, m.sidebar.GetSidebarContentWidth(),
+		"GetSidebarContentWidth should be 0 when DynamicPreviewWidth is 0")
+
+	// Without the early-return guard, syncSidebar would needlessly render
+	// the PR view with a zero-width sidebar.
+	require.NotPanics(t, func() {
+		cmd := m.syncSidebar()
+		require.Nil(t, cmd, "syncSidebar should return nil when sidebar is closed")
+	})
+}
+
 func TestPromptConfirmationForNotificationPR(t *testing.T) {
 	// Test that promptConfirmationForNotificationPR sets the pending action
 	// and displays the confirmation prompt in the footer.


### PR DESCRIPTION
**Bug:** dash panics with "strings: negative Repeat count" when the config has `preview.open` set to `false`.

**Cause:** When `preview.open` is `false`, `DynamicPreviewWidth` is 0 and `GetSidebarContentWidth()` returns a negative value (0 − BorderWidth). If `syncSidebar()` proceeds to render, that negative width propagates to `strings.Repeat()`, which panics on a negative count.

**Fix:** Clamp `GetSidebarContentWidth()` with `max(0, ...)` so callers never see a negative width (root cause), and add an early return in `syncSidebar()` when the sidebar is closed so it doesn't needlessly render with zero width (defense-in-depth). Fixes https://github.com/dlvhdr/gh-dash/issues/798.