### PR TITLE
fix: allow notifications as default view

### DIFF
--- a/docs/src/data/schemas/defaults.yaml
+++ b/docs/src/data/schemas/defaults.yaml
@@ -14,7 +14,7 @@ schematize:
       - Display the preview pane with a width of 50 columns for all work items.
       - Only fetch 20 PRs and issues at a time for each section.
       - Display the PRs view when the dashboard loads.
-      - Refetch PRs and issues for each section every 30 minutes.
+      - Refetch PRs, issues, and notifications for each section every 30 minutes.
       - Display dates using relative values.
 
       For more details on the default layouts, see the documentation for [sref:PR] and [sref:issue]
@@ -216,17 +216,18 @@ properties:
     default: 30
   view:
     title: Default View
-    description: Specifies whether the dashboard should display the PRs or Issues view on load.
+    description: Specifies whether the dashboard should display the PRs, Issues, or Notifications view on load.
     schematize:
       weight: 5
       details: |
-        This setting defines whether the dashboard should display the PRs or Issues view when it
-        first loads.
+        This setting defines whether the dashboard should display the PRs, Issues, or Notifications
+        view when it first loads.
 
         By default, the dashboard displays the PRs view.
     type: string
     enum:
       - issues
+      - notifications
       - prs
     default: prs
   prApproveComment:

--- a/docs/src/pages/schema/defaults.json.ts
+++ b/docs/src/pages/schema/defaults.json.ts
@@ -88,9 +88,9 @@ export function GET() {
         view: {
           title: "Default View",
           description:
-            "Specifies whether the dashboard should display the PRs or Issues view on load.",
+            "Specifies whether the dashboard should display the PRs, Issues, or Notifications view on load.",
           type: "string",
-          enum: ["issues", "prs"],
+          enum: ["issues", "notifications", "prs"],
           default: "prs",
         },
         prApproveComment: {

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -154,6 +154,24 @@ func TestParser(t *testing.T) {
 		require.Equal(t, Color("013"), parsed.Theme.Colors.Inline.Border.Primary)
 		require.Equal(t, Color("008"), parsed.Theme.Colors.Inline.Background.Selected)
 	})
+
+	t.Run("Should accept notifications as default view", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "config")
+		testutils.AssertNoError(t, err)
+		defer os.RemoveAll(dir)
+
+		configPath := path.Join(dir, "config.yml")
+		err = os.WriteFile(configPath, []byte("defaults:\n  view: notifications\n"), 0o600)
+		testutils.AssertNoError(t, err)
+
+		parsed, err := ParseConfig(Location{
+			ConfigFlag:       configPath,
+			SkipGlobalConfig: true,
+		})
+
+		testutils.AssertNoError(t, err)
+		require.Equal(t, NotificationsView, parsed.Defaults.View)
+	})
 }
 
 func loadExpected(t *testing.T, fpath string) Config {


### PR DESCRIPTION
Fixes #867

## Summary
- Allow `notifications` in the documented `defaults.view` schema enum.
- Update the default-view schema wording to mention notifications alongside PRs and issues.
- Add a config parser test covering `defaults.view: notifications`.

## Verification
- `git diff --check`
- `go test ./internal/config`
- `go test ./...`