### PR TITLE
fix: guard isUserDefinedKeybinding against nil model context

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -1630,6 +1630,9 @@ func (m *Model) switchSelectedView() tea.Cmd {
 }
 
 func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
+	if m.ctx == nil || m.ctx.Config == nil {
+		return false
+	}
 	for _, keybinding := range m.ctx.Config.Keybindings.Universal {
 		if keybinding.Builtin == "" && keybinding.Key == msg.String() {
 			return true


### PR DESCRIPTION
## Summary

Fixes #850 — guards `isUserDefinedKeybinding` against a nil `m.ctx` / `m.ctx.Config`, so terminals that emit OSC/CSI responses (e.g. Wave Terminal's eager OSC 11 background-color and CSI cursor-position reports) before the bubbletea model is fully initialized no longer panic the TUI.

## Cause

`Update` can dispatch `KeyMsg` to `isUserDefinedKeybinding` before `m.ctx` is wired up. The function then derefs `m.ctx.Config.Keybindings.Universal` and panics. This is the same class of issue as #812 / `f0b67d7`, but in a different code path that the previous fix didn't cover.

## Fix

Three-line guard at the top of `isUserDefinedKeybinding`:

```go
if m.ctx == nil || m.ctx.Config == nil {
    return false
}
```

Returning `false` here is the safe default: no user-defined binding can match before the config is loaded, so the regular built-in key dispatch handles the message normally (and at this point the relevant code paths have their own `currSection != nil` guards from `f0b67d7`).

## Test plan

- [x] Reproduced the panic on `main` and on tagged v4.22.0 / v4.23.2 from a Wave Terminal block (panic on first key event).
- [x] Built the patched binary, replaced the gh-extension binary, panic gone, `gh dash` opens normally and keybindings work.
- [ ] Maintainers: please confirm the fix doesn't regress user-defined keybinding lookups in normal startup paths.

## AI disclosure (per AI_POLICY.md)

Diagnosis and patch authored with Claude Code assistance. I (the submitter) read the function, understand why the nil guard is correct, and have built and tested the binary locally. Happy to iterate on review feedback.
