### PR TITLE
fix: restore zone.Scan() call lost in bubbletea v2 migration

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -891,7 +891,7 @@ func (m Model) View() tea.View {
 		s.WriteString(m.footer.View())
 	}
 
-	v.SetContent(s.String())
+	v.SetContent(zone.Scan(s.String()))
 	return v
 }
 


### PR DESCRIPTION
Bug: Clicking the **`donate`** button in the footer does nothing.

Cause: Before the v2 migration, `View()` returned `zone.Scan(s.String())`. The v2 migration replaced that with `v.SetContent(s.String())` but dropped the `zone.Scan()` wrapper. Without that, bubblezone never parses the invisible markers injected by `zone.Mark()` — so `zone.Get("donate").InBounds()` always returns false.

Fix: Wrap the `SetContent` argument in `zone.Scan()`.