### PR TITLE
Show diff hunks for PR review threads

### DIFF
--- a/internal/data/prapi.go
+++ b/internal/data/prapi.go
@@ -249,6 +249,7 @@ type ReviewComment struct {
 		Login string
 	}
 	Body      string
+	DiffHunk  string
 	UpdatedAt time.Time
 	StartLine int
 	Line      int
@@ -282,15 +283,17 @@ type Reviews struct {
 }
 
 type ReviewThreadsWithComments struct {
-	Nodes []struct {
-		Id           string
-		IsOutdated   bool
-		OriginalLine int
-		StartLine    int
-		Line         int
-		Path         string
-		Comments     ReviewComments `graphql:"comments(first: 20)"`
-	}
+	Nodes []ReviewThread
+}
+
+type ReviewThread struct {
+	Id           string
+	IsOutdated   bool
+	OriginalLine int
+	StartLine    int
+	Line         int
+	Path         string
+	Comments     ReviewComments `graphql:"comments(first: 20)"`
 }
 
 type ChangedFile struct {

--- a/internal/tui/components/prview/activity.go
+++ b/internal/tui/components/prview/activity.go
@@ -3,6 +3,7 @@ package prview
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"charm.land/glamour/v2"
@@ -32,17 +33,18 @@ func (m *Model) renderActivity() string {
 	}
 
 	for _, review := range m.pr.Data.Enriched.ReviewThreads.Nodes {
-		path := review.Path
-		line := review.Line
-		for _, c := range review.Comments.Nodes {
-			comments = append(comments, comment{
-				Author:    c.Author.Login,
-				Body:      c.Body,
-				UpdatedAt: c.UpdatedAt,
-				Path:      &path,
-				Line:      &line,
-			})
+		if len(review.Comments.Nodes) == 0 {
+			continue
 		}
+
+		renderedThread, err := m.renderReviewThread(review, markdownRenderer)
+		if err != nil {
+			continue
+		}
+		activities = append(activities, RenderedActivity{
+			UpdatedAt:      review.Comments.Nodes[0].UpdatedAt,
+			RenderedString: renderedThread,
+		})
 	}
 
 	for _, c := range m.pr.Data.Enriched.Comments.Nodes {
@@ -106,6 +108,68 @@ type comment struct {
 	Body      string
 	Path      *string
 	Line      *int
+}
+
+func (m *Model) renderReviewThread(
+	thread data.ReviewThread,
+	markdownRenderer glamour.TermRenderer,
+) (string, error) {
+	width := m.getIndentedContentWidth()
+	line := thread.Line
+	if line == 0 {
+		line = thread.StartLine
+	}
+	if line == 0 {
+		line = thread.OriginalLine
+	}
+
+	location := thread.Path
+	if line > 0 {
+		location = fmt.Sprintf("%s#l%d", location, line)
+	}
+	if thread.IsOutdated {
+		location = fmt.Sprintf("%s  %s", location, m.ctx.Styles.Common.FaintTextStyle.Render("outdated"))
+	}
+
+	header := lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Width(width).Render(location)
+
+	diffHunk := ""
+	if firstComment := thread.Comments.Nodes[0]; strings.TrimSpace(firstComment.DiffHunk) != "" {
+		renderedHunk, err := markdownRenderer.Render(fmt.Sprintf(
+			"```diff\n%s\n```",
+			strings.TrimSpace(firstComment.DiffHunk),
+		))
+		if err != nil {
+			return "", err
+		}
+		diffHunk = renderedHunk
+	}
+
+	renderedComments := make([]string, 0, len(thread.Comments.Nodes))
+	for _, c := range thread.Comments.Nodes {
+		renderedComment, err := m.renderComment(comment{
+			Author:    c.Author.Login,
+			Body:      c.Body,
+			UpdatedAt: c.UpdatedAt,
+		}, markdownRenderer)
+		if err != nil {
+			return "", err
+		}
+		renderedComments = append(renderedComments, renderedComment)
+	}
+
+	parts := []string{header}
+	if diffHunk != "" {
+		parts = append(parts, diffHunk)
+	}
+	parts = append(parts, renderedComments...)
+
+	return lipgloss.NewStyle().
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderLeft(true).
+		BorderForeground(m.ctx.Theme.FaintBorder).
+		PaddingLeft(1).
+		Render(lipgloss.JoinVertical(lipgloss.Left, parts...)), nil
 }
 
 func (m *Model) renderComment(

--- a/internal/tui/components/prview/activity_test.go
+++ b/internal/tui/components/prview/activity_test.go
@@ -1,0 +1,75 @@
+package prview
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/markdown"
+)
+
+func TestRenderActivityGroupsReviewThreadWithDiffHunk(t *testing.T) {
+	markdown.InitializeMarkdownStyle(true)
+
+	m := newTestModelForAction(t)
+	m.width = 100
+
+	firstCommentAt := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	replyAt := firstCommentAt.Add(time.Minute)
+	generalCommentAt := firstCommentAt.Add(2 * time.Minute)
+
+	m.pr.Data.Enriched.ReviewThreads.Nodes = []data.ReviewThread{
+		{
+			Path:       "internal/server.go",
+			Line:       42,
+			IsOutdated: true,
+			Comments: data.ReviewComments{
+				Nodes: []data.ReviewComment{
+					{
+						Author:    struct{ Login string }{Login: "reviewer"},
+						Body:      "Please guard this path.",
+						DiffHunk:  "@@ -40,3 +40,4 @@\n-oldCall()\n+newCall()",
+						UpdatedAt: firstCommentAt,
+					},
+					{
+						Author:    struct{ Login string }{Login: "author"},
+						Body:      "Good catch, updated.",
+						UpdatedAt: replyAt,
+					},
+				},
+			},
+		},
+	}
+	m.pr.Data.Enriched.Comments.Nodes = []data.Comment{
+		{
+			Author:    struct{ Login string }{Login: "maintainer"},
+			Body:      "General note.",
+			UpdatedAt: generalCommentAt,
+		},
+	}
+
+	rendered := m.renderActivity()
+
+	for _, want := range []string{
+		"internal/server.go#l42",
+		"outdated",
+		"-oldCall()",
+		"+newCall()",
+		"Please guard this path.",
+		"Good catch, updated.",
+		"General note.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("renderActivity() missing %q:\n%s", want, rendered)
+		}
+	}
+
+	firstCommentIndex := strings.Index(rendered, "Please guard this path.")
+	replyIndex := strings.Index(rendered, "Good catch, updated.")
+	generalCommentIndex := strings.Index(rendered, "General note.")
+
+	if !(firstCommentIndex < replyIndex && replyIndex < generalCommentIndex) {
+		t.Fatalf("comments rendered out of order:\n%s", rendered)
+	}
+}


### PR DESCRIPTION
## Summary
- fetch diffHunk for PR review comments
- render review threads as grouped activity blocks instead of flattening each reply
- show the thread location, diff hunk, and outdated marker in the PR activity tab

Fixes #852

## Verification
- go test ./internal/tui/components/prview ./internal/data
- git diff --check
- git diff --cached --check