### PR TITLE
Fix Windows PR diff pager launch

### DIFF
--- a/internal/data/prdiff.go
+++ b/internal/data/prdiff.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	gh "github.com/cli/go-gh/v2/pkg/api"
+)
+
+func FetchPullRequestDiff(prNumber int, repoName string) (string, error) {
+	host, repoPath, err := splitDiffRepoName(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	client, err := gh.NewRESTClient(gh.ClientOptions{
+		Host: host,
+		Headers: map[string]string{
+			"Accept": "application/vnd.github.v3.diff",
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Request(
+		http.MethodGet,
+		fmt.Sprintf("repos/%s/pulls/%d", repoPath, prNumber),
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	diff, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(diff), nil
+}
+
+func splitDiffRepoName(repoName string) (string, string, error) {
+	parts := strings.Split(repoName, "/")
+	switch len(parts) {
+	case 2:
+		return "", repoName, nil
+	case 3:
+		return parts[0], strings.Join(parts[1:], "/"), nil
+	default:
+		return "", "", fmt.Errorf("invalid repo name %q", repoName)
+	}
+}

--- a/internal/data/prdiff_test.go
+++ b/internal/data/prdiff_test.go
@@ -1,0 +1,56 @@
+package data
+
+import "testing"
+
+func TestSplitDiffRepoName(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoName string
+		wantHost string
+		wantRepo string
+		wantErr  bool
+	}{
+		{
+			name:     "github repo",
+			repoName: "owner/repo",
+			wantRepo: "owner/repo",
+		},
+		{
+			name:     "enterprise repo",
+			repoName: "ghe.example.com/owner/repo",
+			wantHost: "ghe.example.com",
+			wantRepo: "owner/repo",
+		},
+		{
+			name:     "invalid repo",
+			repoName: "owner",
+			wantErr:  true,
+		},
+		{
+			name:     "too many parts",
+			repoName: "one/two/three/four",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotRepo, err := splitDiffRepoName(tt.repoName)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("splitDiffRepoName() err = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitDiffRepoName() err = %v", err)
+			}
+			if gotHost != tt.wantHost {
+				t.Fatalf("splitDiffRepoName() host = %q, want %q", gotHost, tt.wantHost)
+			}
+			if gotRepo != tt.wantRepo {
+				t.Fatalf("splitDiffRepoName() repo = %q, want %q", gotRepo, tt.wantRepo)
+			}
+		})
+	}
+}

--- a/internal/tui/common/diff.go
+++ b/internal/tui/common/diff.go
@@ -1,31 +1,74 @@
 package common
 
 import (
-	"fmt"
+	"os"
 	"os/exec"
+	"runtime"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 )
 
-// DiffPR opens a diff view for a PR using the gh CLI.
+// DiffPR opens a diff view for a PR using the configured pager.
 // The env parameter should be the result of Config.GetFullScreenDiffPagerEnv().
 func DiffPR(prNumber int, repoName string, env []string) tea.Cmd {
-	c := exec.Command(
-		"gh",
-		"pr",
-		"diff",
-		fmt.Sprint(prNumber),
-		"-R",
-		repoName,
-	)
-	c.Env = env
+	return diffPR(prNumber, repoName, env, data.FetchPullRequestDiff)
+}
 
-	return tea.ExecProcess(c, func(err error) tea.Msg {
+type diffFetcher func(prNumber int, repoName string) (string, error)
+
+func diffPR(prNumber int, repoName string, env []string, fetchDiff diffFetcher) tea.Cmd {
+	return func() tea.Msg {
+		diff, err := fetchDiff(prNumber, repoName)
 		if err != nil {
 			return constants.ErrMsg{Err: err}
 		}
-		return nil
-	})
+
+		c := pagerCommand(diffPager(env), diff, env)
+		return tea.ExecProcess(c, func(err error) tea.Msg {
+			if err != nil {
+				return constants.ErrMsg{Err: err}
+			}
+			return nil
+		})()
+	}
+}
+
+func diffPager(env []string) string {
+	for i := len(env) - 1; i >= 0; i-- {
+		pager, ok := strings.CutPrefix(env[i], "GH_PAGER=")
+		if ok && strings.TrimSpace(pager) != "" {
+			return pager
+		}
+	}
+
+	return "less"
+}
+
+func pagerCommand(pager string, diff string, env []string) *exec.Cmd {
+	return pagerCommandForGOOS(runtime.GOOS, pager, diff, env)
+}
+
+func pagerCommandForGOOS(goos string, pager string, diff string, env []string) *exec.Cmd {
+	var c *exec.Cmd
+	if goos == "windows" {
+		shell := os.Getenv("COMSPEC")
+		if shell == "" {
+			shell = "cmd"
+		}
+		c = exec.Command(shell, "/C", pager)
+	} else {
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "sh"
+		}
+		c = exec.Command(shell, "-c", pager)
+	}
+	c.Env = env
+	c.Stdin = strings.NewReader(diff)
+
+	return c
 }

--- a/internal/tui/common/diff_test.go
+++ b/internal/tui/common/diff_test.go
@@ -1,7 +1,11 @@
 package common
 
 import (
+	"errors"
+	"io"
 	"testing"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 )
 
 func TestDiffPR(t *testing.T) {
@@ -43,4 +47,112 @@ func TestDiffPR(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDiffPager(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want string
+	}{
+		{
+			name: "uses configured pager",
+			env:  []string{"GH_PAGER=delta --paging always"},
+			want: "delta --paging always",
+		},
+		{
+			name: "last pager wins",
+			env:  []string{"GH_PAGER=less", "GH_PAGER=delta --paging always"},
+			want: "delta --paging always",
+		},
+		{
+			name: "defaults empty pager",
+			env:  []string{"GH_PAGER="},
+			want: "less",
+		},
+		{
+			name: "defaults missing pager",
+			env:  []string{"LESS=CRX"},
+			want: "less",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := diffPager(tt.env); got != tt.want {
+				t.Fatalf("diffPager() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDiffPRErrorsWhenDiffFetchFails(t *testing.T) {
+	wantErr := errors.New("boom")
+	cmd := diffPR(123, "owner/repo", nil, func(int, string) (string, error) {
+		return "", wantErr
+	})
+
+	msg := cmd()
+	errMsg, ok := msg.(constants.ErrMsg)
+	if !ok {
+		t.Fatalf("diffPR() msg = %T, want constants.ErrMsg", msg)
+	}
+	if !errors.Is(errMsg.Err, wantErr) {
+		t.Fatalf("diffPR() err = %v, want %v", errMsg.Err, wantErr)
+	}
+}
+
+func TestDiffPRReturnsExecMessageAfterDiffFetch(t *testing.T) {
+	cmd := diffPR(123, "owner/repo", nil, func(int, string) (string, error) {
+		return "diff --git a/file b/file\n", nil
+	})
+
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("diffPR() msg = nil, want exec message")
+	}
+}
+
+func TestPagerCommandUsesWindowsShell(t *testing.T) {
+	t.Setenv("COMSPEC", "")
+
+	cmd := pagerCommandForGOOS("windows", "delta --paging always", "diff text", []string{"GH_PAGER=delta"})
+
+	if cmd.Path != "cmd" {
+		t.Fatalf("pagerCommandForGOOS() path = %q, want cmd", cmd.Path)
+	}
+	if got, want := cmd.Args, []string{"cmd", "/C", "delta --paging always"}; !equalStrings(got, want) {
+		t.Fatalf("pagerCommandForGOOS() args = %#v, want %#v", got, want)
+	}
+	if got, _ := io.ReadAll(cmd.Stdin); string(got) != "diff text" {
+		t.Fatalf("pagerCommandForGOOS() stdin = %q, want diff text", string(got))
+	}
+}
+
+func TestPagerCommandUsesUnixShell(t *testing.T) {
+	t.Setenv("SHELL", "/bin/sh")
+
+	cmd := pagerCommandForGOOS("linux", "less", "diff text", []string{"GH_PAGER=less"})
+
+	if cmd.Path != "/bin/sh" {
+		t.Fatalf("pagerCommandForGOOS() path = %q, want /bin/sh", cmd.Path)
+	}
+	if got, want := cmd.Args, []string{"/bin/sh", "-c", "less"}; !equalStrings(got, want) {
+		t.Fatalf("pagerCommandForGOOS() args = %#v, want %#v", got, want)
+	}
+	if got, _ := io.ReadAll(cmd.Stdin); string(got) != "diff text" {
+		t.Fatalf("pagerCommandForGOOS() stdin = %q, want diff text", string(got))
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
# Summary

- [x] Closes issue #866
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

This avoids shelling out to `gh pr diff` for the full-screen PR diff flow. Instead, `gh-dash` now fetches the PR diff through the existing `go-gh` authenticated REST path and streams that diff into the configured pager directly.

That keeps `pager.diff` behavior for common values like `less` and `delta --paging always`, while avoiding the extra `gh -> pager` process chain that can fail on Windows with only `exit status 4` surfaced in the TUI.

It also adds coverage for:

- diff repo parsing, including `host/owner/repo`
- configured pager selection from `GH_PAGER`
- diff fetch errors surfacing as `ErrMsg`
- Windows `cmd /C` and Unix shell command construction for pagers

Duplicate/competition check before opening:

- `gh issue view 866 --repo dlvhdr/gh-dash --json number,title,state,comments,updatedAt,url` showed the issue still open with no comments.
- `gh pr list --repo dlvhdr/gh-dash --state all --search "866 OR \"pager issue\" OR \"exit status 4\""` returned no matching PRs.

AI usage disclosure: this PR was prepared with OpenAI Codex assistance for investigation, implementation, duplicate checks, and local verification. The diff and verification output were reviewed in the Codex session before submission.

## How Did You Test this Change?

- `mise exec go@1.25.10 -- go test ./internal/data ./internal/tui/common`
- `mise exec go@1.25.10 -- go test ./...`
- `git diff --check`

## Images/Videos

Not applicable.
