### PR TITLE
fix: discard browser launcher stdout/stderr to prevent TUI display corruption (closes #829)

### DIFF
--- a/internal/tui/components/notificationssection/commands.go
+++ b/internal/tui/components/notificationssection/commands.go
@@ -3,6 +3,7 @@ package notificationssection
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -252,7 +253,10 @@ func (m *Model) openInBrowser() tea.Cmd {
 			}
 		},
 		func() tea.Msg {
-			b := browser.New("", os.Stdout, os.Stdin)
+			// Discard the launcher's stdout/stderr so any noise (e.g. GTK /
+			// GVFS warnings from xdg-open / gnome-open) does not leak into
+			// the TUI's terminal and corrupt the display. See #829, #584, #679.
+			b := browser.New("", io.Discard, io.Discard)
 			err := b.Browse(notificationUrl)
 			if err != nil {
 				return constants.ErrMsg{Err: err}

--- a/internal/tui/tasks.go
+++ b/internal/tui/tasks.go
@@ -3,7 +3,7 @@ package tui
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io"
 	"reflect"
 	"time"
 
@@ -25,7 +25,10 @@ func (m *Model) openBrowser() tea.Cmd {
 	}
 	startCmd := m.ctx.StartTask(task)
 	openCmd := func() tea.Msg {
-		b := browser.New("", os.Stdout, os.Stdin)
+		// Discard the launcher's stdout/stderr so any noise (e.g. GTK / GVFS
+		// warnings from xdg-open / gnome-open) does not leak into the TUI's
+		// terminal and corrupt the display. See #829, #584, #679.
+		b := browser.New("", io.Discard, io.Discard)
 		currRow := m.getCurrRowData()
 		if currRow == nil || reflect.ValueOf(currRow).IsNil() {
 			return constants.TaskFinishedMsg{

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"runtime/debug"
@@ -812,7 +813,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if zone.Get("donate").InBounds(msg) {
 			log.Info("Donate clicked", "msg", msg)
 			openCmd := func() tea.Msg {
-				b := browser.New("", os.Stdout, os.Stdin)
+				// Discard the launcher's stdout/stderr so any noise (e.g.
+				// GTK / GVFS warnings from xdg-open / gnome-open) does not
+				// leak into the TUI's terminal and corrupt the display.
+				// See #829, #584, #679.
+				b := browser.New("", io.Discard, io.Discard)
 				err := b.Browse("https://github.com/sponsors/dlvhdr")
 				if err != nil {
 					return constants.ErrMsg{Err: err}


### PR DESCRIPTION
### Summary

All three `browser.New` call sites in gh-dash pass `os.Stdin` as the third argument:

```go
b := browser.New("", os.Stdout, os.Stdin)
//                              ^^^^^^^^^
```

The signature in `cli/go-gh/v2/pkg/browser` is `New(launcher string, stdout, stderr io.Writer) *Browser`. The third argument should be a stderr writer. It compiles because `*os.File` implements `io.Writer`, but the launcher subprocess (`xdg-open`, `gnome-open`, `start`) inherits the TTY, and any stderr it emits — GTK / GVFS warnings, GNOME deprecation messages — gets routed through that fd onto the same TTY the TUI is rendering to. That's the display corruption reported in #829, and matches the symptoms in the related #584 and #679 threads.

PR #569 added a manual `Ctrl+L` redraw keybinding as a mitigation, but the leak source was never addressed.

### Fix

Pass `io.Discard` for both writers — for a TUI we never want launcher noise reaching the terminal. Three call sites:

```diff
-		b := browser.New("", os.Stdout, os.Stdin)
+		// Discard the launcher's stdout/stderr so any noise (e.g. GTK / GVFS
+		// warnings from xdg-open / gnome-open) does not leak into the TUI's
+		// terminal and corrupt the display. See #829, #584, #679.
+		b := browser.New("", io.Discard, io.Discard)
```

- [`internal/tui/tasks.go:28`](internal/tui/tasks.go#L28) — main "open in browser" task
- [`internal/tui/components/notificationssection/commands.go:255`](internal/tui/components/notificationssection/commands.go#L255) — notification-row open
- [`internal/tui/ui.go:816`](internal/tui/ui.go#L816) — donate button

`cli/cli` itself uses the analogous pattern: [`browser.New("", io.Out, io.ErrOut)`](https://github.com/cli/cli/blob/trunk/pkg/cmd/factory/default.go) backed by an iostreams wrapper. Discarding here is more aggressive than reproducing iostreams — for a full-screen TUI the launcher's output is never wanted.

### Build verification

| Platform | Result |
|---|---|
| Windows + Go 1.26.2 | `go build ./...` → exit 0 |
| Linux + Go 1.26 (Docker `golang:1.26`) | `go build ./...` → PASS |

I haven't run the `internal/tui` test suite because it hangs on package init (charm/bubbletea TTY setup) on this Windows environment — same issue I hit on #686. The change is purely an import + 3-line callsite swap; build green on both platforms covers it.

### Out of scope

- The `Ctrl+L` redraw keybinding from #569 stays useful for any other source of corruption. This PR removes the most common one (browser launcher noise) but doesn't replace the redraw escape hatch.
- I haven't added a test exercising the actual launcher subprocess — verifying the writers are discarded would require either intercepting the `*Browser` constructor or running an end-to-end TUI test, both of which are heavier than the fix justifies.

Reported by @lwjohnst86, @ShintaroOba, @404Simon.