### PR TITLE
fix: restore Redraw post-bubbletea-v2

### DIFF
--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -303,10 +303,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, fetchSectionsCmds)
 
 		case key.Matches(msg, m.keys.Redraw):
-		// TODO: this doesn't exist in bubbletea v2
-		// can't find a way to just ask to send bubbletea's internal repaintMsg{},
-		// so this seems like the lightest-weight alternative
-		// return m, tea.Batch(tea.ExitAltScreen, tea.EnterAltScreen)
+			// with bubbletea v2's declarative approach, if we just clear the screen then tea will redraw for us
+			return m, tea.ClearScreen
 
 		case key.Matches(msg, m.keys.Search):
 			if currSection != nil {


### PR DESCRIPTION
Commit 556cd987 introduced the Redraw binding.
Commit 076821f7 commented it out because the mechanism used is no longer available with bubbletea v2.

But there is a better solution which I should have used first time around: there's an explicit ClearScreen command, introduced for <https://github.com/charmbracelet/bubbletea/issues/236>, and which is explicitly for Ctrl-L binding.

# Summary

- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

## How Did You Test this Change?

Opening a browser, having the usual junk spew to the display corrupting it, and press my bound Ctrl-L to repair it.

## AI Disclosure

All code written was human-generated and I fully understand what it does.  I used Claude (Web, not Code) to understand the bubbletea v2 rewrite and to understand what my options were for paths to implement a fix.  Claude discovered the existence of Bubbletea's `ClearScreen`, making the human work trivial.