### PR TITLE
Fix PR update branch state

### DIFF
--- a/internal/tui/components/tasks/pr.go
+++ b/internal/tui/components/tasks/pr.go
@@ -240,9 +240,9 @@ func CreatePR(
 	}))
 }
 
-func UpdatePR(ctx *context.ProgramContext, section SectionIdentifier, pr data.RowData) tea.Cmd {
+func updatePRTask(section SectionIdentifier, pr data.RowData) GitHubTask {
 	prNumber := pr.GetNumber()
-	return fireTask(ctx, GitHubTask{
+	return GitHubTask{
 		Id: buildTaskId("pr_update", prNumber),
 		Args: []string{
 			"pr",
@@ -257,10 +257,13 @@ func UpdatePR(ctx *context.ProgramContext, section SectionIdentifier, pr data.Ro
 		Msg: func(c *exec.Cmd, err error) tea.Msg {
 			return UpdatePRMsg{
 				PrNumber: prNumber,
-				IsClosed: utils.BoolPtr(true),
 			}
 		},
-	})
+	}
+}
+
+func UpdatePR(ctx *context.ProgramContext, section SectionIdentifier, pr data.RowData) tea.Cmd {
+	return fireTask(ctx, updatePRTask(section, pr))
 }
 
 func AssignPR(

--- a/internal/tui/components/tasks/pr_test.go
+++ b/internal/tui/components/tasks/pr_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
+func TestUpdatePR_TaskConfiguration(t *testing.T) {
+	section := SectionIdentifier{Id: 2, Type: "pr"}
+	pr := mockIssue{
+		number:   42,
+		repoName: "owner/repo",
+	}
+
+	task := updatePRTask(section, pr)
+
+	require.Equal(t, "pr_update_42", task.Id)
+	require.Equal(t, []string{"pr", "update-branch", "42", "-R", "owner/repo"}, task.Args)
+	require.Equal(t, section, task.Section)
+	require.Equal(t, "Updating PR #42", task.StartText)
+	require.Equal(t, "PR #42 has been updated", task.FinishedText)
+}
+
+func TestUpdatePR_MsgDoesNotMarkPRClosed(t *testing.T) {
+	task := updatePRTask(SectionIdentifier{Id: 2, Type: "pr"}, mockIssue{
+		number:   42,
+		repoName: "owner/repo",
+	})
+
+	msg := task.Msg(nil, nil)
+	updateMsg, ok := msg.(UpdatePRMsg)
+
+	require.True(t, ok, "Msg should return UpdatePRMsg")
+	require.Equal(t, 42, updateMsg.PrNumber)
+	require.Nil(t, updateMsg.IsClosed, "updating a PR branch must not change the PR open/closed state")
+}
+
 func TestApproveWorkflows_TaskConfiguration(t *testing.T) {
 	var capturedTask context.Task
 

--- a/internal/tui/components/tasks/pr_test.go
+++ b/internal/tui/components/tasks/pr_test.go
@@ -37,7 +37,11 @@ func TestUpdatePR_MsgDoesNotMarkPRClosed(t *testing.T) {
 
 	require.True(t, ok, "Msg should return UpdatePRMsg")
 	require.Equal(t, 42, updateMsg.PrNumber)
-	require.Nil(t, updateMsg.IsClosed, "updating a PR branch must not change the PR open/closed state")
+	require.Nil(
+		t,
+		updateMsg.IsClosed,
+		"updating a PR branch must not change the PR open/closed state",
+	)
 }
 
 func TestApproveWorkflows_TaskConfiguration(t *testing.T) {


### PR DESCRIPTION
# Summary

- [x] Fixes #842
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

Prevent the `pr update-branch` task from marking the PR as closed in the follow-up UI update message. Branch updates now leave the open/closed state unchanged; close/reopen/merge actions still update that state explicitly.

## How Did You Test this Change?

- `go test ./internal/tui/components/tasks`
- `go test ./internal/tui/components/tasks ./internal/tui/components/prssection`

## Images/Videos

N/A

AI disclosure: This PR was prepared with AI assistance from Hermes Agent (OpenAI Codex). Assistance included issue/code inspection, implementing the small fix, adding tests, and running verification.
