### PR TITLE
feat: make the PR preview changed-files fetch limit configurable (closes #677)

### DIFF
--- a/docs/src/data/schemas/defaults.yaml
+++ b/docs/src/data/schemas/defaults.yaml
@@ -170,6 +170,24 @@ properties:
           - bottom
           - auto
         default: "auto"
+      filesLimit:
+        title: Changed Files Fetch Limit
+        description: Specifies how many changed files to fetch for a PR's preview pane.
+        schematize:
+          weight: 5
+          details: |
+            Specifies how many changed files are fetched and listed in the "Files changed"
+            section of a PR's preview pane. PRs touching more files than this limit only
+            display the first `filesLimit` files, while the header still shows the real total.
+
+            The value must be between 1 and 100, as GitHub's API returns at most 100 files
+            per request.
+
+            By default, the dashboard fetches 20 changed files.
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
   refetchIntervalMinutes:
     title: Refetch Interval in Minutes
     description: Specifies how often to refetch PRs and Issues in minutes.

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -110,10 +110,11 @@ type NotificationsSectionConfig struct {
 }
 
 type PreviewConfig struct {
-	Open     bool
-	Width    float64 `yaml:"width"              validate:"gt=0"`
-	Height   float64 `yaml:"height,omitempty"`
-	Position string  `yaml:"position,omitempty"`
+	Open       bool
+	Width      float64 `yaml:"width"                validate:"gt=0"`
+	Height     float64 `yaml:"height,omitempty"`
+	Position   string  `yaml:"position,omitempty"`
+	FilesLimit int     `yaml:"filesLimit,omitempty" validate:"omitempty,gte=1,lte=100"`
 }
 
 type NullableBool struct {
@@ -347,10 +348,11 @@ func (parser ConfigParser) getDefaultConfig() Config {
 	return Config{
 		Defaults: Defaults{
 			Preview: PreviewConfig{
-				Open:     true,
-				Width:    0.45,
-				Height:   0.60,
-				Position: "auto",
+				Open:       true,
+				Width:      0.45,
+				Height:     0.60,
+				Position:   "auto",
+				FilesLimit: 20,
 			},
 			PrsLimit:               20,
 			PrApproveComment:       "LGTM",

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -145,6 +145,59 @@ func TestParser(t *testing.T) {
 		require.Equal(t, NotificationsView, parsed.Defaults.View)
 	})
 
+	t.Run("Should default preview filesLimit when unset", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "config")
+		testutils.AssertNoError(t, err)
+		defer os.RemoveAll(dir)
+
+		configPath := path.Join(dir, "config.yml")
+		err = os.WriteFile(configPath, []byte("defaults:\n  view: prs\n"), 0o600)
+		testutils.AssertNoError(t, err)
+
+		parsed, err := ParseConfig(Location{
+			ConfigFlag:       configPath,
+			SkipGlobalConfig: true,
+		})
+
+		testutils.AssertNoError(t, err)
+		require.Equal(t, 20, parsed.Defaults.Preview.FilesLimit)
+	})
+
+	t.Run("Should accept a custom preview filesLimit", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "config")
+		testutils.AssertNoError(t, err)
+		defer os.RemoveAll(dir)
+
+		configPath := path.Join(dir, "config.yml")
+		err = os.WriteFile(configPath, []byte("defaults:\n  preview:\n    filesLimit: 50\n"), 0o600)
+		testutils.AssertNoError(t, err)
+
+		parsed, err := ParseConfig(Location{
+			ConfigFlag:       configPath,
+			SkipGlobalConfig: true,
+		})
+
+		testutils.AssertNoError(t, err)
+		require.Equal(t, 50, parsed.Defaults.Preview.FilesLimit)
+	})
+
+	t.Run("Should reject a preview filesLimit above 100", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "config")
+		testutils.AssertNoError(t, err)
+		defer os.RemoveAll(dir)
+
+		configPath := path.Join(dir, "config.yml")
+		err = os.WriteFile(configPath, []byte("defaults:\n  preview:\n    filesLimit: 101\n"), 0o600)
+		testutils.AssertNoError(t, err)
+
+		_, err = ParseConfig(Location{
+			ConfigFlag:       configPath,
+			SkipGlobalConfig: true,
+		})
+
+		require.Error(t, err)
+	})
+
 	t.Run("Should merge global config with passed config", func(t *testing.T) {
 		clearEnv := setXDGConfigHomeEnvVar(t, "testdata")
 		defer clearEnv()

--- a/internal/config/testdata/global-config.golden.yml
+++ b/internal/config/testdata/global-config.golden.yml
@@ -45,6 +45,7 @@ defaults:
     width: 60
     height: 0.6
     position: auto
+    filesLimit: 20
   prsLimit: 5
   prApproveComment: LGTM
   issuesLimit: 5

--- a/internal/config/testdata/merged-config.golden.yml
+++ b/internal/config/testdata/merged-config.golden.yml
@@ -36,6 +36,7 @@ defaults:
     width: 80
     height: 0.6
     position: auto
+    filesLimit: 20
   prsLimit: 100
   issuesLimit: 100
   notificationsLimit: 100

--- a/internal/data/prapi.go
+++ b/internal/data/prapi.go
@@ -61,7 +61,20 @@ type EnrichedPullRequestData struct {
 	ReviewRequests     ReviewRequests             `graphql:"reviewRequests(last: 100)"`
 	Reviews            Reviews                    `graphql:"reviews(last: 100)"`
 	SuggestedReviewers []SuggestedReviewer
-	Files              ChangedFiles `graphql:"files(first: 20)"`
+	Files              ChangedFiles `graphql:"files(first: $filesLimit)"`
+}
+
+// PullRequestLimits holds the number of nodes fetched for each connection of a
+// single pull request. Values come from the user's config (defaults.preview).
+type PullRequestLimits struct {
+	Files int
+}
+
+// PullRequestLimitsFromConfig maps the preview config to PullRequestLimits.
+func PullRequestLimitsFromConfig(preview config.PreviewConfig) PullRequestLimits {
+	return PullRequestLimits{
+		Files: preview.FilesLimit,
+	}
 }
 
 type PullRequestData struct {
@@ -570,7 +583,7 @@ func FetchPullRequests(query string, limit int, pageInfo *PageInfo) (PullRequest
 	}, nil
 }
 
-func FetchPullRequest(prUrl string) (EnrichedPullRequestData, error) {
+func FetchPullRequest(prUrl string, limits PullRequestLimits) (EnrichedPullRequestData, error) {
 	var err error
 	if client == nil {
 		client, err = gh.DefaultGraphQLClient()
@@ -589,7 +602,8 @@ func FetchPullRequest(prUrl string) (EnrichedPullRequestData, error) {
 		return EnrichedPullRequestData{}, err
 	}
 	variables := map[string]any{
-		"url": githubv4.URI{URL: parsedUrl},
+		"url":        githubv4.URI{URL: parsedUrl},
+		"filesLimit": graphql.Int(limits.Files),
 	}
 	log.Debug("Fetching PR", "url", prUrl)
 	err = client.Query("FetchPullRequest", &queryResult, variables)

--- a/internal/tui/components/notificationssection/notificationssection.go
+++ b/internal/tui/components/notificationssection/notificationssection.go
@@ -968,9 +968,10 @@ func (m *Model) fetchCommentCountsForNotifications(notifications []notificationr
 		case "PullRequest":
 			// Capture variables for closure
 			id, url, readAt, commentUrl := notifId, subjectUrl, lastReadAt, latestCommentUrl
+			limits := data.PullRequestLimitsFromConfig(m.Ctx.Config.Defaults.Preview)
 			cmds = append(cmds, func() tea.Msg {
 				log.Debug("Fetching PR for comment count", "url", url)
-				pr, err := data.FetchPullRequest(url)
+				pr, err := data.FetchPullRequest(url, limits)
 				if err != nil {
 					log.Error("Failed to fetch PR for comment count", "url", url, "err", err)
 					return nil

--- a/internal/tui/components/prview/prview.go
+++ b/internal/tui/components/prview/prview.go
@@ -573,8 +573,9 @@ func (m *Model) EnrichCurrRow() tea.Cmd {
 		return nil
 	}
 	url := m.pr.Data.Primary.Url
+	limits := data.PullRequestLimitsFromConfig(m.ctx.Config.Defaults.Preview)
 	return func() tea.Msg {
-		d, err := data.FetchPullRequest(url)
+		d, err := data.FetchPullRequest(url, limits)
 		return EnrichedPrMsg{
 			Id:   m.sectionId,
 			Type: prssection.SectionType,

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -1452,7 +1452,10 @@ func (m *Model) loadNotificationContent() tea.Cmd {
 				}
 			},
 			func() tea.Msg {
-				pr, err := data.FetchPullRequest(subjectUrl)
+				pr, err := data.FetchPullRequest(
+					subjectUrl,
+					data.PullRequestLimitsFromConfig(m.ctx.Config.Defaults.Preview),
+				)
 				return notificationPRFetchedMsg{
 					NotificationId:   notifId,
 					PR:               pr,


### PR DESCRIPTION
# Summary

- [x] Closes issue #677 
- [x] I have read the [CONTIBUTING.md](../CONTRIBUTING.md) and [AI_POLICY.md](../AI_POLICY.md) guides

fixes #677 

We have made it possible to configure the number of items retrieved for “files changed” via a configuration file, rather than having it hardcoded.
We have implemented the FetchPullRequest arguments as a struct, anticipating the possibility of making other values configurable in the future.

## How Did You Test this Change?
- go build ./... and go test ./... pass
- Added parser tests: default value when unset, custom value, and rejection of values above 100

## AI Disclosure
This change was developed with AI assistance (Claude Code). I reviewed and understand all of the code, and the investigation/approach (config key location, GraphQL variable injection following the existing $limit pattern) was verified by me against the codebase and the GitHub API.

<!-- if relevant, please include any relevant images that show off how your feature is
working -->
