### PR TITLE
feat: add acceptSelection keybinding

### DIFF
--- a/docs/src/content/docs/configuration/keybindings/index.mdx
+++ b/docs/src/content/docs/configuration/keybindings/index.mdx
@@ -32,26 +32,27 @@ keybindings:
 
 The following built-in universal commands can be overridden with custom keybinds:
 
-| Command         | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `up`            | row up                                          |
-| `down`          | row down                                        |
-| `firstLine`     | go to first row                                 |
-| `lastLine`      | go to last row                                  |
-| `togglePreview` | toggle the preview pane                         |
-| `openGithub`    | open the selection in GitHub                    |
-| `refresh`       | refresh the current section                     |
-| `refreshAll`    | refresh all sections                            |
-| `redraw`        | redraw the screen - in case of visual artifacts |
-| `pageDown`      | go one page down in the preview pane            |
-| `pageUp`        | go one page up in the preview pane              |
-| `nextSection`   | go to next section                              |
-| `prevSection`   | go to previous section                          |
-| `search`        | focus the search bar                            |
-| `copyurl`       | copy the URL of the selected row                |
-| `copyNumber`    | copy the number of the selected row             |
-| `help`          | toggle the help menu                            |
-| `quit`          | quit gh-dash                                    |
+| Command           | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `up`              | row up                                          |
+| `down`            | row down                                        |
+| `firstLine`       | go to first row                                 |
+| `lastLine`        | go to last row                                  |
+| `togglePreview`   | toggle the preview pane                         |
+| `openGithub`      | open the selection in GitHub                    |
+| `refresh`         | refresh the current section                     |
+| `refreshAll`      | refresh all sections                            |
+| `redraw`          | redraw the screen - in case of visual artifacts |
+| `pageDown`        | go one page down in the preview pane            |
+| `pageUp`          | go one page up in the preview pane              |
+| `nextSection`     | go to next section                              |
+| `prevSection`     | go to previous section                          |
+| `search`          | focus the search bar                            |
+| `copyurl`         | copy the URL of the selected row                |
+| `copyNumber`      | copy the number of the selected row             |
+| `acceptSelection` | accept the highlighted autocomplete suggestion |
+| `help`            | toggle the help menu                            |
+| `quit`            | quit gh-dash                                    |
 
 See [global keys](../../getting-started/keybindings/global/) and [navigation keys](../../getting-started/keybindings/navigation/) for more details.
 

--- a/docs/src/data/schemas/keybindings/entry.yaml
+++ b/docs/src/data/schemas/keybindings/entry.yaml
@@ -60,7 +60,7 @@ properties:
       details: |
         Specifies the builtin command bound to the the [sref:`key`] for an entry.
 
-        For global actions, the available builtin commands are: `up`, `down`, `firstLine`, `lastLine`, `togglePreview`, `openGithub`, `refresh`, `refreshAll`, `pageDown`, `pageUp`, `nextSection`, `prevSection`, `search`, `copyurl`, `copyNumber`, `help`, `quit`.
+        For global actions, the available builtin commands are: `up`, `down`, `firstLine`, `lastLine`, `togglePreview`, `openGithub`, `refresh`, `refreshAll`, `pageDown`, `pageUp`, `nextSection`, `prevSection`, `search`, `copyurl`, `copyNumber`, `acceptSelection`, `help`, `quit`.
 
         For PRs, the available builtin commands are: `prevSidebarTab`, `nextSidebarTab`, `approve`, `assign`, `unassign`, `comment`, `diff`, `checkout`, `close`, `ready`, `reopen`, `merge`, `update`, `watchChecks`, `viewIssues`, `summaryViewMore`.
 

--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -8,6 +8,7 @@ import (
 	log "charm.land/log/v2"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/fuzzyselect"
 )
 
 // NotificationSubjectType indicates what type of content is being viewed in the notifications view
@@ -308,6 +309,8 @@ func rebindUniversal(universal []config.Keybinding) error {
 			key = &Keys.CopyUrl
 		case "copyNumber":
 			key = &Keys.CopyNumber
+		case "acceptSelection":
+			key = &fuzzyselect.SelectKey
 		case "help":
 			key = &Keys.Help
 		case "quit":

--- a/internal/tui/keys/keys_test.go
+++ b/internal/tui/keys/keys_test.go
@@ -6,6 +6,7 @@ import (
 	"charm.land/bubbles/v2/key"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/fuzzyselect"
 )
 
 func TestSetNotificationSubject(t *testing.T) {
@@ -196,6 +197,27 @@ func TestRebindNotificationKeys_Builtin(t *testing.T) {
 	keys := NotificationKeys.MarkAsDone.Keys()
 	if len(keys) != 1 || keys[0] != "X" {
 		t.Errorf("expected key to be rebound to X, got %v", keys)
+	}
+}
+
+func TestRebindUniversalKeys_AcceptSelectionBuiltin(t *testing.T) {
+	origKeys := fuzzyselect.SelectKey.Keys()
+	origHelp := fuzzyselect.SelectKey.Help()
+	defer func() {
+		fuzzyselect.SelectKey.SetKeys(origKeys...)
+		fuzzyselect.SelectKey.SetHelp(origHelp.Key, origHelp.Desc)
+	}()
+
+	err := rebindUniversal([]config.Keybinding{
+		{Builtin: "acceptSelection", Key: "tab"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	keys := fuzzyselect.SelectKey.Keys()
+	if len(keys) != 1 || keys[0] != "tab" {
+		t.Errorf("expected acceptSelection to bind to tab, got %v", keys)
 	}
 }
 


### PR DESCRIPTION
# Summary

- [x] Closes issue #900
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

Adds `acceptSelection` as a universal builtin keybinding so users can bind autocomplete selection to another key, such as `tab`, while preserving the existing `ctrl+y` default. The builtin maps to the existing fuzzy-select `SelectKey`, so the completion UI and help text stay on the same binding.

Also updates the keybinding docs and schema text to list the new builtin.

Closes #900

## How Did You Test this Change?

- Red regression first: `go test ./internal/tui/keys -run TestRebindUniversalKeys_AcceptSelectionBuiltin -count=1` failed with `unknown built-in universal key: 'acceptSelection'` before the implementation.\n- `go test ./internal/tui/keys -run TestRebindUniversalKeys_AcceptSelectionBuiltin -count=1`\n- `go test ./internal/tui/keys ./internal/tui/components/inputbox ./internal/tui/components/cmpcontroller -count=1`\n- `go test ./...`\n- `git diff --check`\n\nNote: I could not run `task lint` because `task`/`golangci-lint` are only provided by the repo Devbox environment and are not installed in this shell.\n\n## Images/Videos\n\nN/A\n\n## AI Usage Disclosure\n\nOpenAI Codex assisted with issue triage, repository/code inspection, the small implementation, tests, docs updates, and local verification. I reviewed the contribution policy, AI policy, final diff, and verification output before submitting.