### PR TITLE
chore: keep last item selected for notifications after marking last o…

### DIFF
--- a/internal/tui/components/notificationssection/notificationssection.go
+++ b/internal/tui/components/notificationssection/notificationssection.go
@@ -329,6 +329,10 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 			m.SetIsLoading(false)
 			m.Table.SetRows(m.BuildRows())
 			m.UpdateTotalItemsCount(m.TotalCount)
+			// If the removed item was the last one, move the current row to the new last item.
+			if m.TotalCount > 0 && m.CurrRow() >= m.TotalCount {
+				m.LastItem()
+			}
 		}
 
 	case UpdateNotificationReadStateMsg:


### PR DESCRIPTION

# Summary

- [x] Closes issue https://github.com/dlvhdr/gh-dash/issues/858
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides


## How Did You Test this Change?
Built locally and confirmed that marking the last notification item as done results in the new last item in being selected.


## AI Discosure

I used Claude Code to pinpoint the location for the change.
Implemented manually.
