### PR TITLE
fix(schema): remove invalid `properties: null` from pr.json schema

### DIFF
--- a/docs/src/pages/schema/layout/pr.json.ts
+++ b/docs/src/pages/schema/layout/pr.json.ts
@@ -89,7 +89,6 @@ export function GET() {
               $ref: "./options.json",
             },
           ],
-          properties: null,
           default: {
             width: 15,
           },


### PR DESCRIPTION
## Summary

Removes invalid `properties: null` from the PR layout schema. The JSON Schema draft 2020-12 specification requires `properties` to be an object, not `null`.

## Details

- **File**: `docs/src/pages/schema/layout/pr.json.ts`
- **Property**: `author`
- **Fix**: Removed `properties: null` line

The `properties: null` was redundant with the existing `oneOf` reference to `./options.json`.

## Error Message (before fix)

```
Schema 'https://gh-dash.dev/schema.json' is not valid: 
/properties/author/properties : must be object [768]
```

This error appeared when using yaml-language-server to validate config files, as documented in https://www.gh-dash.dev/configuration/schema/

## Reference

- [JSON Schema draft 2020-12 - properties](https://json-schema.org/draft/2020-12/json-schema-validation#name-properties)

## AI Usage

This PR was AI-assisted by Claude Code. The change is straightforward: removal of an invalid field. I understand the change and can maintain it.

Fixes #846