### PR TITLE
docs: allow notifications as default view

### DIFF
--- a/docs/src/content/docs/configuration/defaults.mdx
+++ b/docs/src/content/docs/configuration/defaults.mdx
@@ -228,12 +228,12 @@ You may need to adjust the layout column width depending on your format.
 
 ### Default View (`view`)
 
-| Type   |     Options     | Default |
-| :----- | :-------------: | :-----: |
-| String | "prs", "issues" |   20    |
+| Type   |              Options              | Default |
+| :----- | :-------------------------------: | :-----: |
+| String | "notifications", "prs", "issues" |  "prs"  |
 
-This setting defines whether the dashboard should display the PRs or Issues view when it
-first loads.
+This setting defines whether the dashboard should display the Notifications, PRs, or Issues
+view when it first loads.
 
 By default, the dashboard displays the PRs view.
 

--- a/docs/src/pages/schema/defaults.json.ts
+++ b/docs/src/pages/schema/defaults.json.ts
@@ -88,9 +88,9 @@ export function GET() {
         view: {
           title: "Default View",
           description:
-            "Specifies whether the dashboard should display the PRs or Issues view on load.",
+            "Specifies which dashboard view should be displayed on load.",
           type: "string",
-          enum: ["issues", "prs"],
+          enum: ["notifications", "issues", "prs"],
           default: "prs",
         },
         prApproveComment: {

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -127,6 +127,24 @@ func TestParser(t *testing.T) {
 		assert.Empty(t, cmp.Diff(expected, actual, keybindSorter))
 	})
 
+	t.Run("Should accept notifications as the default view", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "config")
+		testutils.AssertNoError(t, err)
+		defer os.RemoveAll(dir)
+
+		configPath := path.Join(dir, "config.yml")
+		err = os.WriteFile(configPath, []byte("defaults:\n  view: notifications\n"), 0o600)
+		testutils.AssertNoError(t, err)
+
+		parsed, err := ParseConfig(Location{
+			ConfigFlag:       configPath,
+			SkipGlobalConfig: true,
+		})
+
+		testutils.AssertNoError(t, err)
+		require.Equal(t, NotificationsView, parsed.Defaults.View)
+	})
+
 	t.Run("Should merge global config with passed config", func(t *testing.T) {
 		clearEnv := setXDGConfigHomeEnvVar(t, "testdata")
 		defer clearEnv()


### PR DESCRIPTION
# Summary

- [x] Closes issue #867
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides
- Add `notifications` to the `defaults.view` schema enum
- Update the defaults docs to list `notifications` alongside `prs` and `issues`
- Add a config parser regression test proving `defaults.view: notifications` maps to `NotificationsView`

## How Did You Test this Change?

- `mise exec go@1.25.10 -- go test ./internal/config`
- `git diff --check HEAD~1..HEAD`

## AI Assistance Disclosure

This PR was prepared with Codex assistance. The change was kept scoped to the existing `ViewType` parser behavior: the code already accepts `notifications`, and this PR updates docs/schema plus a focused regression test.

## Images/Videos

N/A