### PR TITLE
feat(prview): PR review-comment threading, diff hunks, and web-parity activity (closes #852)

### DIFF
--- a/internal/data/prapi.go
+++ b/internal/data/prapi.go
@@ -241,6 +241,7 @@ type Comment struct {
 		Login string
 	}
 	Body      string
+	CreatedAt time.Time
 	UpdatedAt time.Time
 }
 
@@ -248,10 +249,18 @@ type ReviewComment struct {
 	Author struct {
 		Login string
 	}
-	Body      string
-	UpdatedAt time.Time
-	StartLine int
-	Line      int
+	Body              string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	StartLine         int
+	Line              int
+	DiffHunk          string
+	PullRequestReview struct {
+		Id string
+	}
+	ReplyTo struct {
+		Id string
+	}
 }
 
 type ReviewComments struct {
@@ -268,12 +277,14 @@ type ReviewThreads struct {
 }
 
 type Review struct {
+	Id     string
 	Author struct {
 		Login string
 	}
-	Body      string
-	State     string
-	UpdatedAt time.Time
+	Body        string
+	State       string
+	SubmittedAt time.Time
+	UpdatedAt   time.Time
 }
 
 type Reviews struct {
@@ -285,6 +296,7 @@ type ReviewThreadsWithComments struct {
 	Nodes []struct {
 		Id           string
 		IsOutdated   bool
+		IsResolved   bool
 		OriginalLine int
 		StartLine    int
 		Line         int

--- a/internal/tui/components/prview/activity.go
+++ b/internal/tui/components/prview/activity.go
@@ -3,6 +3,7 @@ package prview
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"charm.land/glamour/v2"
@@ -14,153 +15,334 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/utils"
 )
 
-type RenderedActivity struct {
-	UpdatedAt      time.Time
-	RenderedString string
+// diffHunkPreviewLines is the number of trailing context lines we keep when
+// rendering a thread's diff hunk — matches the collapsed preview GitHub web
+// shows above the first comment of a thread.
+const diffHunkPreviewLines = 4
+
+// activityItem is a tagged union of the top-level PR-activity kinds. Exactly
+// one of review/issueComment/thread is set; at is the chronological key
+// (Review.SubmittedAt, IssueComment.CreatedAt, or — for an implicit-Review
+// promoted thread — its first comment's CreatedAt) used for top-level
+// ordering. The thread variant exists only because GitHub creates a synthetic
+// "implicit" Review wrapper (state=COMMENTED, body="") to host inline activity
+// that wasn't part of a formal review submission; we strip those wrappers and
+// surface their threads directly. See docs/adr/0001 for the three-case rule.
+type activityItem struct {
+	at           time.Time
+	review       *data.Review
+	issueComment *data.Comment
+	thread       *reviewThread
+}
+
+// isImplicitReview is true for the GitHub-generated wrapper Review that hosts
+// inline activity outside a formal "Start a review" flow. The signal is
+// state=COMMENTED with an empty body — a real "just commented" Review always
+// carries a body.
+func isImplicitReview(r data.Review) bool {
+	return r.State == "COMMENTED" && r.Body == ""
+}
+
+// reviewThread is the local-to-this-package view of one
+// data.ReviewThreadsWithComments node. The upstream data type is an anonymous
+// struct, so we copy what we need into this typed shape to keep the render
+// code free of inline struct gymnastics.
+type reviewThread struct {
+	Id         string
+	IsOutdated bool
+	IsResolved bool
+	Path       string
+	Line       int
+	StartLine  int
+	Comments   []data.ReviewComment
 }
 
 func (m *Model) renderActivity() string {
-	width := m.getIndentedContentWidth()
-	markdownRenderer := markdown.GetMarkdownRenderer(width)
-	bodyStyle := lipgloss.NewStyle()
-
-	var activities []RenderedActivity
-	var comments []comment
-
 	if !m.pr.Data.IsEnriched {
-		return bodyStyle.Render("Loading...")
+		return lipgloss.NewStyle().Render("Loading...")
 	}
 
-	for _, review := range m.pr.Data.Enriched.ReviewThreads.Nodes {
-		path := review.Path
-		line := review.Line
-		for _, c := range review.Comments.Nodes {
-			comments = append(comments, comment{
-				Author:    c.Author.Login,
-				Body:      c.Body,
-				UpdatedAt: c.UpdatedAt,
-				Path:      &path,
-				Line:      &line,
-			})
+	width := m.getIndentedContentWidth()
+	r := markdown.GetMarkdownRenderer(width)
+
+	threads := m.collectThreads()
+	items := m.collectActivityItems(threads)
+
+	var rendered []string
+	for _, it := range items {
+		switch {
+		case it.review != nil:
+			rendered = append(rendered, m.renderReviewItem(*it.review, threads, r))
+		case it.issueComment != nil:
+			rendered = append(rendered, m.renderIssueComment(*it.issueComment, r))
+		case it.thread != nil:
+			rendered = append(rendered, m.renderThread(*it.thread, r))
 		}
 	}
 
-	for _, c := range m.pr.Data.Enriched.Comments.Nodes {
-		comments = append(comments, comment{
-			Author:    c.Author.Login,
-			Body:      c.Body,
-			UpdatedAt: c.UpdatedAt,
-		})
+	if len(rendered) == 0 {
+		return renderEmptyState()
 	}
 
-	for _, comment := range comments {
-		renderedComment, err := m.renderComment(comment, markdownRenderer)
-		if err != nil {
+	title := m.ctx.Styles.Common.MainTextStyle.MarginBottom(1).Underline(true).Render(
+		fmt.Sprintf("%s  %d comments", constants.CommentsIcon, m.leafCommentCount(items)))
+	body := lipgloss.JoinVertical(lipgloss.Left, rendered...)
+	return lipgloss.JoinVertical(lipgloss.Left, title, body)
+}
+
+// collectActivityItems flattens the top-level streams (Reviews, IssueComments)
+// into a single chronologically-sorted slice and applies the implicit-Review
+// unwrap rule from docs/adr/0001:
+//
+//   - 0 threads opened — implicit Review only contributed replies into other
+//     people's threads. Hide entirely; the reply already renders inside its
+//     parent thread.
+//   - 1 thread opened — promote the thread to a top-level activityItem.
+//   - 2+ threads opened — promote each thread as a sibling top-level item.
+//
+// Non-implicit Reviews render their wrapper with their opened threads nested
+// inside. ReviewThreads opened by non-implicit Reviews are intentionally not
+// top-level.
+func (m *Model) collectActivityItems(threads []reviewThread) []activityItem {
+	enriched := m.pr.Data.Enriched
+	items := make([]activityItem, 0, len(enriched.Reviews.Nodes)+len(enriched.Comments.Nodes))
+	for i := range enriched.Reviews.Nodes {
+		rev := &enriched.Reviews.Nodes[i]
+		if isImplicitReview(*rev) {
+			opened := threadsOpenedBy(rev.Id, threads)
+			for j := range opened {
+				t := &opened[j]
+				key := rev.SubmittedAt
+				if len(t.Comments) > 0 {
+					key = t.Comments[0].CreatedAt
+				}
+				items = append(items, activityItem{at: key, thread: t})
+			}
 			continue
 		}
-		activities = append(activities, RenderedActivity{
-			UpdatedAt:      comment.UpdatedAt,
-			RenderedString: renderedComment,
+		items = append(items, activityItem{at: rev.SubmittedAt, review: rev})
+	}
+	for i := range enriched.Comments.Nodes {
+		ic := &enriched.Comments.Nodes[i]
+		items = append(items, activityItem{at: ic.CreatedAt, issueComment: ic})
+	}
+	sort.SliceStable(items, func(i, j int) bool { return items[i].at.Before(items[j].at) })
+	return items
+}
+
+// leafCommentCount returns the leaf-level "N comments" figure GitHub web's
+// Conversation tab badge displays: inline thread comments + top-level
+// IssueComments + review-summary cards that carry a body — except a
+// state=COMMENTED review whose body has zero inline comments, which the badge
+// silently excludes (it treats those as redundant with a plain issue-comment,
+// even though the timeline still renders the card).
+func (m *Model) leafCommentCount(items []activityItem) int {
+	n := 0
+	threads := m.collectThreads()
+	for _, it := range items {
+		switch {
+		case it.review != nil:
+			inlineCount := 0
+			for _, t := range threadsOpenedBy(it.review.Id, threads) {
+				inlineCount += len(t.Comments)
+			}
+			if it.review.Body != "" && !(it.review.State == "COMMENTED" && inlineCount == 0) {
+				n++
+			}
+			n += inlineCount
+		case it.thread != nil:
+			n += len(it.thread.Comments)
+		case it.issueComment != nil:
+			n++
+		}
+	}
+	return n
+}
+
+func (m *Model) renderIssueComment(c data.Comment, r glamour.TermRenderer) string {
+	pill := m.renderAuthorTimePill(c.Author.Login, c.CreatedAt)
+	body, _ := r.Render(c.Body)
+	return lipgloss.JoinVertical(lipgloss.Left, pill, body)
+}
+
+// renderAuthorTimePill draws the standard rounded-border "{author} {time}"
+// header used by IssueComments and ReviewComment openers. Replies use a
+// compact ↳-prefix instead and bypass this helper.
+func (m *Model) renderAuthorTimePill(login string, at time.Time) string {
+	return lipgloss.NewStyle().
+		Width(m.getIndentedContentWidth()).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(m.ctx.Theme.FaintBorder).
+		Render(lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			m.ctx.Styles.Common.MainTextStyle.Render(login),
+			" ",
+			lipgloss.NewStyle().
+				Foreground(m.ctx.Theme.FaintText).
+				Render(utils.TimeElapsed(at)),
+		))
+}
+
+// collectThreads copies the enriched-PR review threads into the local
+// reviewThread shape, keyed in encounter order (the order GitHub returned
+// them, which is reverse-chronological by default).
+func (m *Model) collectThreads() []reviewThread {
+	out := make([]reviewThread, 0, len(m.pr.Data.Enriched.ReviewThreads.Nodes))
+	for _, t := range m.pr.Data.Enriched.ReviewThreads.Nodes {
+		out = append(out, reviewThread{
+			Id:         t.Id,
+			IsOutdated: t.IsOutdated,
+			IsResolved: t.IsResolved,
+			Path:       t.Path,
+			Line:       t.Line,
+			StartLine:  t.StartLine,
+			Comments:   t.Comments.Nodes,
 		})
 	}
+	return out
+}
 
-	for _, review := range m.pr.Data.Primary.Reviews.Nodes {
-		renderedReview, err := m.renderReview(review, markdownRenderer)
-		if err != nil {
+// threadsOpenedBy returns every thread whose first ReviewComment points back
+// to the given Review via its PullRequestReview.Id link. That is GitHub's
+// canonical "this Review opened this thread" relationship.
+func threadsOpenedBy(reviewId string, threads []reviewThread) []reviewThread {
+	var out []reviewThread
+	for _, t := range threads {
+		if len(t.Comments) == 0 {
 			continue
 		}
-		activities = append(activities, RenderedActivity{
-			UpdatedAt:      review.UpdatedAt,
-			RenderedString: renderedReview,
-		})
-	}
-
-	sort.Slice(activities, func(i, j int) bool {
-		return activities[i].UpdatedAt.Before(activities[j].UpdatedAt)
-	})
-
-	body := ""
-	if len(activities) == 0 {
-		body = renderEmptyState()
-	} else {
-		var renderedActivities []string
-		for _, activity := range activities {
-			renderedActivities = append(renderedActivities, activity.RenderedString)
+		if t.Comments[0].PullRequestReview.Id == reviewId {
+			out = append(out, t)
 		}
-		title := m.ctx.Styles.Common.MainTextStyle.MarginBottom(1).Underline(true).Render(
-			fmt.Sprintf("%s  %d comments", constants.CommentsIcon, len(activities)))
-		body = lipgloss.JoinVertical(lipgloss.Left, renderedActivities...)
-		body = lipgloss.JoinVertical(lipgloss.Left, title, body)
+	}
+	return out
+}
+
+func (m *Model) renderReviewItem(
+	review data.Review,
+	threads []reviewThread,
+	r glamour.TermRenderer,
+) string {
+	header := m.renderReviewHeader(review)
+	body, _ := r.Render(review.Body)
+
+	parts := []string{header, body}
+	for _, t := range threadsOpenedBy(review.Id, threads) {
+		parts = append(parts, m.renderThread(t, r))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+// joinedWithSpaces returns the input slice with a single-space separator
+// interleaved between each element, suitable for JoinHorizontal. Mirrors
+// strings.Join's shape but for lipgloss horizontal layout.
+func joinedWithSpaces(parts []string) []string {
+	if len(parts) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(parts)*2-1)
+	for i, p := range parts {
+		if i > 0 {
+			out = append(out, " ")
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// previewDiffHunk strips the leading "@@ … @@" position header and keeps only
+// the last diffHunkPreviewLines content lines (the ones closest to the comment
+// anchor). For brand-new files the raw hunk is the entire file body — without
+// this preview, a single inline comment can scroll for pages.
+func previewDiffHunk(hunk string) string {
+	lines := strings.Split(hunk, "\n")
+	if len(lines) > 0 && strings.HasPrefix(lines[0], "@@") {
+		lines = lines[1:]
+	}
+	if len(lines) <= diffHunkPreviewLines {
+		return strings.Join(lines, "\n")
+	}
+	tail := lines[len(lines)-diffHunkPreviewLines:]
+	return strings.Join(append([]string{"…"}, tail...), "\n")
+}
+
+func (m *Model) renderThread(t reviewThread, r glamour.TermRenderer) string {
+	// Anchor format mirrors CLI conventions (grep, stack traces, IDE links):
+	// "path:line" for single-line comments, "path:start-end" for multi-line.
+	// GitHub returns StartLine == 0 for single-line comments.
+	anchor := fmt.Sprintf("%s:%d", t.Path, t.Line)
+	if t.StartLine > 0 && t.StartLine != t.Line {
+		anchor = fmt.Sprintf("%s:%d-%d", t.Path, t.StartLine, t.Line)
+	}
+	anchorRendered := lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render(anchor)
+	var badges []string
+	if t.IsOutdated {
+		badges = append(badges,
+			lipgloss.NewStyle().Foreground(m.ctx.Theme.WarningText).Render("[Outdated]"))
+	}
+	if t.IsResolved {
+		badges = append(badges,
+			lipgloss.NewStyle().Foreground(m.ctx.Theme.SuccessText).Render("[Resolved]"))
+	}
+	header := anchorRendered
+	if len(badges) > 0 {
+		badgeRow := lipgloss.JoinHorizontal(lipgloss.Top, joinedWithSpaces(badges)...)
+		// Try to fit anchor + " " + badges on one line; wrap badges to a
+		// second line if they'd overflow the content width.
+		oneLine := lipgloss.JoinHorizontal(lipgloss.Top, anchorRendered, " ", badgeRow)
+		if lipgloss.Width(oneLine) <= m.getIndentedContentWidth() {
+			header = oneLine
+		} else {
+			header = lipgloss.JoinVertical(lipgloss.Left, anchorRendered, badgeRow)
+		}
 	}
 
-	return bodyStyle.Render(body)
+	hunk := ""
+	if len(t.Comments) > 0 && t.Comments[0].DiffHunk != "" {
+		rendered, _ := r.Render("```diff\n" + previewDiffHunk(t.Comments[0].DiffHunk) + "\n```")
+		hunk = rendered
+	}
+
+	commentParts := make([]string, 0, len(t.Comments))
+	for i, c := range t.Comments {
+		if i == 0 {
+			commentParts = append(commentParts, m.renderReviewComment(c, r))
+		} else {
+			commentParts = append(commentParts, m.renderReviewCommentReply(c, r))
+		}
+	}
+
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		append([]string{header, hunk}, commentParts...)...,
+	)
+}
+
+func (m *Model) renderReviewComment(c data.ReviewComment, r glamour.TermRenderer) string {
+	pill := m.renderAuthorTimePill(c.Author.Login, c.CreatedAt)
+	body, _ := r.Render(c.Body)
+	return lipgloss.JoinVertical(lipgloss.Left, pill, body)
+}
+
+// renderReviewCommentReply renders a non-opener comment in a thread with a
+// compact "↳ {author} {time}" prefix and no pill, distinguishing it from the
+// thread opener and saving vertical space when threads are deep.
+func (m *Model) renderReviewCommentReply(c data.ReviewComment, r glamour.TermRenderer) string {
+	prefix := lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render("↳ "),
+		m.ctx.Styles.Common.MainTextStyle.Render(c.Author.Login),
+		" ",
+		lipgloss.NewStyle().
+			Foreground(m.ctx.Theme.FaintText).
+			Render(utils.TimeElapsed(c.CreatedAt)),
+	)
+	body, _ := r.Render(c.Body)
+	return lipgloss.JoinVertical(lipgloss.Left, prefix, body)
 }
 
 func renderEmptyState() string {
 	return lipgloss.NewStyle().Italic(true).Render("No comments...")
-}
-
-type comment struct {
-	Author    string
-	UpdatedAt time.Time
-	Body      string
-	Path      *string
-	Line      *int
-}
-
-func (m *Model) renderComment(
-	comment comment,
-	markdownRenderer glamour.TermRenderer,
-) (string, error) {
-	width := m.getIndentedContentWidth()
-	authorAndTime := lipgloss.NewStyle().
-		Width(width).
-		BorderStyle(lipgloss.RoundedBorder()).
-		BorderForeground(m.ctx.Theme.FaintBorder).Render(
-		lipgloss.JoinHorizontal(
-			lipgloss.Top,
-			m.ctx.Styles.Common.MainTextStyle.Render(comment.Author),
-			" ",
-			lipgloss.NewStyle().
-				Foreground(m.ctx.Theme.FaintText).
-				Render(utils.TimeElapsed(comment.UpdatedAt)),
-		))
-
-	var header string
-	if comment.Path != nil && comment.Line != nil {
-		filePath := lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Width(width).Render(
-			fmt.Sprintf(
-				"%s#l%d",
-				*comment.Path,
-				*comment.Line,
-			),
-		)
-		header = lipgloss.JoinVertical(lipgloss.Left, authorAndTime, filePath, "")
-	} else {
-		header = authorAndTime
-	}
-
-	body := lineCleanupRegex.ReplaceAllString(comment.Body, "")
-	body, err := markdownRenderer.Render(body)
-
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		header,
-		body,
-	), err
-}
-
-func (m *Model) renderReview(
-	review data.Review,
-	markdownRenderer glamour.TermRenderer,
-) (string, error) {
-	header := m.renderReviewHeader(review)
-	body, err := markdownRenderer.Render(review.Body)
-	return lipgloss.JoinVertical(
-		lipgloss.Left,
-		header,
-		body,
-	), err
 }
 
 func (m *Model) renderReviewHeader(review data.Review) string {
@@ -170,7 +352,7 @@ func (m *Model) renderReviewHeader(review data.Review) string {
 		m.ctx.Styles.Common.MainTextStyle.Render(review.Author.Login),
 		" ",
 		lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render(
-			"reviewed "+utils.TimeElapsed(review.UpdatedAt)),
+			"reviewed "+utils.TimeElapsed(review.SubmittedAt)),
 	)
 }
 
@@ -184,7 +366,8 @@ func (m *Model) renderReviewDecision(decision string) string {
 		return m.ctx.Styles.Common.SuccessGlyph
 	case "CHANGES_REQUESTED":
 		return m.ctx.Styles.Common.FailureGlyph
+	case "DISMISSED":
+		return lipgloss.NewStyle().Foreground(m.ctx.Theme.FaintText).Render("↺")
 	}
-
 	return ""
 }

--- a/internal/tui/components/prview/activity_test.go
+++ b/internal/tui/components/prview/activity_test.go
@@ -1,0 +1,667 @@
+package prview
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	graphql "github.com/cli/shurcooL-graphql"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prrow"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/markdown"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
+)
+
+func init() {
+	markdown.InitializeMarkdownStyle(true)
+}
+
+// ansiRE matches CSI/SGR escape sequences emitted by lipgloss/glamour. Tests
+// assert on rendered substrings; stripping ANSI is required when adjacent
+// styled fragments are split across different styles (e.g. "↳ " then author).
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripAnsi(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+// reviewSpec is a compact test input for one PullRequestReview submission.
+type reviewSpec struct {
+	id          string // synthetic ID; threads opened by this Review point back to it
+	state       string // APPROVED, CHANGES_REQUESTED, COMMENTED, PENDING
+	body        string
+	author      string
+	submittedAt time.Time
+}
+
+// threadSpec is a compact test input for one ReviewThread.
+type threadSpec struct {
+	openedByReviewId string // links the thread to its parent reviewSpec.id
+	path             string
+	line             int
+	startLine        int // 0 for single-line
+	isOutdated       bool
+	isResolved       bool
+	diffHunk         string
+	comments         []reviewCommentSpec
+}
+
+type reviewCommentSpec struct {
+	author    string
+	body      string
+	createdAt time.Time
+	replyToId string // empty for openers
+}
+
+// issueCommentSpec is a compact test input for one top-level PR conversation
+// IssueComment (the github "Comment" type, not a ReviewComment).
+type issueCommentSpec struct {
+	author    string
+	body      string
+	createdAt time.Time
+}
+
+type activityTestOptions struct {
+	reviews       []reviewSpec
+	threads       []threadSpec
+	issueComments []issueCommentSpec
+}
+
+func newTestModelForActivity(t *testing.T, opts activityTestOptions) Model {
+	t.Helper()
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	thm := theme.ParseTheme(&cfg)
+	ctx := &context.ProgramContext{
+		Config:           &cfg,
+		Theme:            thm,
+		Styles:           context.InitStyles(thm),
+		MainContentWidth: 100,
+	}
+
+	enriched := data.EnrichedPullRequestData{}
+
+	for _, r := range opts.reviews {
+		enriched.Reviews.Nodes = append(enriched.Reviews.Nodes, data.Review{
+			Id:          r.id,
+			State:       r.state,
+			Body:        r.body,
+			SubmittedAt: r.submittedAt,
+			Author: struct {
+				Login string
+			}{Login: r.author},
+		})
+	}
+	enriched.Reviews.TotalCount = len(enriched.Reviews.Nodes)
+
+	for _, ic := range opts.issueComments {
+		enriched.Comments.Nodes = append(enriched.Comments.Nodes, data.Comment{
+			Body:      ic.body,
+			CreatedAt: ic.createdAt,
+			UpdatedAt: ic.createdAt,
+			Author: struct {
+				Login string
+			}{Login: ic.author},
+		})
+	}
+	enriched.Comments.TotalCount = graphql.Int(len(enriched.Comments.Nodes))
+
+	for _, th := range opts.threads {
+		threadNode := struct {
+			Id           string
+			IsOutdated   bool
+			IsResolved   bool
+			OriginalLine int
+			StartLine    int
+			Line         int
+			Path         string
+			Comments     data.ReviewComments `graphql:"comments(first: 20)"`
+		}{
+			Id:         th.path + "#" + th.openedByReviewId,
+			IsOutdated: th.isOutdated,
+			IsResolved: th.isResolved,
+			StartLine:  th.startLine,
+			Line:       th.line,
+			Path:       th.path,
+		}
+		for _, c := range th.comments {
+			threadNode.Comments.Nodes = append(threadNode.Comments.Nodes, data.ReviewComment{
+				Body:      c.body,
+				CreatedAt: c.createdAt,
+				DiffHunk:  th.diffHunk,
+				StartLine: th.startLine,
+				Line:      th.line,
+				Author: struct {
+					Login string
+				}{Login: c.author},
+				PullRequestReview: struct{ Id string }{Id: th.openedByReviewId},
+				ReplyTo:           struct{ Id string }{Id: c.replyToId},
+			})
+		}
+		threadNode.Comments.TotalCount = len(threadNode.Comments.Nodes)
+		enriched.ReviewThreads.Nodes = append(enriched.ReviewThreads.Nodes, threadNode)
+	}
+
+	m := NewModel(ctx)
+	m.ctx = ctx
+	m.width = 100
+	m.pr = &prrow.PullRequest{
+		Ctx: ctx,
+		Data: &prrow.Data{
+			Primary: &data.PullRequestData{
+				Repository: data.Repository{},
+			},
+			IsEnriched: true,
+			Enriched:   enriched,
+		},
+	}
+	return m
+}
+
+const sampleDiffHunk = `@@ -38,7 +38,11 @@ func (m *Model) renderActivity() string {
+ 	var activities []RenderedActivity
+ 	var comments []comment
+-	if !m.pr.Data.IsEnriched {
++	if !m.pr.Data.IsEnriched {
++		return bodyStyle.Render("Loading...")
++	}
++
++	if len(m.pr.Data.Enriched.ReviewThreads.Nodes) == 0 {
+ 		return bodyStyle.Render("Loading...")
+ 	}`
+
+// Cycle 1 (tracer): A Review opening one ReviewThread (one ReviewComment)
+// renders the Review pill, the thread's path:line header, the diff-hunk
+// content, and the comment body.
+func TestRenderActivity_ReviewWithOneThread(t *testing.T) {
+	submittedAt := time.Date(2026, 5, 13, 16, 33, 24, 0, time.UTC)
+	createdAt := submittedAt.Add(-2 * time.Second)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{
+				id:          "REVIEW_1",
+				state:       "APPROVED",
+				body:        "LGTM with one nit.",
+				author:      "alice",
+				submittedAt: submittedAt,
+			},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "REVIEW_1",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{
+						author:    "alice",
+						body:      "Could we extract this into a helper?",
+						createdAt: createdAt,
+					},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := m.renderActivity()
+
+	require.Contains(t, got, "alice", "review author should appear")
+	require.Contains(t, got, "LGTM with one nit.", "review body should appear")
+	require.Contains(t, got, "internal/data/prapi.go:42", "thread path:line anchor should appear")
+	require.Contains(t, got, "ReviewThreads.Nodes",
+		"diff hunk content should appear (truncated to last 4 lines, which contain this fragment)")
+	require.Contains(t, got, "Could we extract this", "comment body should appear")
+	require.False(t, strings.Contains(got, "no comments"), "should not show empty state")
+}
+
+// Cycle 2: A multi-line ReviewThread (StartLine != Line) renders the anchor
+// header as "path:startLine-line" rather than "path:line".
+func TestRenderActivity_MultiLineAnchor(t *testing.T) {
+	submittedAt := time.Date(2026, 5, 13, 16, 33, 24, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "bob", submittedAt: submittedAt},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             "internal/data/prapi.go",
+				startLine:        38,
+				line:             42,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "bob", body: "Multi-line concern", createdAt: submittedAt},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := m.renderActivity()
+
+	require.Contains(t, got, "internal/data/prapi.go:38-42",
+		"multi-line anchor should render as path:start-end")
+	require.NotContains(t, got, "internal/data/prapi.go:42 ",
+		"should not render the single-line path:line form for a multi-line thread")
+}
+
+// Cycle 3: A ReviewThread with IsOutdated=true shows an [Outdated] badge in
+// its header. The thread content stays visible (we deliberately do not
+// collapse — see Q4a in the spec).
+func TestRenderActivity_OutdatedBadge(t *testing.T) {
+	submittedAt := time.Date(2026, 5, 13, 16, 33, 24, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "bob", submittedAt: submittedAt},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             "old/file.go",
+				line:             10,
+				isOutdated:       true,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "bob", body: "Stale concern", createdAt: submittedAt},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := m.renderActivity()
+
+	require.Contains(t, got, "Outdated", "outdated badge should appear")
+	require.Contains(t, got, "Stale concern", "outdated thread body should still render")
+}
+
+// Cycle 4: A ReviewThread with IsResolved=true shows a [Resolved] badge in
+// its header. Like Outdated, content stays visible.
+func TestRenderActivity_ResolvedBadge(t *testing.T) {
+	submittedAt := time.Date(2026, 5, 13, 16, 33, 24, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "bob", submittedAt: submittedAt},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             "internal/data/prapi.go",
+				line:             10,
+				isResolved:       true,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "bob", body: "Closed convo", createdAt: submittedAt},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := m.renderActivity()
+
+	require.Contains(t, got, "Resolved", "resolved badge should appear")
+	require.Contains(t, got, "Closed convo", "resolved thread body should still render")
+}
+
+// Cycle 6: Reviews and IssueComments interleave in chronological order at the
+// top level. We key Reviews by SubmittedAt and IssueComments by CreatedAt and
+// expect the rendered output to contain them in that order regardless of the
+// source-stream order they arrived in.
+func TestRenderActivity_ChronologicalOrdering(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 9, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R_LATE", state: "APPROVED", body: "review-late-body", author: "carol", submittedAt: t0.Add(10 * time.Hour)},
+			{id: "R_EARLY", state: "CHANGES_REQUESTED", body: "review-early-body", author: "alice", submittedAt: t0},
+		},
+		issueComments: []issueCommentSpec{
+			{author: "bob", body: "issue-comment-body", createdAt: t0.Add(5 * time.Hour)},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	earlyIdx := strings.Index(got, "review-early-body")
+	icIdx := strings.Index(got, "issue-comment-body")
+	lateIdx := strings.Index(got, "review-late-body")
+
+	require.NotEqual(t, -1, earlyIdx, "early review body should render")
+	require.NotEqual(t, -1, icIdx, "issue comment body should render")
+	require.NotEqual(t, -1, lateIdx, "late review body should render")
+	require.Less(t, earlyIdx, icIdx, "earlier review should render before later issue comment")
+	require.Less(t, icIdx, lateIdx, "earlier issue comment should render before later review")
+}
+
+// Cycle 7: An implicit Review (state=COMMENTED, body="") that opened exactly
+// one ReviewThread is unwrapped: the thread renders as a top-level item, and
+// no "X reviewed" wrapper appears for the synthetic Review.
+func TestRenderActivity_ImplicitReviewOneThreadPromoted(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "IMPLICIT", state: "COMMENTED", body: "", author: "alice", submittedAt: t0},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "IMPLICIT",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "bare-thread-body", createdAt: t0},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, "bare-thread-body", "promoted thread body should render")
+	require.Contains(t, got, "internal/data/prapi.go:42", "thread anchor should render")
+	require.NotContains(t, got, "reviewed", "implicit Review wrapper should be stripped (no 'reviewed' header)")
+}
+
+// Cycle 8: An implicit Review (state=COMMENTED, body="") that opened zero
+// ReviewThreads — i.e. it only contributed replies into other people's
+// threads — is hidden entirely. The reply already renders inside its parent
+// thread, so surfacing the empty wrapper would be redundant noise.
+func TestRenderActivity_ImplicitReviewZeroThreadsHidden(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "REAL", state: "APPROVED", body: "real-review-body", author: "alice", submittedAt: t0},
+			// Implicit Review contributes a reply into REAL's thread; opens no threads itself.
+			{id: "IMPLICIT_REPLIER", state: "COMMENTED", body: "", author: "bob", submittedAt: t0.Add(time.Hour)},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "REAL",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "opener-body", createdAt: t0},
+					{author: "bob", body: "reply-body", createdAt: t0.Add(time.Hour)},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, "real-review-body", "real review body should render")
+	require.Contains(t, got, "reply-body", "reply should still render inside the parent thread")
+	bobReviewedIdx := strings.Index(got, "bob reviewed")
+	require.Equal(t, -1, bobReviewedIdx, "implicit reply-only Review wrapper must not appear as 'bob reviewed'")
+}
+
+// Cycle 9: An implicit Review (state=COMMENTED, body="") that opened 2+
+// ReviewThreads in a single submission is unwrapped into multiple bare
+// top-level threads (one activityItem per thread). No "X reviewed" wrapper
+// appears for the synthetic Review.
+func TestRenderActivity_ImplicitReviewMultipleThreadsPromoted(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "IMPLICIT", state: "COMMENTED", body: "", author: "alice", submittedAt: t0},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "IMPLICIT",
+				path:             "a/first.go",
+				line:             10,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "first-thread-body", createdAt: t0},
+				},
+			},
+			{
+				openedByReviewId: "IMPLICIT",
+				path:             "b/second.go",
+				line:             20,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "second-thread-body", createdAt: t0.Add(time.Second)},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, "first-thread-body", "first promoted thread should render")
+	require.Contains(t, got, "second-thread-body", "second promoted thread should render")
+	require.Contains(t, got, "a/first.go:10", "first thread anchor should render")
+	require.Contains(t, got, "b/second.go:20", "second thread anchor should render")
+	require.NotContains(t, got, "reviewed", "implicit Review wrapper should be stripped")
+}
+
+// Cycle 10: The activity title's "N comments" count matches GitHub web — it
+// counts leaf-level comments (non-empty review bodies + all thread comments +
+// all issue comments), not top-level rendered items. Implicit reviews (empty
+// body) never contribute, since their wrapper is stripped.
+func TestRenderActivity_TitleCountIsLeafComments(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "REAL", state: "APPROVED", body: "real-review-body", author: "alice", submittedAt: t0},
+			// Implicit review — should not contribute to the count.
+			{id: "IMPLICIT", state: "COMMENTED", body: "", author: "bob", submittedAt: t0.Add(time.Hour)},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "REAL",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "opener", createdAt: t0},
+					{author: "bob", body: "reply", createdAt: t0.Add(time.Hour)},
+				},
+			},
+		},
+		issueComments: []issueCommentSpec{
+			{author: "carol", body: "issue-comment", createdAt: t0.Add(2 * time.Hour)},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	// Leaf count: 1 review body + 2 thread comments + 1 issue comment = 4.
+	require.Contains(t, got, "4 comments",
+		"title should show leaf-comment count (1 review body + 2 thread comments + 1 issue comment)")
+}
+
+// Cycle 11: A DISMISSED review renders with a state glyph in its header (web
+// signals "dismissed" with explicit affordance and so should we). Before this
+// fix, renderReviewDecision returned "" for DISMISSED, leaving just whitespace
+// before the author name.
+func TestRenderActivity_DismissedReviewHasGlyph(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R_DISMISSED", state: "DISMISSED", body: "stale-approval", author: "jasper", submittedAt: t0},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	// The glyph used is ↺ (faint, "rotated/dismissed"). Test asserts presence
+	// rather than a specific glyph so the visual can be tweaked without churn.
+	require.Contains(t, got, "↺", "DISMISSED review header should include a state glyph")
+	require.Contains(t, got, "stale-approval", "DISMISSED review body should still render")
+	require.Contains(t, got, "jasper reviewed", "DISMISSED review still gets a reviewer header")
+}
+
+// Cycle 12: A diff hunk longer than 4 content lines is truncated to its last 4
+// (closest to the anchor), matching GitHub web's collapsed preview. Earlier
+// lines are dropped and an ellipsis marker indicates truncation. The @@ header
+// is never shown — it's just position metadata.
+func TestRenderActivity_DiffHunkTruncatedToLast4Lines(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	// 8 content lines after the @@ header; only the last 4 should survive.
+	longHunk := "@@ -0,0 +1,8 @@\n" +
+		"+line-one-FAR-FROM-ANCHOR\n" +
+		"+line-two-FAR-FROM-ANCHOR\n" +
+		"+line-three-FAR-FROM-ANCHOR\n" +
+		"+line-four-FAR-FROM-ANCHOR\n" +
+		"+line-five-KEEP\n" +
+		"+line-six-KEEP\n" +
+		"+line-seven-KEEP\n" +
+		"+line-eight-KEEP-ANCHOR"
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "alice", submittedAt: t0},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             "new_file.py",
+				line:             8,
+				diffHunk:         longHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "concern", createdAt: t0},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, "line-eight-KEEP-ANCHOR", "last hunk line should render")
+	require.Contains(t, got, "line-five-KEEP", "4th-from-last line should render")
+	require.NotContains(t, got, "line-four-FAR-FROM-ANCHOR", "5th-from-last line should be truncated")
+	require.NotContains(t, got, "line-one-FAR-FROM-ANCHOR", "first line should be truncated")
+	require.NotContains(t, got, "@@ -0,0", "the @@ header itself should never render")
+}
+
+// Cycle 13: When the anchor + badges together exceed the panel's content
+// width, the badges fall to a second line under the anchor instead of being
+// clipped. Badges carry "is this thread still actionable?" signal; truncating
+// them silently loses information.
+func TestRenderActivity_BadgesWrapWhenAnchorOverflows(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	longPath := strings.Repeat("very/deeply/nested/", 6) + "module.py"
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "alice", submittedAt: t0},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             longPath,
+				line:             9999,
+				isOutdated:       true,
+				isResolved:       true,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "concern", createdAt: t0},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, longPath+":9999", "anchor should render in full")
+	require.Contains(t, got, "Outdated", "Outdated badge should still appear even when anchor is wide")
+	require.Contains(t, got, "Resolved", "Resolved badge should still appear even when anchor is wide")
+
+	// Wrap is detected by the badges sitting on their own line — i.e. the
+	// anchor and the first badge are separated by a newline, not just a space.
+	anchorIdx := strings.Index(got, longPath+":9999")
+	resolvedIdx := strings.Index(got, "[Resolved]")
+	require.Greater(t, resolvedIdx, anchorIdx, "badges should follow the anchor")
+	between := got[anchorIdx:resolvedIdx]
+	require.Contains(t, between, "\n",
+		"badges should wrap to a new line when they don't fit alongside the anchor")
+}
+
+// Cycle 5: Within a thread, the second-and-later ReviewComments render with a
+// compact "↳ {author}" reply prefix instead of the full pill that the opener
+// uses. This signals "this is a reply, not a new thread starter."
+func TestRenderActivity_ReplyPrefix(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			{id: "R1", state: "COMMENTED", body: "x", author: "alice", submittedAt: t0},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R1",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				diffHunk:         sampleDiffHunk,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "opener-body", createdAt: t0},
+					{author: "bob", body: "reply-body", createdAt: t0.Add(time.Hour)},
+				},
+			},
+		},
+	}
+
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+
+	require.Contains(t, got, "opener-body", "opener comment body should render")
+	require.Contains(t, got, "reply-body", "reply comment body should render")
+	require.Contains(t, got, "↳ bob", "reply should be prefixed with ↳ {author}")
+}
+
+// Cycle 14: GitHub web's Conversation N badge silently excludes review-summary
+// cards where state=COMMENTED, body is non-empty, and inline-comment count is
+// zero — it treats them as redundant with a plain IssueComment. Reviews with
+// any other non-COMMENTED state (DISMISSED/CHANGES_REQUESTED/APPROVED) still
+// count, and COMMENTED reviews that DO host inline comments also count.
+func TestRenderActivity_CountExcludesCommentedReviewWithNoInlines(t *testing.T) {
+	t0 := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	opts := activityTestOptions{
+		reviews: []reviewSpec{
+			// COMMENTED + body + 0 inline → excluded from count (bot fallback
+			// pattern, e.g. gemini "I am having trouble creating individual
+			// review comments").
+			{id: "R_COMMENTED_BODY_NO_INLINE", state: "COMMENTED", body: "trouble-body", author: "gemini-bot", submittedAt: t0},
+			// COMMENTED + body + inline > 0 → counted.
+			{id: "R_COMMENTED_BODY_WITH_INLINE", state: "COMMENTED", body: "review-with-inlines", author: "alice", submittedAt: t0.Add(time.Hour)},
+			// DISMISSED + body + 0 inline → counted (state != COMMENTED).
+			{id: "R_DISMISSED_NO_INLINE", state: "DISMISSED", body: "dismissed-body", author: "jasper", submittedAt: t0.Add(2 * time.Hour)},
+		},
+		threads: []threadSpec{
+			{
+				openedByReviewId: "R_COMMENTED_BODY_WITH_INLINE",
+				path:             "internal/data/prapi.go",
+				line:             42,
+				comments: []reviewCommentSpec{
+					{author: "alice", body: "inline-1", createdAt: t0.Add(time.Hour)},
+				},
+			},
+		},
+		issueComments: []issueCommentSpec{
+			{author: "carol", body: "ic-1", createdAt: t0.Add(3 * time.Hour)},
+		},
+	}
+
+	// Counted: R_COMMENTED_BODY_WITH_INLINE (1) + R_DISMISSED_NO_INLINE (1)
+	//          + 1 inline + 1 IC = 4.
+	// R_COMMENTED_BODY_NO_INLINE is excluded — that's the GitHub-web rule.
+	m := newTestModelForActivity(t, opts)
+	got := stripAnsi(m.renderActivity())
+	require.Contains(t, got, "4 comments",
+		"COMMENTED review with body but no inline comments should NOT contribute to the count")
+}


