### PR TITLE
fix: clear GH_DASH_CONFIG in default-config test

### DIFF
--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -60,6 +60,7 @@ func TestParser(t *testing.T) {
 		defer func() {
 			os.Unsetenv("XDG_CONFIG_HOME")
 		}()
+		t.Setenv("GH_DASH_CONFIG", "")
 
 		parsed, err := ParseConfig(Location{})
 		testutils.AssertNoError(t, err)


### PR DESCRIPTION
**Bug:** The `TestParser/Should_create_default_config` test fails when `GH_DASH_CONFIG` is set in the environment.

**Cause:** The test set `XDG_CONFIG_HOME` to an empty temp dir — to isolate it from any actual local config — but didn’t clear `GH_DASH_CONFIG`. `ParseConfig` checks `GH_DASH_CONFIG` — so if it’s set, dash uses the local config file specified in the value, and that local config may specify more PR sections than the 3 the test expects (causing the test to fail).

**Fix:** Clear `GH_DASH_CONFIG` with `t.Setenv` (which restores it afterward).
