### PR TITLE
fix: handle paste in inputboxes

### DIFF
--- a/internal/tui/components/detailedit/controller.go
+++ b/internal/tui/components/detailedit/controller.go
@@ -201,6 +201,14 @@ func (c Controller) Update(msg tea.Msg) (Controller, tea.Cmd, *Submit, bool) {
 	)
 
 	switch msg := msg.(type) {
+	case tea.PasteMsg:
+		if c.Active() {
+			c.inputBox, taCmd = c.inputBox.Update(msg)
+			cmds = append(cmds, taCmd)
+			return c, tea.Batch(cmds...), nil, true
+		}
+		return c, nil, nil, false
+
 	case RepoLabelsFetchedMsg:
 		c.repoLabels = msg.Labels
 		c.ac.SetSuggestions(labelSuggestions(msg.Labels))

--- a/internal/tui/components/detailedit/controller_test.go
+++ b/internal/tui/components/detailedit/controller_test.go
@@ -338,3 +338,56 @@ func TestUnassignModeDoesNotUseAutocomplete(t *testing.T) {
 
 	require.False(t, c.usesAutocomplete())
 }
+
+func TestPasteInCommentMode(t *testing.T) {
+	data.ClearUserCache()
+	c := newTestController(t)
+	c, _ = c.Enter(EnterOptions{
+		Mode:                             ModeComment,
+		Prompt:                           "comment",
+		Source:                           dataautocomplete.UserMentionSource{},
+		Repo:                             testRepo(),
+		SuggestionKind:                   SuggestionUsers,
+		EnterFetch:                       FetchNone,
+		ConfirmDiscardOnCancel:           true,
+		HideAutocompleteWhenContextEmpty: true,
+	})
+
+	msg := tea.PasteMsg{Content: "pasted text"}
+	c, _, _, handled := c.Update(msg)
+
+	require.True(t, handled)
+	require.Contains(t, c.inputBox.Value(), "pasted text",
+		"pasted text should appear in the inputbox")
+}
+
+func TestPasteInAssignMode(t *testing.T) {
+	data.ClearUserCache()
+	c := newTestController(t)
+	c, _ = c.Enter(EnterOptions{
+		Mode:                             ModeAssign,
+		Prompt:                           "assign",
+		Source:                           dataautocomplete.WhitespaceSource{},
+		Repo:                             testRepo(),
+		SuggestionKind:                   SuggestionUsers,
+		EnterFetch:                       FetchNone,
+		HideAutocompleteWhenContextEmpty: false,
+	})
+
+	msg := tea.PasteMsg{Content: "alice bob"}
+	c, _, _, handled := c.Update(msg)
+
+	require.True(t, handled)
+	require.Contains(t, c.inputBox.Value(), "alice bob",
+		"pasted text should appear in the inputbox during assignment")
+}
+
+func TestPasteIgnoredWhenInactive(t *testing.T) {
+	c := newTestController(t)
+
+	msg := tea.PasteMsg{Content: "should not appear"}
+	_, _, _, handled := c.Update(msg)
+
+	require.False(t, handled,
+		"paste should not be handled when controller is inactive")
+}


### PR DESCRIPTION
**Bug:** Pasting text into the comment, approve, assign, or label inputbox does nothing.

**Cause:** Bubbletea v2 enables bracketed paste by default, delivering pasted text as `PasteMsg` rather than individual `KeyMsg` events. The inputbox controller only handled `KeyMsg`, so `PasteMsg` was silently dropped.

**Fix:** Add a `PasteMsg` case in `Controller.Update()` that forwards the message to the underlying textarea when the controller is active.

Fixes https://github.com/dlvhdr/gh-dash/issues/811