### PR TITLE
fix: accept pgdn keybinding alias

### DIFF
--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -245,6 +245,15 @@ var (
 	CustomNotificationBindings []key.Binding
 )
 
+func normalizeConfigKey(key string) string {
+	switch key {
+	case "pgdn":
+		return "pgdown"
+	default:
+		return key
+	}
+}
+
 func rebindUniversal(universal []config.Keybinding) error {
 	log.Debug("Rebinding universal keys", "keys", universal)
 
@@ -260,7 +269,7 @@ func rebindUniversal(universal []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(kb.Key),
+					key.WithKeys(normalizeConfigKey(kb.Key)),
 					key.WithHelp(kb.Key, name),
 				)
 
@@ -316,7 +325,7 @@ func rebindUniversal(universal []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in universal key: '%s'", kb.Builtin)
 		}
 
-		key.SetKeys(kb.Key)
+		key.SetKeys(normalizeConfigKey(kb.Key))
 
 		helpDesc := key.Help().Desc
 		if kb.Name != "" {

--- a/internal/tui/keys/keys_test.go
+++ b/internal/tui/keys/keys_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 )
@@ -196,6 +197,30 @@ func TestRebindNotificationKeys_Builtin(t *testing.T) {
 	keys := NotificationKeys.MarkAsDone.Keys()
 	if len(keys) != 1 || keys[0] != "X" {
 		t.Errorf("expected key to be rebound to X, got %v", keys)
+	}
+}
+
+func TestRebindUniversalPageDownAcceptsPgdnAlias(t *testing.T) {
+	origKeys := append([]string(nil), Keys.PageDown.Keys()...)
+	origHelp := Keys.PageDown.Help()
+	defer func() {
+		Keys.PageDown.SetKeys(origKeys...)
+		Keys.PageDown.SetHelp(origHelp.Key, origHelp.Desc)
+	}()
+
+	err := rebindUniversal([]config.Keybinding{
+		{Builtin: "pageDown", Key: "pgdn"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	msg := tea.KeyPressMsg(tea.Key{Code: tea.KeyPgDown})
+	if !key.Matches(msg, Keys.PageDown) {
+		t.Fatalf("PageDown key = %q; want to match %q", msg.String(), "pgdn")
+	}
+	if Keys.PageDown.Help().Key != "pgdn" {
+		t.Fatalf("PageDown help key = %q; want %q", Keys.PageDown.Help().Key, "pgdn")
 	}
 }
 


### PR DESCRIPTION
## Summary
- [x] Closes issue #465
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

- normalize configured `pgdn` keybindings to Bubble Tea's `pgdown` key event name
- preserve the configured help label so help still shows `pgdn`
- add regression coverage for rebinding `pageDown` to `pgdn`

Fixes #465

## AI assistance
OpenAI GPT-5 assisted with drafting the patch and verification steps. I reviewed the change, checked it against the keybinding behavior, and kept responsibility for the final submission.

## How Did You Test this Change?
Red test before the fix:
- `go test ./internal/tui/keys -run TestRebindUniversalPageDownAcceptsPgdnAlias -count=1 -v` failed because the PageDown event string was `pgdown` and did not match configured `pgdn`

After the fix:
- `go test ./internal/tui/keys -run TestRebindUniversalPageDownAcceptsPgdnAlias -count=1 -v`
- `go test ./internal/tui/keys -count=1`
- `go test ./internal/tui -run 'Test.*Keybinding|Test.*Page|Test.*Preview' -count=1`
- `go test ./... -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1 run --path-mode=abs --config=.golangci.yml --timeout=5m ./internal/tui/keys`
- `git diff --check`

## Images/Videos
Not applicable.