### PR TITLE
Default confirmation prompts to No for destructive actions

### DIFF
--- a/internal/tui/components/issuessection/issuessection.go
+++ b/internal/tui/components/issuessection/issuessection.go
@@ -87,7 +87,7 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 			case "enter":
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
-				if input == "" || input == "Y" || input == "y" {
+				if input == "Y" || input == "y" {
 					issue := m.GetCurrRow()
 					sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
 					switch action {

--- a/internal/tui/components/notificationssection/notificationssection.go
+++ b/internal/tui/components/notificationssection/notificationssection.go
@@ -239,7 +239,7 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 			case "enter":
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
-				if input == "" || input == "Y" || input == "y" {
+				if input == "Y" || input == "y" {
 					switch action {
 					case "done":
 						cmd = m.markAsDone()

--- a/internal/tui/components/notificationview/notificationview.go
+++ b/internal/tui/components/notificationview/notificationview.go
@@ -145,7 +145,7 @@ func (m Model) Update(msg tea.Msg) (Model, string) {
 
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
-		if msg.String() == "y" || msg.String() == "Y" || msg.Code == tea.KeyEnter {
+		if msg.String() == "y" || msg.String() == "Y" {
 			action := m.pendingAction
 			m.pendingAction = ""
 			return m, action

--- a/internal/tui/components/notificationview/notificationview_test.go
+++ b/internal/tui/components/notificationview/notificationview_test.go
@@ -210,7 +210,7 @@ func TestUpdate_ConfirmWithUppercaseY(t *testing.T) {
 	require.False(t, newModel.HasPendingAction(), "pending action should be cleared")
 }
 
-func TestUpdate_ConfirmWithEnter(t *testing.T) {
+func TestUpdate_EnterDoesNotConfirm(t *testing.T) {
 	m := NewModel(&context.ProgramContext{})
 	m.SetSubjectIssue(&data.IssueData{Number: 789}, "notif-id")
 	m.SetPendingIssueAction("reopen")
@@ -218,7 +218,7 @@ func TestUpdate_ConfirmWithEnter(t *testing.T) {
 	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
 	newModel, action := m.Update(msg)
 
-	require.Equal(t, "issue_reopen", action, "should return the confirmed action")
+	require.Empty(t, action, "Enter should not confirm when default is No")
 	require.False(t, newModel.HasPendingAction(), "pending action should be cleared")
 }
 
@@ -331,7 +331,7 @@ func TestUpdate_AllIssueActions(t *testing.T) {
 			m.SetSubjectIssue(&data.IssueData{Number: 456}, "notif-id")
 			m.SetPendingIssueAction(action)
 
-			msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+			msg := tea.KeyPressMsg{Text: "y"}
 			newModel, confirmedAction := m.Update(msg)
 
 			require.Equal(t, "issue_"+action, confirmedAction)

--- a/internal/tui/components/prssection/prssection.go
+++ b/internal/tui/components/prssection/prssection.go
@@ -91,7 +91,7 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				action := m.GetPromptConfirmationAction()
 				pr := m.GetCurrRow()
 				sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
-				if input == "" || input == "Y" || input == "y" {
+				if input == "Y" || input == "y" {
 					switch action {
 					case "close":
 						cmd = tasks.ClosePR(m.Ctx, sid, pr)

--- a/internal/tui/components/prssection/prssection_test.go
+++ b/internal/tui/components/prssection/prssection_test.go
@@ -36,15 +36,14 @@ func newTestModel(action string) Model {
 	return m
 }
 
-func TestConfirmation_AcceptWithEmptyInput(t *testing.T) {
-	// Pressing Enter without typing anything should confirm, since the
-	// prompt says (Y/n) indicating Y is the default.
+func TestConfirmation_EmptyInputDoesNotConfirm(t *testing.T) {
+	// Pressing Enter without typing anything should NOT confirm, since the
+	// prompt says (y/N) indicating N is the default.
 	m := newTestModel("close")
 
 	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
-	_, cmd := m.Update(msg)
+	_, _ = m.Update(msg)
 
-	require.NotNil(t, cmd, "empty input (default Y) should execute the action")
 	require.False(t, m.IsPromptConfirmationShown,
 		"confirmation prompt should be dismissed")
 }
@@ -109,14 +108,14 @@ func TestConfirmation_AllActions(t *testing.T) {
 	actions := []string{"close", "reopen", "ready", "merge", "update", "approveWorkflows"}
 
 	for _, action := range actions {
-		t.Run(action+"_empty_input", func(t *testing.T) {
+		t.Run(action+"_empty_input_does_not_confirm", func(t *testing.T) {
 			m := newTestModel(action)
 
 			msg := tea.KeyPressMsg{Code: tea.KeyEnter}
-			_, cmd := m.Update(msg)
+			_, _ = m.Update(msg)
 
-			require.NotNil(t, cmd,
-				"empty input should confirm for action %q", action)
+			require.False(t, m.IsPromptConfirmationShown,
+				"empty input should dismiss prompt for action %q", action)
 		})
 
 		t.Run(action+"_explicit_y", func(t *testing.T) {

--- a/internal/tui/components/reposection/reposection.go
+++ b/internal/tui/components/reposection/reposection.go
@@ -110,7 +110,7 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 					cmd = tasks.CreatePR(m.Ctx, sid, branch, input)
 				default:
 					pr := findPRForRef(m.Prs, branch)
-					if input == "" || input == "Y" || input == "y" {
+					if input == "Y" || input == "y" {
 						switch action {
 						case "delete":
 							cmd = m.deleteBranch()

--- a/internal/tui/components/section/section.go
+++ b/internal/tui/components/section/section.go
@@ -473,36 +473,36 @@ func (m *BaseModel) GetPromptConfirmation() string {
 		var prompt string
 		switch {
 		case m.PromptConfirmationAction == "close" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to close this PR? (Y/n) "
+			prompt = "Are you sure you want to close this PR? (y/N) "
 
 		case m.PromptConfirmationAction == "reopen" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to reopen this PR? (Y/n) "
+			prompt = "Are you sure you want to reopen this PR? (y/N) "
 
 		case m.PromptConfirmationAction == "ready" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to mark this PR as ready? (Y/n) "
+			prompt = "Are you sure you want to mark this PR as ready? (y/N) "
 
 		case m.PromptConfirmationAction == "merge" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to merge this PR? (Y/n) "
+			prompt = "Are you sure you want to merge this PR? (y/N) "
 
 		case m.PromptConfirmationAction == "update" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to update this PR? (Y/n) "
+			prompt = "Are you sure you want to update this PR? (y/N) "
 
 		case m.PromptConfirmationAction == "approveWorkflows" && m.Ctx.View == config.PRsView:
-			prompt = "Are you sure you want to approve all workflows? (Y/n) "
+			prompt = "Are you sure you want to approve all workflows? (y/N) "
 
 		case m.PromptConfirmationAction == "close" && m.Ctx.View == config.IssuesView:
-			prompt = "Are you sure you want to close this issue? (Y/n) "
+			prompt = "Are you sure you want to close this issue? (y/N) "
 
 		case m.PromptConfirmationAction == "reopen" && m.Ctx.View == config.IssuesView:
-			prompt = "Are you sure you want to reopen this issue? (Y/n) "
+			prompt = "Are you sure you want to reopen this issue? (y/N) "
 		case m.PromptConfirmationAction == "delete" && m.Ctx.View == config.RepoView:
-			prompt = "Are you sure you want to delete this branch? (Y/n) "
+			prompt = "Are you sure you want to delete this branch? (y/N) "
 		case m.PromptConfirmationAction == "new" && m.Ctx.View == config.RepoView:
 			prompt = "Enter branch name: "
 		case m.PromptConfirmationAction == "create_pr" && m.Ctx.View == config.RepoView:
 			prompt = "Enter PR title: "
 		case m.PromptConfirmationAction == "done_all" && m.Ctx.View == config.NotificationsView:
-			prompt = "Are you sure you want to mark all as done? (Y/n) "
+			prompt = "Are you sure you want to mark all as done? (y/N) "
 		}
 
 		m.PromptConfirmationBox.SetPrompt(prompt)

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -1551,8 +1551,8 @@ func TestNotificationConfirmation_AcceptWithUpperY(t *testing.T) {
 	require.NotNil(t, cmd, "should return a command to execute the action")
 }
 
-func TestNotificationConfirmation_AcceptWithEnter(t *testing.T) {
-	// Test that pressing Enter also confirms
+func TestNotificationConfirmation_EnterDoesNotConfirm(t *testing.T) {
+	// Test that pressing Enter does NOT confirm (default is No)
 	cfg, err := config.ParseConfig(config.Location{
 		ConfigFlag: "../config/testdata/test-config.yml",
 	})
@@ -1585,15 +1585,14 @@ func TestNotificationConfirmation_AcceptWithEnter(t *testing.T) {
 	}, "test-notification-id")
 	m.notificationView.SetPendingIssueAction("reopen")
 
-	// Press Enter to confirm
+	// Press Enter -- should cancel since default is No
 	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
-	newModel, cmd := m.Update(msg)
+	newModel, _ := m.Update(msg)
 	m = newModel.(Model)
 
-	// Verify pending action is cleared and command is returned
+	// Verify pending action is cleared (cancelled, not confirmed)
 	require.Empty(t, m.notificationView.GetPendingAction(),
-		"pendingNotificationAction should be cleared after confirmation")
-	require.NotNil(t, cmd, "should return a command to execute the action")
+		"pendingNotificationAction should be cleared after Enter cancels")
 }
 
 func TestPromptConfirmationForNotificationIssue_NilSubject(t *testing.T) {


### PR DESCRIPTION
Fixes #596.

Close/reopen/delete prompts default to Yes — pressing Enter without
typing triggers the action. This is unsafe for destructive operations.

Flip all confirmation prompts from `(Y/n)` to `(y/N)` and remove the
`input == ""` accept condition so empty input no longer confirms.
Also fixes an inconsistency in notification view where the prompt
showed `(y/N)` but Enter still confirmed.