### PR TITLE
fix: avoid markdown renderer panic before theme init

### DIFF
--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -21,7 +21,7 @@ func InitializeMarkdownStyle(hasDarkBackground bool) {
 
 func GetMarkdownRenderer(width int) glamour.TermRenderer {
 	markdownRenderer, err := glamour.NewTermRenderer(
-		glamour.WithStyles(*markdownStyle),
+		glamour.WithStyles(getMarkdownStyle()),
 		glamour.WithWordWrap(width),
 	)
 	if err != nil || markdownRenderer == nil {
@@ -35,4 +35,12 @@ func GetMarkdownRenderer(width int) glamour.TermRenderer {
 	}
 
 	return *markdownRenderer
+}
+
+func getMarkdownStyle() ansi.StyleConfig {
+	if markdownStyle == nil {
+		return styles.LightStyleConfig
+	}
+
+	return *markdownStyle
 }

--- a/internal/tui/markdown/markdownRenderer_test.go
+++ b/internal/tui/markdown/markdownRenderer_test.go
@@ -1,0 +1,14 @@
+package markdown
+
+import "testing"
+
+func TestGetMarkdownRendererWithoutInitializedStyle(t *testing.T) {
+	markdownStyle = nil
+	t.Cleanup(func() { markdownStyle = nil })
+
+	renderer := GetMarkdownRenderer(80)
+
+	if _, err := renderer.Render("# title"); err != nil {
+		t.Fatalf("render markdown: %v", err)
+	}
+}


### PR DESCRIPTION
# Summary

- [x] Closes issue #876
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

Fix `GetMarkdownRenderer` when `tea.BackgroundColorMsg` is not received by using the light markdown style as a local fallback while `markdownStyle` is nil.

The change also adds a regression test that leaves `markdownStyle` uninitialized and verifies markdown rendering does not panic.

Fixes #876

## AI usage disclosure

Tool used: OpenAI GPT-5. Extent: assisted with code/test drafting, repository navigation, and validation command selection. I reviewed and edited the final diff and verified the bug reproduction and fix locally.

## How Did You Test this Change?

- Red check before implementation: `go test ./internal/tui/markdown -run TestGetMarkdownRendererWithoutInitializedStyle -count=1` failed with the reported nil pointer panic.
- `go test ./internal/tui/markdown -run TestGetMarkdownRendererWithoutInitializedStyle -count=1`
- `go test ./internal/tui/markdown ./internal/tui/components/issueview ./internal/tui/components/prview ./internal/tui -count=1`
- `go test ./... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --path-mode=abs --config=.golangci.yml --timeout=5m ./internal/tui/markdown` reported `0 issues`.
- `git diff --check`

Note: `task lint` was not available in this environment because `task`, `golangci-lint`, and `gofumpt` were not installed. I invoked the configured `golangci-lint` version directly for the touched package.

## Images/Videos

Not applicable; this fixes a panic path covered by a regression test.
