### PR TITLE
feat: add bottom preview layout with P keybinding

### DIFF
--- a/docs/src/content/docs/configuration/defaults.mdx
+++ b/docs/src/content/docs/configuration/defaults.mdx
@@ -15,6 +15,8 @@ defaults:
   preview:
     open: true
     width: 0.45
+    height: 0.60
+    position: auto
   prsLimit: 20
   refetchIntervalMinutes: 30
   view: prs
@@ -22,7 +24,7 @@ defaults:
 
 By default, the dashboard is configured to:
 
-- Display the preview pane with a width of 45% for all work items.
+- Display the preview pane to the right at 45% width, or below at 40% height when the terminal is narrow.
 - Only fetch 20 PRs, issues, and notifications at a time for each section.
 - Display the PRs view when the dashboard loads.
 - Refetch PRs and issues for each section every 30 minutes.
@@ -129,7 +131,8 @@ This setting defines how many notifications the dashboard should fetch when:
 ### Preview Pane (`preview`)
 
 These settings define how the preview pane displays in the dashboard. You can specify
-whether the preview pane is open by default and how many columns wide it should be when
+whether the preview pane is open by default, its width (for right position), its height
+(for bottom position), and its position relative to the main content.
 
 #### Open on Load (`open`)
 
@@ -154,6 +157,35 @@ By default, the dashboard displays the preview pane.
 Specifies the width of the preview pane. You can set the size to the percentage of the terminal size by using fractions (e.g. 0.4 would be 40%).
 
 By default, the preview pane is 45% wide.
+
+#### Preview Pane Height (`height`)
+
+| Type   | Minimum | Default |
+| :----- | :-----: | :-----: |
+| Number |    0    |  0.60   |
+
+Specifies the height of the preview pane when it appears below the main content (in bottom
+position mode). You can set the size to a percentage of the terminal height by using
+fractions (e.g. 0.4 would be 40%). Values greater than 1 specify a fixed number of rows.
+
+By default, the preview pane height is 40%.
+
+#### Preview Pane Position (`position`)
+
+| Type   |        Options         | Default |
+| :----- | :--------------------: | :-----: |
+| String | `right`, `bottom`, `auto` | `auto`  |
+
+Specifies where the preview pane appears relative to the main content.
+
+- `right` — the preview pane appears to the right of the main content (vertical split).
+- `bottom` — the preview pane appears below the main content (horizontal split).
+- `auto` — automatically chooses `right` when the terminal is wide enough, and switches
+  to `bottom` when the main content would have fewer than 80 columns.
+
+You can toggle the position at runtime with the <kbd>P</kbd> key.
+
+By default, the position is `auto`.
 
 ### Refetch Interval in Minutes (`refetchIntervalMinutes`)
 

--- a/docs/src/content/docs/getting-started/keybindings/preview.mdx
+++ b/docs/src/content/docs/getting-started/keybindings/preview.mdx
@@ -12,6 +12,11 @@ summary: >-
 Press <kbd>p</kbd> to open the preview pane for the selected work item if it's hidden or hide the
 preview pane if it's visible.
 
+## `P` - Toggle Preview Position
+
+Press <kbd>P</kbd> (shift+p) to toggle the preview pane between the right side and bottom of the
+dashboard. In `auto` mode, resizing the terminal resets this override.
+
 ## `ctrl+d` - Preview Page Down
 
 Press <kbd>Ctrl</kbd>+<kbd>d</kbd> to shift the view for the preview pane down one step. The first line in

--- a/docs/src/data/schemas/defaults.yaml
+++ b/docs/src/data/schemas/defaults.yaml
@@ -100,9 +100,9 @@ properties:
       weight: 3
       skip_schema_render: true
       details: |
-        These settings define the how the preview pane displays in the dashboard. You can specify
-        whether the preview pane is open by default and how many columns wide it should be when
-        displayed.
+        These settings define how the preview pane displays in the dashboard. You can specify
+        whether the preview pane is open by default, its width (for right position), its height
+        (for bottom position), and its position relative to the main content.
     type: object
     properties:
       open:
@@ -132,6 +132,44 @@ properties:
         type: integer
         minimum: 1
         default: 50
