### PR TITLE
fix: use shared-state background color to avoid nil pointer (#876)

### DIFF
--- a/internal/tui/components/issueview/activity.go
+++ b/internal/tui/components/issueview/activity.go
@@ -19,7 +19,7 @@ type RenderedActivity struct {
 
 func (m *Model) renderActivity() string {
 	width := m.getIndentedContentWidth() - 2
-	markdownRenderer := markdown.GetMarkdownRenderer(width)
+	markdownRenderer := markdown.GetMarkdownRenderer(width, m.ctx)
 
 	var activity []RenderedActivity
 	for _, comment := range m.issue.Data.Comments.Nodes {

--- a/internal/tui/components/issueview/issueview.go
+++ b/internal/tui/components/issueview/issueview.go
@@ -225,7 +225,7 @@ func (m *Model) renderBody() string {
 			Render("No description provided.")
 	}
 
-	markdownRenderer := markdown.GetMarkdownRenderer(width)
+	markdownRenderer := markdown.GetMarkdownRenderer(width, m.ctx)
 	rendered, err := markdownRenderer.Render(body)
 	if err != nil {
 		return ""

--- a/internal/tui/components/prview/activity.go
+++ b/internal/tui/components/prview/activity.go
@@ -21,7 +21,7 @@ type RenderedActivity struct {
 
 func (m *Model) renderActivity() string {
 	width := m.getIndentedContentWidth()
-	markdownRenderer := markdown.GetMarkdownRenderer(width)
+	markdownRenderer := markdown.GetMarkdownRenderer(width, m.ctx)
 	bodyStyle := lipgloss.NewStyle()
 
 	var activities []RenderedActivity

--- a/internal/tui/components/prview/prview.go
+++ b/internal/tui/components/prview/prview.go
@@ -514,7 +514,7 @@ func (m *Model) renderSummary() string {
 		)
 	}
 
-	markdownRenderer := markdown.GetMarkdownRenderer(width)
+	markdownRenderer := markdown.GetMarkdownRenderer(width, m.ctx)
 	rendered, err := markdownRenderer.Render(body)
 	if err != nil {
 		return ""

--- a/internal/tui/context/context.go
+++ b/internal/tui/context/context.go
@@ -40,6 +40,8 @@ type ProgramContext struct {
 	DynamicPreviewHeight int    // calculated preview height for bottom mode
 	PreviewPosition      string // resolved "right" or "bottom"
 	SidebarOpen          bool
+	HasDarkBackground    bool
+	BackgroundSource     string
 	Config               *config.Config
 	ConfigFlag           string
 	Version              string

--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -4,14 +4,19 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/glamour/v2/styles"
+	log "charm.land/log/v2"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
-var markdownStyle *ansi.StyleConfig
+var (
+	markdownStyle       *ansi.StyleConfig
+	markdownStyleSource string
+)
 
 func InitializeMarkdownStyle(ctx *context.ProgramContext) {
-	if markdownStyle != nil && ctx.BackgroundSource == "bubbletea" {
+	if markdownStyle != nil && markdownStyleSource == "bubbletea" {
+		log.Debugf("InitializeMarkdownStyle: keeping existing bubbletea style")
 		return
 	}
 
@@ -20,6 +25,13 @@ func InitializeMarkdownStyle(ctx *context.ProgramContext) {
 	} else {
 		markdownStyle = &styles.LightStyleConfig
 	}
+	markdownStyleSource = ctx.BackgroundSource
+
+	log.Debugf(
+		"InitializeMarkdownStyle: assigned ctx.hasDarkBackground=%t, markdownStyleSource=%q",
+		ctx.HasDarkBackground,
+		markdownStyleSource,
+	)
 }
 
 func GetMarkdownRenderer(width int, ctx *context.ProgramContext) glamour.TermRenderer {

--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -4,22 +4,29 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/glamour/v2/ansi"
 	"charm.land/glamour/v2/styles"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 )
 
 var markdownStyle *ansi.StyleConfig
 
-func InitializeMarkdownStyle(hasDarkBackground bool) {
-	if markdownStyle != nil {
+func InitializeMarkdownStyle(ctx *context.ProgramContext) {
+	if markdownStyle != nil && ctx.BackgroundSource == "bubbletea" {
 		return
 	}
-	if hasDarkBackground {
+
+	if ctx.HasDarkBackground {
 		markdownStyle = &CustomDarkStyleConfig
 	} else {
 		markdownStyle = &styles.LightStyleConfig
 	}
 }
 
-func GetMarkdownRenderer(width int) glamour.TermRenderer {
+func GetMarkdownRenderer(width int, ctx *context.ProgramContext) glamour.TermRenderer {
+	if markdownStyle == nil {
+		InitializeMarkdownStyle(ctx)
+	}
+
 	markdownRenderer, err := glamour.NewTermRenderer(
 		glamour.WithStyles(*markdownStyle),
 		glamour.WithWordWrap(width),

--- a/internal/tui/modelUtils.go
+++ b/internal/tui/modelUtils.go
@@ -331,7 +331,7 @@ func (m *Model) executeCustomCommand(cmd string) tea.Cmd {
 	c := exec.Command(shell, "-c", cmd)
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		if err != nil {
-			mdRenderer := markdown.GetMarkdownRenderer(m.ctx.ScreenWidth)
+			mdRenderer := markdown.GetMarkdownRenderer(m.ctx.ScreenWidth, m.ctx)
 			md, mdErr := mdRenderer.Render(fmt.Sprintf("While running: `%s`", cmd))
 			if mdErr != nil {
 				return constants.ErrMsg{Err: mdErr}

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -683,7 +683,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			log.Debugf("Setting markdownStyle in initMsg")
 			m.ctx.HasDarkBackground = compat.HasDarkBackground
 			m.ctx.BackgroundSource = "compat"
-			log.Debugf("HasDarkBackground: %t, BackgroundSource: %s", m.ctx.HasDarkBackground, m.ctx.BackgroundSource)
+			log.Debugf(
+				"HasDarkBackground: %t, BackgroundSource: %s",
+				m.ctx.HasDarkBackground,
+				m.ctx.BackgroundSource,
+			)
 			markdown.InitializeMarkdownStyle(m.ctx)
 		}
 
@@ -841,7 +845,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		log.Debugf("Setting markdownStyle in BackgroundColorMsg")
 		m.ctx.HasDarkBackground = msg.IsDark()
 		m.ctx.BackgroundSource = "bubbletea"
-		log.Debugf("HasDarkBackground: %t, BackgroundSource: %s", m.ctx.HasDarkBackground, m.ctx.BackgroundSource)
+		log.Debugf(
+			"HasDarkBackground: %t, BackgroundSource: %s",
+			m.ctx.HasDarkBackground,
+			m.ctx.BackgroundSource,
+		)
 		markdown.InitializeMarkdownStyle(m.ctx)
 
 	case updateFooterMsg:

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -13,6 +13,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
 	log "charm.land/log/v2"
 	"github.com/atotto/clipboard"
 	"github.com/cli/go-gh/v2/pkg/browser"
@@ -89,7 +90,9 @@ func NewModel(location config.Location) Model {
 			m.tasks[task.Id] = task
 			return m.taskSpinner.Tick
 		},
-		Theme: *theme.DefaultTheme,
+		HasDarkBackground: true,
+		BackgroundSource:  "default",
+		Theme:             *theme.DefaultTheme,
 	}
 
 	m.footer = footer.NewModel(m.ctx)
@@ -675,6 +678,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		newSections, fetchSectionsCmds := m.fetchAllViewSections()
 		m.setCurrentViewSections(newSections)
 		m.tabs.SetCurrSectionId(1)
+
+		if m.ctx.BackgroundSource != "bubbletea" {
+			log.Debugf("Setting markdownStyle in initMsg")
+			m.ctx.HasDarkBackground = compat.HasDarkBackground
+			m.ctx.BackgroundSource = "compat"
+			log.Debugf("HasDarkBackground: %t, BackgroundSource: %s", m.ctx.HasDarkBackground, m.ctx.BackgroundSource)
+			markdown.InitializeMarkdownStyle(m.ctx)
+		}
+
 		cmds = append(cmds, fetchSectionsCmds, m.tabs.Init(), fetchUser,
 			m.doRefreshAtInterval(), m.doUpdateFooterAtInterval())
 
@@ -826,7 +838,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.onWindowSizeChanged(msg)
 
 	case tea.BackgroundColorMsg:
-		markdown.InitializeMarkdownStyle(msg.IsDark())
+		log.Debugf("Setting markdownStyle in BackgroundColorMsg")
+		m.ctx.HasDarkBackground = msg.IsDark()
+		m.ctx.BackgroundSource = "bubbletea"
+		log.Debugf("HasDarkBackground: %t, BackgroundSource: %s", m.ctx.HasDarkBackground, m.ctx.BackgroundSource)
+		markdown.InitializeMarkdownStyle(m.ctx)
 
 	case updateFooterMsg:
 		cmds = append(cmds, cmd, m.doUpdateFooterAtInterval())


### PR DESCRIPTION
## Summary
Fixes #876 — TUI crashes with nil pointer dereference of `markdownStyle` when
`BackgroundColorMsg` not reached

This PR introduces background color shared state, default and fallback behaviors, and changes to the `InitializeMarkdownStyle` and `GetMarkdownRender` functions signatures to ensure that `*markdownStyle` is never nil when dereferenced.

- [x] Closes issue #876
- [x] I have read the [CONTIBUTING.md](https://github.com/dlvhdr/gh-dash/CONTRIBUTING.md) and [AI_POLICY.md](https://github.com/dlvhdr/gh-dash/AI_POLICY.md) guides

## AI disclosure (per AI_POLICY.md)
Diagnosis of nil pointer dereference location was done with assistance of GPT-5.4 (via OpenCode). Same AI was also used to identify `GetMarkdownRender` usage extense given the bugfix plan I'm proposing involved altering the function's signature.

## Solution
Here are the changes introduced:

`internal/tui/context/context.go`
- introduce 2 new fields to the `ProgramContext` struct: `HasDarkBackground` bool, `BackgroundSource` string

`interna/tui/markdown/markdownRenderer.go`
- alter `InitializeMarkdownStyle` and `GetMarkdownRenderer` signatures to include `*context.ProgramContext`. These ensure the shared state values `ctx.HasBackground` and `ctx.BackgroundSource` are available for the create of the markdown renderer.

`internal/tui/ui.go`
- initialize program context with defaults for `ctx.HasBackground` and `ctx.BackgroundSource`
- create fallback behavior that uses lipgloss's `compat.HasDarkBackground` as boolean for `ctx.HasDarkBackground`
- set background color fields in context from `tea.BackgroundColorMsg` when reached
- debug log statements with background color values

`internal/tui/components/issueview/activity.go`
`internal/tui/components/issueview/issueview.go`
`internal/tui/components/prview/activity.go`
`internal/tui/components/prview/prview.go`
`internal/tui/modelUtils.go`
- call `GetMarkdownRender` with context as argument

## Testing
Verified the nil pointer derefence panic present on tag v4.24.1 on setup described in #876.

Rebuilt binary with patch (commit 46b5843787fc), removed and reinstalled dash extension from local repo

Started gh dash with debug flag. Verified nil pointer derefence panic is gone and that debug logs describe shared state as expected. 

Verified gh dash works normally and renders markdown contents of PRs and issues with expected background