### PR DESCRIPTION
# Summary

- [x] Closes issue #852
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

**Status: WIP — please comment if you don't like the current direction while I polish the edges.**

Reworks the PR activity panel to look more like GitHub web's Conversation tab. A few things going on here:

- **Thread grouping** — review comments now sit under the thread they belong to instead of flat-by-timestamp. Replies get a compact `↳ {author}` prefix.
- **Diff hunks** — fetch `diffHunk` on review comments and render the last 4 content lines above each thread (mirroring the collapsed preview on web). `@@` headers get stripped since they're just positional metadata.
- **Thread badges** — `[Outdated]` and `[Resolved]` render inline next to the anchor, and wrap to the next line when the anchor is too wide rather than getting clipped.
- **DISMISSED glyph** — was rendering as blank space before. Now uses a faint `↺` so dismissed approvals don't look like rendering bugs.
- **Implicit-Review unwrap** — GitHub auto-generates a `state=COMMENTED, body=""` wrapper whenever a thread starts outside a formal review. The TUI was rendering these as empty `xyz reviewed` blocks. Now: 0 threads → hide; 1 → promote the thread up a level; 2+ → promote them all as siblings.
- **Conversation count** — the `N comments` figure in the title now matches the web `(N)` badge, including the slightly weird case where reviews with `state=COMMENTED` + body + zero inline comments get excluded (web treats them as redundant with plain IssueComments, even though it still renders the card — I went back and forth on this one, ended up matching web for consistency).

Keybindings and overall panel layout unchanged.

## How Did You Test this Change?

- `go test ./internal/tui/components/prview ./internal/data` — added 14 new tests in `activity_test.go` covering each behaviour above (thread grouping, diff-hunk truncation, badges, DISMISSED glyph, implicit-review unwrap cases, count-badge web-parity)
- `go build && go vet ./...` clean
- Manual side-by-side against `gh-dash` v4.24.1 on a 20+-review PR (mixed thread/IssueComment/DISMISSED activity); will attach screenshots once the UI is polished

## Images/Videos

(will attach side-by-side screenshots once I'm happy with the UI)

## AI Usage Disclosure

Per [AI_POLICY.md](../AI_POLICY.md): wrote the code with **Claude Code** as a pair-programming assistant, with substantial AI involvement on the implementation drafts and tests. Each design decision (web-parity counting, implicit-review unwrap cases, diff-hunk truncation length, badge wrap behaviour) was driven and reviewed by me, with multiple rounds of pushback on the approach before landing. I understand the changes and can explain how the activity-panel pipeline interacts with the GraphQL fragment and the existing PR view — happy to walk through any part on request.

Closes #852 