+      height:
+        title: Preview Pane Height
+        description: Specifies the height of the preview pane when displayed at the bottom.
+        schematize:
+          weight: 3
+          details: |
+            Specifies how tall the preview pane should be when it appears below the main content
+            (in bottom position mode).
+
+            When set to a value between 0 and 1, specifies a percentage of the available
+            terminal height. When set to a value greater than 1, specifies a fixed number
+            of rows.
+
+            By default, the preview pane is 40% of the terminal height.
+        type: number
+        default: 0.60
+      position:
+        title: Preview Pane Position
+        description: Specifies where the preview pane is displayed relative to the main content.
+        schematize:
+          weight: 4
+          details: |
+            Specifies the position of the preview pane relative to the list of work items.
+
+            - `right`: The preview pane appears to the right of the main content (vertical split).
+            - `bottom`: The preview pane appears below the main content (horizontal split).
+            - `auto`: Automatically chooses `right` when the terminal is wide enough, and
+              switches to `bottom` when the main content would have fewer than 80 columns.
+
+            You can toggle the position at runtime with the `P` key.
+
+            By default, the position is `auto`.
+        type: string
+        enum:
+          - right
+          - bottom
+          - auto
+        default: "auto"
   refetchIntervalMinutes:
     title: Refetch Interval in Minutes
     description: Specifies how often to refetch PRs and Issues in minutes.

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -110,8 +110,10 @@ type NotificationsSectionConfig struct {
 }
 
 type PreviewConfig struct {
-	Open  bool
-	Width float64 `yaml:"width" validate:"gt=0"`
+	Open     bool
+	Width    float64 `yaml:"width"              validate:"gt=0"`
+	Height   float64 `yaml:"height,omitempty"`
+	Position string  `yaml:"position,omitempty"`
 }
 
 type NullableBool struct {
@@ -345,8 +347,10 @@ func (parser ConfigParser) getDefaultConfig() Config {
 	return Config{
 		Defaults: Defaults{
 			Preview: PreviewConfig{
-				Open:  true,
-				Width: 0.45,
+				Open:     true,
+				Width:    0.45,
+				Height:   0.60,
+				Position: "auto",
 			},
 			PrsLimit:               20,
 			PrApproveComment:       "LGTM",

--- a/internal/config/testdata/global-config.golden.yml
+++ b/internal/config/testdata/global-config.golden.yml
@@ -43,6 +43,8 @@ defaults:
   preview:
     open: true
     width: 60
+    height: 0.6
+    position: auto
   prsLimit: 5
   prApproveComment: LGTM
   issuesLimit: 5

--- a/internal/config/testdata/merged-config.golden.yml
+++ b/internal/config/testdata/merged-config.golden.yml
@@ -34,6 +34,8 @@ defaults:
   preview:
     open: true
     width: 80
+    height: 0.6
+    position: auto
   prsLimit: 100
   issuesLimit: 100
   notificationsLimit: 100

--- a/internal/tui/components/cmpcontroller/controller.go
+++ b/internal/tui/components/cmpcontroller/controller.go
@@ -348,9 +348,8 @@ func (c *Controller) Update(msg tea.Msg) (tea.Cmd, bool) {
 	}
 
 	c.inputBox, taCmd = c.inputBox.Update(msg)
-	cmds = append(cmds, taCmd)
 
-	return nil, false
+	return taCmd, false
 }
 
 func (c *Controller) LineFromBottom() int {

--- a/internal/tui/components/cmpcontroller/controller.go
+++ b/internal/tui/components/cmpcontroller/controller.go
@@ -145,6 +145,10 @@ func (c *Controller) SetWidth(width int) {
 	c.cmp.SetWidth(width)
 }
 
+func (c *Controller) Column() int {
+	return c.inputBox.Column()
+}
+
 func (c *Controller) CursorEnd() {
 	c.inputBox.CursorEnd()
 }
@@ -157,6 +161,7 @@ func (c *Controller) UpdateProgramContext(ctx *context.ProgramContext) {
 
 func (c *Controller) Exit() {
 	c.inputBox.Blur()
+	c.inputBox.CursorStart()
 	c.resetAutocompleteState()
 	c.mode = ModeNone
 	c.prompt = ""
@@ -170,6 +175,8 @@ func (c *Controller) Exit() {
 // todo make pinter
 func (c *Controller) Enter(opts EnterOptions) tea.Cmd {
 	c.inputBox.Reset()
+	c.inputBox.SetValue(opts.InitialValue)
+	c.CursorEnd()
 	c.resetAutocompleteState()
 	c.mode = opts.Mode
 	c.prompt = opts.Prompt
@@ -181,7 +188,6 @@ func (c *Controller) Enter(opts EnterOptions) tea.Cmd {
 
 	c.inputBox.SetPrompt(opts.Prompt)
 	c.inputBox.SetAutocompleteSource(opts.Source)
-	c.inputBox.SetValue(opts.InitialValue)
 
 	cmds := []tea.Cmd{textarea.Blink, c.inputBox.Focus()}
 
@@ -340,6 +346,9 @@ func (c *Controller) Update(msg tea.Msg) (tea.Cmd, bool) {
 		*c.cmp, acCmd = c.cmp.Update(msg)
 		return acCmd, c.Active() || c.suggestionKind != SuggestionNone
 	}
+
+	c.inputBox, taCmd = c.inputBox.Update(msg)
+	cmds = append(cmds, taCmd)
 
 	return nil, false
 }

--- a/internal/tui/components/inputbox/inputbox.go
+++ b/internal/tui/components/inputbox/inputbox.go
@@ -215,8 +215,16 @@ func (m *Model) GetAbsoluteCursorPosition() tea.Position {
 	return tea.Position{X: col, Y: line}
 }
 
+func (m *Model) CursorStart() {
+	m.textArea.CursorStart()
+}
+
 func (m *Model) CursorEnd() {
 	m.textArea.CursorEnd()
+}
+
+func (m *Model) Column() int {
+	return m.textArea.Column()
 }
 
 func (m *Model) LineFromBottom() int {

--- a/internal/tui/components/prview/prview.go
+++ b/internal/tui/components/prview/prview.go
@@ -215,7 +215,7 @@ func (m *Model) ViewCompletions() string {
 	return m.editor.ViewCompletions()
 }
 
-func (m *Model) InputBoxLineFromButton() int {
+func (m *Model) InputBoxLineFromBottom() int {
 	return m.editor.LineFromBottom()
 }
 

--- a/internal/tui/components/search/search.go
+++ b/internal/tui/components/search/search.go
@@ -29,11 +29,13 @@ func NewModel(ctx *context.ProgramContext, opts SearchOptions) Model {
 	base := lipgloss.NewStyle()
 	ta.SetStyles(textarea.Styles{
 		Focused: textarea.StyleState{
+			Base:        base,
 			Placeholder: lipgloss.NewStyle().Foreground(ctx.Theme.FaintText),
 			Prompt:      base.Foreground(ctx.Theme.SecondaryText),
 			Text:        base.Foreground(ctx.Theme.PrimaryText),
 		},
 		Blurred: textarea.StyleState{
+			Base:        base.Foreground(ctx.Theme.FaintText),
 			Placeholder: lipgloss.NewStyle().Foreground(ctx.Theme.FaintText),
 			Prompt:      base.Foreground(ctx.Theme.SecondaryText),
 			Text:        lipgloss.NewStyle().Foreground(ctx.Theme.FaintText),
@@ -49,6 +51,7 @@ func NewModel(ctx *context.ProgramContext, opts SearchOptions) Model {
 	// act as an input to allow reuse of autocomplete
 	ta.MaxHeight = 1
 	ta.SetHeight(1)
+	ta.MaxWidth = -1
 
 	ta.ShowLineNumbers = false
 	ta.Blur()
@@ -70,10 +73,6 @@ func NewModel(ctx *context.ProgramContext, opts SearchOptions) Model {
 	return m
 }
 
-func (m Model) Init() tea.Cmd {
-	return nil
-}
-
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	cmd, _ := m.cmpctl.Update(msg)
 	return m, cmd
@@ -81,6 +80,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 func (m Model) View(ctx *context.ProgramContext) string {
 	return m.ctx.Styles.Search.Root.Render(m.cmpctl.View())
+}
+
+func (m *Model) CursorEnd() {
+	m.cmpctl.CursorEnd()
 }
 
 func (m *Model) Focus() tea.Cmd {
@@ -118,13 +121,6 @@ func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
 }
 
 func (m *Model) getInputWidth(ctx *context.ProgramContext) int {
-	if m.ctx.SidebarOpen {
-		return max(
-			2,
-			ctx.MainContentWidth,
-		)
-	}
-
 	return max(
 		2,
 		ctx.MainContentWidth-4,

--- a/internal/tui/components/section/section.go
+++ b/internal/tui/components/section/section.go
@@ -436,13 +436,15 @@ func (m *BaseModel) GetMainContent() string {
 
 func (m *BaseModel) View() string {
 	search := m.SearchBar.View(m.Ctx)
-	return m.Ctx.Styles.Section.ContainerStyle.Render(
-		lipgloss.JoinVertical(
-			lipgloss.Left,
-			search,
-			m.GetMainContent(),
-		),
-	)
+	return m.Ctx.Styles.Section.ContainerStyle.
+		Width(m.Ctx.MainContentWidth).
+		Render(
+			lipgloss.JoinVertical(
+				lipgloss.Left,
+				search,
+				m.GetMainContent(),
+			),
+		)
 }
 
 func (m *BaseModel) ResetRows() {

--- a/internal/tui/components/section/section.go
+++ b/internal/tui/components/section/section.go
@@ -350,7 +350,10 @@ func (m *BaseModel) GetIsLoading() bool {
 func (m *BaseModel) SetIsSearching(val bool) tea.Cmd {
 	m.IsSearching = val
 	if val {
-		return tea.Batch(m.SearchBar.Focus(), m.SearchBar.Init())
+		cmd := m.SearchBar.Focus()
+		m.SearchBar.CursorEnd()
+		m.SearchBar, _ = m.SearchBar.Update(nil)
+		return cmd
 	} else {
 		m.SearchBar.Blur()
 		return nil

--- a/internal/tui/components/section/section_test.go
+++ b/internal/tui/components/section/section_test.go
@@ -4,13 +4,19 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"charm.land/lipgloss/v2"
 	"github.com/cli/go-gh/v2/pkg/repository"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prompt"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/search"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/table"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
 )
 
 func currentRepoFilter(t *testing.T) string {
@@ -452,6 +458,54 @@ func TestGetPromptConfirmation(t *testing.T) {
 					tt.action,
 					tt.view,
 				)
+			}
+		})
+	}
+}
+
+func TestViewRendersAtMainContentWidth(t *testing.T) {
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+
+	thm := theme.ParseTheme(&cfg)
+	styles := context.InitStyles(thm)
+
+	widths := []int{80, 120, 200}
+	for _, targetWidth := range widths {
+		t.Run(fmt.Sprintf("width_%d", targetWidth), func(t *testing.T) {
+			ctx := &context.ProgramContext{
+				Config:            &cfg,
+				MainContentWidth:  targetWidth,
+				MainContentHeight: 20,
+				Theme:             thm,
+				Styles:            styles,
+			}
+			m := BaseModel{
+				Ctx:       ctx,
+				SearchBar: search.NewModel(ctx, search.SearchOptions{}),
+				Table: table.NewModel(
+					*ctx,
+					constants.Dimensions{Width: targetWidth, Height: 10},
+					time.Now(),
+					time.Now(),
+					nil,
+					nil,
+					"pr",
+					nil,
+					"Loading...",
+					false,
+				),
+			}
+
+			view := m.View()
+			lines := strings.Split(view, "\n")
+			for i, line := range lines {
+				w := lipgloss.Width(line)
+				require.Equal(t, targetWidth, w,
+					"line %d rendered at width %d, expected %d", i, w, targetWidth)
 			}
 		})
 	}

--- a/internal/tui/components/sidebar/sidebar.go
+++ b/internal/tui/components/sidebar/sidebar.go
@@ -55,6 +55,29 @@ func (m Model) View() string {
 		return ""
 	}
 
+	if m.ctx.PreviewPosition == "bottom" {
+		height := m.ctx.DynamicPreviewHeight
+		width := m.ctx.DynamicPreviewWidth
+		style := m.ctx.Styles.Sidebar.BottomRoot.
+			Height(height).
+			Width(width).
+			MaxWidth(width)
+
+		if m.data == "" {
+			return style.Align(lipgloss.Center).Render(
+				lipgloss.PlaceVertical(height, lipgloss.Center, m.emptyState),
+			)
+		}
+
+		return style.Render(lipgloss.JoinVertical(
+			lipgloss.Top,
+			m.viewport.View(),
+			m.ctx.Styles.Sidebar.PagerStyle.
+				Render(fmt.Sprintf("%d%%", int(m.viewport.ScrollPercent()*100))),
+		))
+	}
+
+	// Right mode
 	height := m.ctx.MainContentHeight
 	style := m.ctx.Styles.Sidebar.Root.
 		Height(height).
@@ -84,6 +107,9 @@ func (m *Model) GetSidebarContentWidth() int {
 	if m.ctx == nil || m.ctx.Config == nil {
 		return 0
 	}
+	if m.ctx.PreviewPosition == "bottom" {
+		return max(0, m.ctx.DynamicPreviewWidth)
+	}
 	return max(0, m.ctx.DynamicPreviewWidth-m.ctx.Styles.Sidebar.BorderWidth)
 }
 
@@ -110,6 +136,10 @@ func (m *Model) UpdateProgramContext(ctx *context.ProgramContext) {
 		return
 	}
 	m.ctx = ctx
-	m.viewport.SetHeight(m.ctx.MainContentHeight - m.ctx.Styles.Sidebar.PagerHeight)
+	if m.ctx.PreviewPosition == "bottom" {
+		m.viewport.SetHeight(m.ctx.DynamicPreviewHeight - m.ctx.Styles.Sidebar.PagerHeight)
+	} else {
+		m.viewport.SetHeight(m.ctx.MainContentHeight - m.ctx.Styles.Sidebar.PagerHeight)
+	}
 	m.viewport.SetWidth(m.GetSidebarContentWidth())
 }

--- a/internal/tui/context/context.go
+++ b/internal/tui/context/context.go
@@ -29,23 +29,25 @@ type Task struct {
 }
 
 type ProgramContext struct {
-	RepoPath            string
-	RepoUrl             string
-	User                string
-	ScreenHeight        int
-	ScreenWidth         int
-	MainContentWidth    int
-	MainContentHeight   int
-	DynamicPreviewWidth int
-	SidebarOpen         bool
-	Config              *config.Config
-	ConfigFlag          string
-	Version             string
-	View                config.ViewType
-	Error               error
-	StartTask           func(task Task) tea.Cmd
-	Theme               theme.Theme
-	Styles              Styles
+	RepoPath             string
+	RepoUrl              string
+	User                 string
+	ScreenHeight         int
+	ScreenWidth          int
+	MainContentWidth     int
+	MainContentHeight    int
+	DynamicPreviewWidth  int
+	DynamicPreviewHeight int    // calculated preview height for bottom mode
+	PreviewPosition      string // resolved "right" or "bottom"
+	SidebarOpen          bool
+	Config               *config.Config
+	ConfigFlag           string
+	Version              string
+	View                 config.ViewType
+	Error                error
+	StartTask            func(task Task) tea.Cmd
+	Theme                theme.Theme
+	Styles               Styles
 }
 
 func (ctx *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {

--- a/internal/tui/context/styles.go
+++ b/internal/tui/context/styles.go
@@ -190,16 +190,7 @@ func InitStyles(theme theme.Theme) Styles {
 		BorderForeground(theme.PrimaryBorder)
 	s.Sidebar.BottomRoot = lipgloss.NewStyle().
 		BorderTop(true).
-		BorderStyle(lipgloss.Border{
-			Top:         "─",
-			Bottom:      "",
-			Left:        "",
-			Right:       "",
-			TopLeft:     "",
-			TopRight:    "",
-			BottomRight: "",
-			BottomLeft:  "",
-		}).
+		BorderStyle(lipgloss.ThickBorder()).
 		BorderForeground(theme.PrimaryBorder)
 	s.Sidebar.PagerStyle = lipgloss.NewStyle().
 		Height(s.Sidebar.PagerHeight).

--- a/internal/tui/context/styles.go
+++ b/internal/tui/context/styles.go
@@ -59,6 +59,7 @@ type Styles struct {
 		PagerHeight    int
 		ContentPadding int
 		Root           lipgloss.Style
+		BottomRoot     lipgloss.Style
 		PagerStyle     lipgloss.Style
 		InputBox       lipgloss.Style
 	}
@@ -180,6 +181,19 @@ func InitStyles(theme theme.Theme) Styles {
 			Top:         "",
 			Bottom:      "",
 			Left:        "│",
+			Right:       "",
+			TopLeft:     "",
+			TopRight:    "",
+			BottomRight: "",
+			BottomLeft:  "",
+		}).
+		BorderForeground(theme.PrimaryBorder)
+	s.Sidebar.BottomRoot = lipgloss.NewStyle().
+		BorderTop(true).
+		BorderStyle(lipgloss.Border{
+			Top:         "─",
+			Bottom:      "",
+			Left:        "",
 			Right:       "",
 			TopLeft:     "",
 			TopRight:    "",

--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -28,25 +28,26 @@ func SetNotificationSubject(subjectType NotificationSubjectType) {
 }
 
 type KeyMap struct {
-	viewType      config.ViewType
-	Up            key.Binding
-	Down          key.Binding
-	FirstLine     key.Binding
-	LastLine      key.Binding
-	TogglePreview key.Binding
-	OpenGithub    key.Binding
-	Refresh       key.Binding
-	RefreshAll    key.Binding
-	Redraw        key.Binding
-	PageDown      key.Binding
-	PageUp        key.Binding
-	NextSection   key.Binding
-	PrevSection   key.Binding
-	Search        key.Binding
-	CopyUrl       key.Binding
-	CopyNumber    key.Binding
-	Help          key.Binding
-	Quit          key.Binding
+	viewType              config.ViewType
+	Up                    key.Binding
+	Down                  key.Binding
+	FirstLine             key.Binding
+	LastLine              key.Binding
+	TogglePreview         key.Binding
+	TogglePreviewPosition key.Binding
+	OpenGithub            key.Binding
+	Refresh               key.Binding
+	RefreshAll            key.Binding
+	Redraw                key.Binding
+	PageDown              key.Binding
+	PageUp                key.Binding
+	NextSection           key.Binding
+	PrevSection           key.Binding
+	Search                key.Binding
+	CopyUrl               key.Binding
+	CopyNumber            key.Binding
+	Help                  key.Binding
+	Quit                  key.Binding
 }
 
 func CreateKeyMapForView(viewType config.ViewType) help.KeyMap {
@@ -123,6 +124,7 @@ func (k KeyMap) AppKeys() []key.Binding {
 		k.Refresh,
 		k.RefreshAll,
 		k.TogglePreview,
+		k.TogglePreviewPosition,
 		k.OpenGithub,
 		k.CopyNumber,
 		k.CopyUrl,
@@ -153,7 +155,11 @@ var Keys = &KeyMap{
 	),
 	TogglePreview: key.NewBinding(
 		key.WithKeys("p"),
-		key.WithHelp("p", "open in Preview"),
+		key.WithHelp("p", "toggle preview"),
+	),
+	TogglePreviewPosition: key.NewBinding(
+		key.WithKeys("P"),
+		key.WithHelp("P", "toggle preview position"),
 	),
 	OpenGithub: key.NewBinding(
 		key.WithKeys("o"),
@@ -278,6 +284,8 @@ func rebindUniversal(universal []config.Keybinding) error {
 			key = &Keys.LastLine
 		case "togglePreview":
 			key = &Keys.TogglePreview
+		case "togglePreviewPosition":
+			key = &Keys.TogglePreviewPosition
 		case "openGithub":
 			key = &Keys.OpenGithub
 		case "refresh":

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -62,6 +62,7 @@ type Model struct {
 	ctx              *context.ProgramContext
 	taskSpinner      spinner.Model
 	tasks            map[string]context.Task
+	positionOverride string // "" means no override, "right" or "bottom"
 }
 
 func NewModel(location config.Location) Model {
@@ -270,7 +271,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case key.Matches(msg, m.keys.TogglePreview):
 			m.sidebar.IsOpen = !m.sidebar.IsOpen
-			m.syncMainContentWidth()
+			m.syncMainContentDimensions()
+
+		case key.Matches(msg, m.keys.TogglePreviewPosition):
+			if m.sidebar.IsOpen {
+				if m.ctx.PreviewPosition == "right" {
+					m.positionOverride = "bottom"
+				} else {
+					m.positionOverride = "right"
+				}
+				m.syncMainContentDimensions()
+				m.syncProgramContext()
+				cmd := m.syncSidebar()
+				cmds = append(cmds, cmd)
+			}
 
 		case key.Matches(msg, m.keys.Refresh):
 			if currSection != nil {
@@ -301,14 +315,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case key.Matches(msg, m.keys.Help):
-			if !m.footer.ShowAll {
-				m.ctx.MainContentHeight = m.ctx.MainContentHeight +
-					common.FooterHeight - common.ExpandedHelpHeight
-			} else {
-				m.ctx.MainContentHeight = m.ctx.MainContentHeight +
-					common.ExpandedHelpHeight - common.FooterHeight
-			}
 			m.footer.ShowAll = !m.footer.ShowAll
+			m.syncMainContentDimensions()
 
 		case key.Matches(msg, m.keys.CopyNumber):
 			var cmd tea.Cmd
@@ -662,7 +670,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ctx.View = m.ctx.Config.Defaults.View
 		m.currSectionId = m.getCurrentViewDefaultSection()
 		m.sidebar.IsOpen = msg.Config.Defaults.Preview.Open
-		m.syncMainContentWidth()
+		m.syncMainContentDimensions()
 
 		newSections, fetchSectionsCmds := m.fetchAllViewSections()
 		m.setCurrentViewSections(newSections)
@@ -898,11 +906,19 @@ func (m Model) View() tea.View {
 	content := "No sections defined"
 	currSection := m.getCurrSection()
 	if currSection != nil {
-		content = lipgloss.JoinHorizontal(
-			lipgloss.Top,
-			m.getCurrSection().View(),
-			m.sidebar.View(),
-		)
+		if m.ctx.PreviewPosition == "bottom" && m.sidebar.IsOpen {
+			content = lipgloss.JoinVertical(
+				lipgloss.Left,
+				m.getCurrSection().View(),
+				m.sidebar.View(),
+			)
+		} else {
+			content = lipgloss.JoinHorizontal(
+				lipgloss.Top,
+				m.getCurrSection().View(),
+				m.sidebar.View(),
+			)
+		}
 	}
 	s.WriteString(content)
 	s.WriteString("\n")
@@ -1004,12 +1020,13 @@ func (m *Model) onWindowSizeChanged(msg tea.WindowSizeMsg) {
 	m.footer.SetWidth(msg.Width)
 	m.ctx.ScreenWidth = msg.Width
 	m.ctx.ScreenHeight = msg.Height
-	if m.footer.ShowAll {
-		m.ctx.MainContentHeight = msg.Height - common.TabsHeight - common.ExpandedHelpHeight
-	} else {
-		m.ctx.MainContentHeight = msg.Height - common.TabsHeight - common.FooterHeight
+	if m.ctx.Config != nil {
+		if m.ctx.Config.Defaults.Preview.Position == "auto" ||
+			m.ctx.Config.Defaults.Preview.Position == "" {
+			m.positionOverride = ""
+		}
+		m.syncMainContentDimensions()
 	}
-	m.syncMainContentWidth()
 }
 
 func (m *Model) syncProgramContext() {
@@ -1066,18 +1083,83 @@ func (m *Model) updateCurrentSection(msg tea.Msg) (cmd tea.Cmd) {
 	return m.updateSection(section.GetId(), section.GetType(), msg)
 }
 
-func (m *Model) syncMainContentWidth() {
-	sideBarOffset := 0
-	if m.sidebar.IsOpen {
+const minTableWidthForRightPreview = 80
+
+func (m *Model) resolvePreviewPosition() string {
+	pos := m.ctx.Config.Defaults.Preview.Position
+	if pos == "" {
+		pos = "auto"
+	}
+
+	if m.positionOverride != "" {
+		return m.positionOverride
+	}
+
+	if pos == "right" || pos == "bottom" {
+		return pos
+	}
+
+	// auto: check if right mode would leave enough room for the main content
+	w := m.ctx.Config.Defaults.Preview.Width
+	if w > 0 && w < 1 {
+		w *= float64(m.ctx.ScreenWidth)
+	}
+	previewWidth := min(int(w), m.ctx.ScreenWidth)
+	tableWidth := m.ctx.ScreenWidth - previewWidth
+	if tableWidth < minTableWidthForRightPreview {
+		return "bottom"
+	}
+	return "right"
+}
+
+func (m *Model) getBaseContentHeight() int {
+	if m.footer.ShowAll {
+		// Measure actual footer height — the ExpandedHelpHeight constant
+		// doesn't account for custom keybindings or view-specific bindings.
+		footerHeight := lipgloss.Height(m.footer.View())
+		return m.ctx.ScreenHeight - common.TabsHeight - footerHeight
+	}
+	return m.ctx.ScreenHeight - common.TabsHeight - common.FooterHeight
+}
+
+func (m *Model) syncMainContentDimensions() {
+	m.ctx.PreviewPosition = m.resolvePreviewPosition()
+
+	if !m.sidebar.IsOpen {
+		m.ctx.MainContentWidth = m.ctx.ScreenWidth
+		m.ctx.MainContentHeight = m.getBaseContentHeight()
+		m.ctx.DynamicPreviewWidth = 0
+		m.ctx.DynamicPreviewHeight = 0
+		m.ctx.SidebarOpen = false
+		return
+	}
+
+	m.ctx.SidebarOpen = true
+
+	if m.ctx.PreviewPosition == "bottom" {
+		m.ctx.MainContentWidth = m.ctx.ScreenWidth
+
+		// Subtract border height: lipgloss Height() sets content height,
+		// and BorderTop adds an extra row outside of that.
+		availableHeight := m.getBaseContentHeight() - m.ctx.Styles.Sidebar.BorderWidth
+		h := m.ctx.Config.Defaults.Preview.Height
+		if h > 0 && h < 1 {
+			h *= float64(availableHeight)
+		}
+		m.ctx.DynamicPreviewHeight = min(int(h), availableHeight)
+		m.ctx.MainContentHeight = availableHeight - m.ctx.DynamicPreviewHeight
+		m.ctx.DynamicPreviewWidth = m.ctx.ScreenWidth
+	} else {
+		m.ctx.MainContentHeight = m.getBaseContentHeight()
+
 		w := m.ctx.Config.Defaults.Preview.Width
 		if w > 0 && w < 1 {
 			w *= float64(m.ctx.ScreenWidth)
 		}
 		m.ctx.DynamicPreviewWidth = min(int(w), m.ctx.ScreenWidth)
-		sideBarOffset = m.ctx.DynamicPreviewWidth
+		m.ctx.MainContentWidth = m.ctx.ScreenWidth - m.ctx.DynamicPreviewWidth
+		m.ctx.DynamicPreviewHeight = 0
 	}
-	m.ctx.MainContentWidth = m.ctx.ScreenWidth - sideBarOffset
-	m.ctx.SidebarOpen = m.sidebar.IsOpen
 }
 
 func (m *Model) openSidebarForPRInput(setFunc func(bool) tea.Cmd) tea.Cmd {
@@ -1088,7 +1170,7 @@ func (m *Model) openSidebarForPRInput(setFunc func(bool) tea.Cmd) tea.Cmd {
 func (m *Model) openSidebarForInput(setFunc func(bool) tea.Cmd) tea.Cmd {
 	m.sidebar.IsOpen = true
 	cmd := setFunc(true)
-	m.syncMainContentWidth()
+	m.syncMainContentDimensions()
 	m.syncSidebar()
 	m.sidebar.ScrollToBottom()
 	return cmd
@@ -1529,7 +1611,7 @@ func (m *Model) switchSelectedView() tea.Cmd {
 		}
 	}
 
-	m.syncMainContentWidth()
+	m.syncMainContentDimensions()
 	m.setCurrSectionId(m.getCurrentViewDefaultSection())
 
 	var cmds []tea.Cmd

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -943,7 +943,7 @@ func (m Model) View() tea.View {
 
 	prCmp := m.prView.ViewCompletions()
 	if prCmp != "" {
-		y := m.ctx.ScreenHeight - common.FooterHeight - m.prView.InputBoxLineFromButton() - common.InputBoxHeight - 4
+		y := m.ctx.ScreenHeight - common.FooterHeight - m.prView.InputBoxLineFromBottom() - common.InputBoxHeight - 4
 		layers = append(layers, lipgloss.NewLayer(prCmp).X(m.ctx.MainContentWidth+4).Y(y))
 	}
 
@@ -1026,6 +1026,7 @@ func (m *Model) onWindowSizeChanged(msg tea.WindowSizeMsg) {
 			m.positionOverride = ""
 		}
 		m.syncMainContentDimensions()
+		m.syncSidebar()
 	}
 }
 

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -13,6 +14,8 @@ import (
 	// "charm.land/x/exp/teatest"
 
 	"github.com/stretchr/testify/require"
+
+	zone "github.com/lrstanley/bubblezone/v2"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
@@ -922,8 +925,9 @@ func TestSyncMainContentWidth(t *testing.T) {
 			cfg := config.Config{
 				Defaults: config.Defaults{
 					Preview: config.PreviewConfig{
-						Open:  true,
-						Width: tc.previewWidth,
+						Open:     true,
+						Width:    tc.previewWidth,
+						Position: "right",
 					},
 				},
 			}
@@ -938,7 +942,7 @@ func TestSyncMainContentWidth(t *testing.T) {
 				},
 			}
 
-			m.syncMainContentWidth()
+			m.syncMainContentDimensions()
 
 			if tc.sidebarOpen {
 				require.Equal(t, tc.expectedPreviewWidth, m.ctx.DynamicPreviewWidth,
@@ -1018,6 +1022,321 @@ func TestSyncSidebar_NoOpWhenSidebarClosed(t *testing.T) {
 		cmd := m.syncSidebar()
 		require.Nil(t, cmd, "syncSidebar should return nil when sidebar is closed")
 	})
+}
+
+func TestSyncMainContentDimensions_BottomMode(t *testing.T) {
+	tests := []struct {
+		name                  string
+		screenWidth           int
+		screenHeight          int
+		previewHeight         float64
+		sidebarOpen           bool
+		expectedPreviewHeight int
+		expectedMainHeight    int
+		expectedMainWidth     int
+	}{
+		{
+			name:                  "bottom mode with 40% height",
+			screenWidth:           100,
+			screenHeight:          40,
+			previewHeight:         0.4,
+			sidebarOpen:           true,
+			expectedPreviewHeight: 14,
+			expectedMainHeight:    21,
+			expectedMainWidth:     100,
+		},
+		{
+			name:                  "bottom mode sidebar closed",
+			screenWidth:           100,
+			screenHeight:          40,
+			previewHeight:         0.4,
+			sidebarOpen:           false,
+			expectedPreviewHeight: 0,
+			expectedMainHeight:    36,
+			expectedMainWidth:     100,
+		},
+		{
+			name:                  "bottom mode with absolute height",
+			screenWidth:           100,
+			screenHeight:          40,
+			previewHeight:         10,
+			sidebarOpen:           true,
+			expectedPreviewHeight: 10,
+			expectedMainHeight:    25,
+			expectedMainWidth:     100,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.ParseConfig(config.Location{
+				ConfigFlag:       "../config/testdata/test-config.yml",
+				SkipGlobalConfig: true,
+			})
+			require.NoError(t, err)
+			cfg.Defaults.Preview.Width = 0.45
+			cfg.Defaults.Preview.Height = tc.previewHeight
+			cfg.Defaults.Preview.Position = "bottom"
+			thm := theme.ParseTheme(&cfg)
+			styles := context.InitStyles(thm)
+
+			m := Model{
+				ctx: &context.ProgramContext{
+					Config:       &cfg,
+					ScreenWidth:  tc.screenWidth,
+					ScreenHeight: tc.screenHeight,
+					Styles:       styles,
+				},
+				sidebar: sidebar.Model{
+					IsOpen: tc.sidebarOpen,
+				},
+			}
+
+			m.syncMainContentDimensions()
+
+			require.Equal(t, tc.expectedMainWidth, m.ctx.MainContentWidth,
+				"MainContentWidth mismatch")
+			require.Equal(t, tc.expectedMainHeight, m.ctx.MainContentHeight,
+				"MainContentHeight mismatch")
+			if tc.sidebarOpen {
+				require.Equal(t, tc.expectedPreviewHeight, m.ctx.DynamicPreviewHeight,
+					"DynamicPreviewHeight mismatch")
+				// Verify total doesn't exceed available space:
+				// main content + preview + border must equal base content height
+				baseHeight := tc.screenHeight - 4 // TabsHeight=3 + FooterHeight=1
+				borderHeight := styles.Sidebar.BorderWidth
+				require.Equal(
+					t,
+					baseHeight,
+					m.ctx.MainContentHeight+m.ctx.DynamicPreviewHeight+borderHeight,
+					"table + preview + border should equal base content height",
+				)
+			}
+			require.Equal(t, "bottom", m.ctx.PreviewPosition,
+				"PreviewPosition should be bottom")
+		})
+	}
+}
+
+func TestTogglePreviewPosition_NoOpWhenSidebarClosed(t *testing.T) {
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+	cfg.Defaults.Preview.Width = 0.45
+	cfg.Defaults.Preview.Height = 0.4
+	cfg.Defaults.Preview.Position = "right"
+
+	ctx := &context.ProgramContext{
+		Config:       &cfg,
+		ScreenWidth:  100,
+		ScreenHeight: 40,
+		View:         config.PRsView,
+		StartTask:    func(task context.Task) tea.Cmd { return nil },
+	}
+	ctx.Theme = theme.ParseTheme(ctx.Config)
+	ctx.Styles = context.InitStyles(ctx.Theme)
+
+	prSection := prssection.NewModel(
+		0,
+		ctx,
+		config.PrsSectionConfig{
+			Title:   "Test",
+			Filters: "is:open",
+		},
+		time.Now(),
+		time.Now(),
+	)
+
+	m := Model{
+		ctx:              ctx,
+		keys:             keys.Keys,
+		prs:              []section.Section{&prSection},
+		sidebar:          sidebar.NewModel(),
+		footer:           footer.NewModel(ctx),
+		tabs:             tabs.NewModel(ctx),
+		prView:           prview.NewModel(ctx),
+		issueSidebar:     issueview.NewModel(ctx),
+		branchSidebar:    branchsidebar.NewModel(ctx),
+		notificationView: notificationview.NewModel(ctx),
+	}
+
+	// Sidebar is closed by default from NewModel()
+	require.False(t, m.sidebar.IsOpen, "sidebar should start closed")
+
+	// Set initial dimensions via syncMainContentDimensions
+	m.syncMainContentDimensions()
+	initialMainWidth := m.ctx.MainContentWidth
+	initialMainHeight := m.ctx.MainContentHeight
+	initialPreviewWidth := m.ctx.DynamicPreviewWidth
+	initialPreviewHeight := m.ctx.DynamicPreviewHeight
+	initialPosition := m.ctx.PreviewPosition
+
+	// Pressing P when sidebar is closed should be a no-op
+	msg := tea.KeyPressMsg{Text: "P"}
+	_, _ = m.Update(msg)
+
+	require.Equal(t, initialMainWidth, m.ctx.MainContentWidth,
+		"MainContentWidth should not change when sidebar is closed")
+	require.Equal(t, initialMainHeight, m.ctx.MainContentHeight,
+		"MainContentHeight should not change when sidebar is closed")
+	require.Equal(t, initialPreviewWidth, m.ctx.DynamicPreviewWidth,
+		"DynamicPreviewWidth should not change when sidebar is closed")
+	require.Equal(t, initialPreviewHeight, m.ctx.DynamicPreviewHeight,
+		"DynamicPreviewHeight should not change when sidebar is closed")
+	require.Equal(t, initialPosition, m.ctx.PreviewPosition,
+		"PreviewPosition should not change when sidebar is closed")
+	require.Equal(t, "", m.positionOverride,
+		"positionOverride should remain empty when sidebar is closed")
+}
+
+func TestTogglePreviewPosition_TogglesWhenSidebarOpen(t *testing.T) {
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+	cfg.Defaults.Preview.Width = 0.45
+	cfg.Defaults.Preview.Height = 0.4
+	cfg.Defaults.Preview.Position = "right"
+
+	ctx := &context.ProgramContext{
+		Config:       &cfg,
+		ScreenWidth:  100,
+		ScreenHeight: 40,
+		View:         config.PRsView,
+		StartTask:    func(task context.Task) tea.Cmd { return nil },
+	}
+	ctx.Theme = theme.ParseTheme(ctx.Config)
+	ctx.Styles = context.InitStyles(ctx.Theme)
+
+	prSection := prssection.NewModel(
+		0,
+		ctx,
+		config.PrsSectionConfig{
+			Title:   "Test",
+			Filters: "is:open",
+		},
+		time.Now(),
+		time.Now(),
+	)
+
+	m := Model{
+		ctx:              ctx,
+		keys:             keys.Keys,
+		prs:              []section.Section{&prSection},
+		sidebar:          sidebar.NewModel(),
+		footer:           footer.NewModel(ctx),
+		tabs:             tabs.NewModel(ctx),
+		prView:           prview.NewModel(ctx),
+		issueSidebar:     issueview.NewModel(ctx),
+		branchSidebar:    branchsidebar.NewModel(ctx),
+		notificationView: notificationview.NewModel(ctx),
+	}
+
+	// Open the sidebar and set initial right-mode dimensions
+	m.sidebar.IsOpen = true
+	m.syncMainContentDimensions()
+	require.Equal(t, "right", m.ctx.PreviewPosition)
+
+	// Press P to toggle to bottom
+	msg := tea.KeyPressMsg{Text: "P"}
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+
+	require.Equal(t, "bottom", m.positionOverride,
+		"positionOverride should be bottom after toggling from right")
+	require.Equal(t, "bottom", m.ctx.PreviewPosition,
+		"PreviewPosition should be bottom after toggle")
+	require.Equal(t, 100, m.ctx.MainContentWidth,
+		"MainContentWidth should be full screen width in bottom mode")
+	require.Greater(t, m.ctx.DynamicPreviewHeight, 0,
+		"DynamicPreviewHeight should be set in bottom mode")
+
+	// Press P again to toggle back to right
+	updated, _ = m.Update(msg)
+	m = updated.(Model)
+
+	require.Equal(t, "right", m.positionOverride,
+		"positionOverride should be right after toggling back")
+	require.Equal(t, "right", m.ctx.PreviewPosition,
+		"PreviewPosition should be right after second toggle")
+	require.Greater(t, m.ctx.DynamicPreviewWidth, 0,
+		"DynamicPreviewWidth should be set in right mode")
+	require.Less(t, m.ctx.MainContentWidth, 100,
+		"MainContentWidth should be less than screen width in right mode")
+}
+
+func TestView_ClosingSidebarFromBottomMode_NoExtraLine(t *testing.T) {
+	// Regression test: closing the sidebar while PreviewPosition is "bottom"
+	// must not produce an extra line from JoinVertical with an empty string.
+	// The rendered View should have the same line count regardless of whether
+	// we close from right mode or bottom mode.
+	zone.NewGlobal()
+	zone.SetEnabled(false)
+
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+	cfg.Defaults.Preview.Width = 0.45
+	cfg.Defaults.Preview.Height = 0.4
+	cfg.Defaults.Preview.Position = "right"
+
+	ctx := &context.ProgramContext{
+		Config:       &cfg,
+		ScreenWidth:  120,
+		ScreenHeight: 40,
+		View:         config.PRsView,
+		StartTask:    func(task context.Task) tea.Cmd { return nil },
+	}
+	ctx.Theme = theme.ParseTheme(ctx.Config)
+	ctx.Styles = context.InitStyles(ctx.Theme)
+
+	prSection := prssection.NewModel(
+		0,
+		ctx,
+		config.PrsSectionConfig{
+			Title:   "Test",
+			Filters: "is:open",
+		},
+		time.Now(),
+		time.Now(),
+	)
+
+	m := Model{
+		ctx:              ctx,
+		keys:             keys.Keys,
+		prs:              []section.Section{&prSection},
+		sidebar:          sidebar.NewModel(),
+		footer:           footer.NewModel(ctx),
+		tabs:             tabs.NewModel(ctx),
+		prView:           prview.NewModel(ctx),
+		issueSidebar:     issueview.NewModel(ctx),
+		branchSidebar:    branchsidebar.NewModel(ctx),
+		notificationView: notificationview.NewModel(ctx),
+	}
+
+	// Baseline: sidebar closed in right mode
+	m.sidebar.IsOpen = false
+	m.positionOverride = ""
+	m.syncMainContentDimensions()
+	m.syncProgramContext()
+	rightClosedView := m.View()
+	rightClosedLines := strings.Count(rightClosedView.Content, "\n")
+
+	// Now: sidebar closed while in bottom mode (the bug scenario)
+	m.positionOverride = "bottom"
+	m.sidebar.IsOpen = false
+	m.syncMainContentDimensions()
+	m.syncProgramContext()
+	bottomClosedView := m.View()
+	bottomClosedLines := strings.Count(bottomClosedView.Content, "\n")
+
+	require.Equal(t, rightClosedLines, bottomClosedLines,
+		"closing sidebar from bottom mode should produce the same number of lines as right mode")
 }
 
 func TestPromptConfirmationForNotificationPR(t *testing.T) {


### PR DESCRIPTION
Add a “bottom” preview position that renders the preview pane below the main content rather than to the right. You can toggle between “right” and “bottom” with the <kbd>P</kbd> key while the preview is open.

### New config options

```yaml
defaults:
  preview:
    position: auto   # auto | right | bottom
    height: 0.40     # how tall the preview pane is (% or rows)
```

#### position
- **`auto`** (default) — uses “right” when the terminal is wide enough for both the main content and the preview, falls back to “bottom” when the main content would have fewer than 80 columns.
- **`right`** — preview pane to the right (vertical split).
- **`bottom`** — preview pane below the main content (horizontal split).

#### height
- how tall the preview pane is in “bottom” mode (default: 0.40). Values less than 1 are treated as a percentage of the screen height; values 1 or greater are treated as a fixed number of rows.

The <kbd>P</kbd> key toggles between right and bottom at runtime, without persisting the change. Fixes https://github.com/dlvhdr/gh-dash/issues/107.

<img width="1024" height="1397" alt="image" src="https://github.com/user-attachments/assets/bf624c42-23e4-4647-8732-780fe945e317" />

<img width="1024" height="612" alt="image" src="https://github.com/user-attachments/assets/15383e7c-af4d-4a49-b3f7-96fcb53a4398" />