### PR TITLE
docs: clarify keybinding key values

### DIFF
--- a/docs/src/content/docs/configuration/keybindings/index.mdx
+++ b/docs/src/content/docs/configuration/keybindings/index.mdx
@@ -13,8 +13,8 @@ There are 3 types of keybindings: `universal`, `prs` and `issues`.
 
 ## Key Values
 
-The `key` value must match the key string emitted by [Bubble Tea][bubbletea-keys]. `dash` does
-not translate alternate key names or terminal labels before matching a keybinding.
+The `key` value must match one of the [Ultraviolet key strings][ultraviolet-key-strings].
+`dash` does not translate alternate key names or terminal labels before matching a keybinding.
 
 For example, Page Down is emitted as `pgdown`, not `pgdn`:
 
@@ -219,4 +219,4 @@ The following built-in notifications commands can be overridden with custom keyb
 
 See [notification keys](../../getting-started/keybindings/selected-notification/) for more details.
 
-[bubbletea-keys]: https://github.com/charmbracelet/bubbletea/blob/main/key.go
+[ultraviolet-key-strings]: https://github.com/charmbracelet/ultraviolet/blob/main/key.go#L612

--- a/docs/src/content/docs/configuration/keybindings/index.mdx
+++ b/docs/src/content/docs/configuration/keybindings/index.mdx
@@ -11,6 +11,22 @@ To help you identify your custom commands, an additional `name` property can be 
 
 There are 3 types of keybindings: `universal`, `prs` and `issues`.
 
+## Key Values
+
+The `key` value must match the key string emitted by [Bubble Tea][bubbletea-keys]. `dash` does
+not translate alternate key names or terminal labels before matching a keybinding.
+
+For example, Page Down is emitted as `pgdown`, not `pgdn`:
+
+```yaml
+keybindings:
+  universal:
+    - key: pgup
+      builtin: pageUp
+    - key: pgdown
+      builtin: pageDown
+```
+
 ## Universal Keybindings
 
 Define keybindings that will work in any view.
@@ -202,3 +218,5 @@ The following built-in notifications commands can be overridden with custom keyb
 | `toggleBookmark` | toggle bookmark                                    |
 
 See [notification keys](../../getting-started/keybindings/selected-notification/) for more details.
+
+[bubbletea-keys]: https://github.com/charmbracelet/bubbletea/blob/main/key.go


### PR DESCRIPTION
## Summary
- [x] Closes issue #465
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

- document that configured `key` values must match Bubble Tea key strings
- add the Page Up/Page Down example using `pgup` and `pgdown`
- follow up on the docs direction from #895 for issue #465

Closes #465

## AI assistance
OpenAI GPT-5 assisted with drafting the docs wording and verification steps. I reviewed the repository guidance, AI policy, maintainer feedback, and final docs change before submitting.

## How Did You Test this Change?
- `corepack pnpm exec prettier --check src/content/docs/configuration/keybindings/index.mdx`
- `git diff --check`
- `corepack pnpm run build`

Note: the docs build completed successfully. The existing broken-link checker reported pre-existing unrelated links in `/configuration/reusing/` and `/configuration/`; this change did not add those links.