### PR TITLE
feat(config): support multiple keys per binding (closes #504)

### DIFF
--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -202,11 +203,26 @@ type RepoConfig struct {
 	PrsRefetchIntervalSeconds      int `yaml:"prsRefetchIntervalSeconds,omitempty"`
 }
 
+// KeyList holds the key(s) bound to a single action. In config it accepts
+// either a single key (`key: ctrl+d`) or a list (`key: [ctrl+d, pgdown]`):
+// koanf decodes config through mapstructure with WeaklyTypedInput, which lifts
+// a scalar into a one-element slice, so both forms decode without a custom
+// unmarshaler.
+type KeyList []string
+
+// String renders the bound keys for help text, e.g. "ctrl+d/pgdown" — matching
+// the "/" separator gh-dash already uses for multi-key help descriptions.
+func (kl KeyList) String() string { return strings.Join(kl, "/") }
+
+// Contains reports whether s is one of the bound keys (used to match a pressed
+// key against a custom-command binding).
+func (kl KeyList) Contains(s string) bool { return slices.Contains(kl, s) }
+
 type Keybinding struct {
-	Key     string `yaml:"key"`
-	Command string `yaml:"command,omitempty"`
-	Builtin string `yaml:"builtin,omitempty"`
-	Name    string `yaml:"name,omitempty"`
+	Key     KeyList `yaml:"key"`
+	Command string  `yaml:"command,omitempty"`
+	Builtin string  `yaml:"builtin,omitempty"`
+	Name    string  `yaml:"name,omitempty"`
 }
 
 func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
@@ -220,8 +236,8 @@ func (kb Keybinding) NewBinding(previous *key.Binding) key.Binding {
 	}
 
 	return key.NewBinding(
-		key.WithKeys(kb.Key),
-		key.WithHelp(kb.Key, helpDesc),
+		key.WithKeys(kb.Key...),
+		key.WithHelp(kb.Key.String(), helpDesc),
 	)
 }
 
@@ -645,7 +661,7 @@ func mergeOption() koanf.Option {
 		// below can tell which sections this layer actually declared.
 		overridesCopy := maps.Copy(overrides)
 
-		unioned := make(map[string][]map[string]string, len(keybindingTypes))
+		unioned := make(map[string][]map[string]any, len(keybindingTypes))
 		for _, typ := range keybindingTypes {
 			unioned[typ] = mergeKeybindings(overrides, dest, typ)
 		}
@@ -735,49 +751,72 @@ func (parser ConfigParser) mergeConfigs(globalCfgPath, userProvidedCfgPath strin
 	return parser.unmarshalConfigWithDefaults()
 }
 
-func mergeKeybindings(overrides, dest map[string]any, typ string) []map[string]string {
-	byKey := make(map[string]map[string]string)
+func mergeKeybindings(overrides, dest map[string]any, typ string) []map[string]any {
+	byKey := make(map[string]map[string]any)
+	order := make([]string, 0)
 	// dest first, then overrides, so a key bound in both resolves to overrides.
 	for _, layer := range []map[string]any{dest, overrides} {
 		for _, keybind := range keybindingsByType(layer, typ) {
-			if key, ok := keybind["key"]; ok {
-				byKey[key] = keybind
+			val, ok := keybind["key"]
+			if !ok {
+				continue
 			}
+			dk := keybindDedupKey(val)
+			if _, exists := byKey[dk]; !exists {
+				order = append(order, dk)
+			}
+			byKey[dk] = keybind
 		}
 	}
 
-	merged := make([]map[string]string, 0, len(byKey))
-	for _, keybind := range byKey {
-		merged = append(merged, keybind)
+	merged := make([]map[string]any, 0, len(byKey))
+	for _, dk := range order {
+		merged = append(merged, byKey[dk])
 	}
 	return merged
 }
 
-func keybindingsByType(layer map[string]any, typ string) []map[string]string {
+// keybindDedupKey canonicalizes a binding's `key` field (which may be a single
+// key string or a list of keys) into a stable string, so two layers binding the
+// same key(s) dedup against each other.
+func keybindDedupKey(val any) string {
+	switch v := val.(type) {
+	case string:
+		return v
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, e := range v {
+			parts = append(parts, fmt.Sprint(e))
+		}
+		return strings.Join(parts, "\x00")
+	case []string:
+		return strings.Join(v, "\x00")
+	default:
+		return fmt.Sprint(val)
+	}
+}
+
+func keybindingsByType(layer map[string]any, typ string) []map[string]any {
 	keybindings, ok := layer["keybindings"].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	// Raw YAML parses to []any, but a previous merge pass writes the type back as
-	// []map[string]string, so both shapes can show up once 3+ layers are merged.
+	// []map[string]any, so both shapes can show up once 3+ layers are merged. The
+	// per-binding maps are preserved as-is so a list-valued `key` (multiple keys
+	// bound to one action) survives the merge instead of being dropped.
 	switch list := keybindings[typ].(type) {
-	case []map[string]string:
+	case []map[string]any:
 		return list
 	case []any:
-		out := make([]map[string]string, 0, len(list))
+		out := make([]map[string]any, 0, len(list))
 		for _, item := range list {
 			m, ok := item.(map[string]any)
 			if !ok {
 				continue
 			}
-			casted := make(map[string]string)
-			for key, val := range m {
-				if s, ok := val.(string); ok {
-					casted[key] = s
-				}
-			}
-			out = append(out, casted)
+			out = append(out, m)
 		}
 		return out
 	default:

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -40,7 +40,7 @@ func init() {
 var keybindSorter = cmp.Transformer("Sort", func(in []Keybinding) []Keybinding {
 	out := append([]Keybinding(nil), in...) // Copy input to avoid mutating it
 	sort.Slice(out, func(i, j int) bool {
-		return strings.Compare(out[i].Key, out[j].Key) == -1
+		return strings.Compare(out[i].Key.String(), out[j].Key.String()) == -1
 	})
 	return out
 })
@@ -181,7 +181,7 @@ func TestParser(t *testing.T) {
 		// to panic when a later merge re-read already-merged keybindings.
 		keys := make([]string, 0, len(parsed.Keybindings.Universal))
 		for _, kb := range parsed.Keybindings.Universal {
-			keys = append(keys, kb.Key)
+			keys = append(keys, kb.Key.String())
 		}
 		require.ElementsMatch(t, []string{"a", "b", "c"}, keys)
 	})
@@ -198,6 +198,30 @@ func TestParser(t *testing.T) {
 		require.Equal(t, Color("013"), parsed.Theme.Colors.Inline.Border.Primary)
 		require.Equal(t, Color("008"), parsed.Theme.Colors.Inline.Background.Selected)
 	})
+}
+
+func TestParseConfig_KeyListScalarAndList(t *testing.T) {
+	// A keybinding's `key` may be a single key (scalar) or a list of keys.
+	// koanf/mapstructure (WeaklyTypedInput) lifts a scalar into a one-element
+	// slice, so both forms decode into KeyList without a custom unmarshaler.
+	dir := t.TempDir()
+	configPath := path.Join(dir, "config.yml")
+	cfg := "" +
+		"keybindings:\n" +
+		"  universal:\n" +
+		"    - key: x\n" +
+		"      builtin: refresh\n" +
+		"    - key: [ctrl+d, pgdown]\n" +
+		"      builtin: pageDown\n"
+	err := os.WriteFile(configPath, []byte(cfg), 0o600)
+	testutils.AssertNoError(t, err)
+
+	parsed, err := ParseConfig(Location{ConfigFlag: configPath, SkipGlobalConfig: true})
+	testutils.AssertNoError(t, err)
+
+	require.Len(t, parsed.Keybindings.Universal, 2)
+	require.Equal(t, KeyList{"x"}, parsed.Keybindings.Universal[0].Key)
+	require.Equal(t, KeyList{"ctrl+d", "pgdown"}, parsed.Keybindings.Universal[1].Key)
 }
 
 func loadExpected(t *testing.T, fpath string) Config {

--- a/internal/tui/keys/branchKeys.go
+++ b/internal/tui/keys/branchKeys.go
@@ -87,8 +87,8 @@ func rebindBranchKeys(keys []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(branchKey.Key),
-					key.WithHelp(branchKey.Key, name),
+					key.WithKeys(branchKey.Key...),
+					key.WithHelp(branchKey.Key.String(), name),
 				)
 
 				CustomBranchBindings = append(CustomBranchBindings, customBinding)
@@ -123,13 +123,13 @@ func rebindBranchKeys(keys []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in branch key: '%s'", branchKey.Builtin)
 		}
 
-		key.SetKeys(branchKey.Key)
+		key.SetKeys(branchKey.Key...)
 
 		helpDesc := key.Help().Desc
 		if branchKey.Name != "" {
 			helpDesc = branchKey.Name
 		}
-		key.SetHelp(branchKey.Key, helpDesc)
+		key.SetHelp(branchKey.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/keys/completionKeys.go
+++ b/internal/tui/keys/completionKeys.go
@@ -52,8 +52,8 @@ func rebindCmpKeys(keys []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(cmpKey.Key),
-					key.WithHelp(cmpKey.Key, name),
+					key.WithKeys(cmpKey.Key...),
+					key.WithHelp(cmpKey.Key.String(), name),
 				)
 
 				CustomCmpBindings = append(CustomCmpBindings, customBinding)
@@ -79,13 +79,13 @@ func rebindCmpKeys(keys []config.Keybinding) error {
 			return fmt.Errorf("unknown builtin: '%s'", cmpKey.Builtin)
 		}
 
-		key.SetKeys(cmpKey.Key)
+		key.SetKeys(cmpKey.Key...)
 
 		helpDesc := key.Help().Desc
 		if cmpKey.Name != "" {
 			helpDesc = cmpKey.Name
 		}
-		key.SetHelp(cmpKey.Key, helpDesc)
+		key.SetHelp(cmpKey.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/keys/issueKeys.go
+++ b/internal/tui/keys/issueKeys.go
@@ -87,8 +87,8 @@ func rebindIssueKeys(keys []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(issueKey.Key),
-					key.WithHelp(issueKey.Key, name),
+					key.WithKeys(issueKey.Key...),
+					key.WithHelp(issueKey.Key.String(), name),
 				)
 
 				CustomIssueBindings = append(CustomIssueBindings, customBinding)
@@ -121,13 +121,13 @@ func rebindIssueKeys(keys []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in issue key: '%s'", issueKey.Builtin)
 		}
 
-		key.SetKeys(issueKey.Key)
+		key.SetKeys(issueKey.Key...)
 
 		helpDesc := key.Help().Desc
 		if issueKey.Name != "" {
 			helpDesc = issueKey.Name
 		}
-		key.SetHelp(issueKey.Key, helpDesc)
+		key.SetHelp(issueKey.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/keys/keys.go
+++ b/internal/tui/keys/keys.go
@@ -268,8 +268,8 @@ func rebindUniversal(universal []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(kb.Key),
-					key.WithHelp(kb.Key, name),
+					key.WithKeys(kb.Key...),
+					key.WithHelp(kb.Key.String(), name),
 				)
 
 				CustomUniversalBindings = append(CustomUniversalBindings, customBinding)
@@ -324,7 +324,7 @@ func rebindUniversal(universal []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in universal key: '%s'", kb.Builtin)
 		}
 
-		key.SetKeys(kb.Key)
+		key.SetKeys(kb.Key...)
 
 		helpDesc := key.Help().Desc
 		if kb.Name != "" {
@@ -332,7 +332,7 @@ func rebindUniversal(universal []config.Keybinding) error {
 		} else if kb.Command != "" {
 			helpDesc = kb.Command
 		}
-		key.SetHelp(kb.Key, helpDesc)
+		key.SetHelp(kb.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/keys/keys_test.go
+++ b/internal/tui/keys/keys_test.go
@@ -187,7 +187,7 @@ func TestRebindNotificationKeys_Builtin(t *testing.T) {
 	}()
 
 	err := rebindNotificationKeys([]config.Keybinding{
-		{Builtin: "markAsDone", Key: "X"},
+		{Builtin: "markAsDone", Key: config.KeyList{"X"}},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -199,9 +199,35 @@ func TestRebindNotificationKeys_Builtin(t *testing.T) {
 	}
 }
 
+func TestRebindNotificationKeys_BuiltinMultipleKeys(t *testing.T) {
+	// A single binding may list multiple keys; all of them should be bound to
+	// the action (e.g. so both ctrl+d and pgdown page down).
+	origKey := NotificationKeys.MarkAsDone.Keys()
+	origHelp := NotificationKeys.MarkAsDone.Help().Desc
+	defer func() {
+		NotificationKeys.MarkAsDone.SetKeys(origKey...)
+		NotificationKeys.MarkAsDone.SetHelp(origKey[0], origHelp)
+	}()
+
+	err := rebindNotificationKeys([]config.Keybinding{
+		{Builtin: "markAsDone", Key: config.KeyList{"X", "D"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	keys := NotificationKeys.MarkAsDone.Keys()
+	if len(keys) != 2 || keys[0] != "X" || keys[1] != "D" {
+		t.Errorf("expected key to be rebound to [X D], got %v", keys)
+	}
+	if got := NotificationKeys.MarkAsDone.Help().Key; got != "X/D" {
+		t.Errorf("expected help key to be %q, got %q", "X/D", got)
+	}
+}
+
 func TestRebindNotificationKeys_UnknownBuiltin(t *testing.T) {
 	err := rebindNotificationKeys([]config.Keybinding{
-		{Builtin: "nonExistent", Key: "Z"},
+		{Builtin: "nonExistent", Key: config.KeyList{"Z"}},
 	})
 	if err == nil {
 		t.Error("expected error for unknown builtin, got nil")
@@ -213,7 +239,7 @@ func TestRebindNotificationKeys_CustomCommand(t *testing.T) {
 	CustomNotificationBindings = nil
 
 	err := rebindNotificationKeys([]config.Keybinding{
-		{Key: "N", Command: "echo hello"},
+		{Key: config.KeyList{"N"}, Command: "echo hello"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/tui/keys/notificationKeys.go
+++ b/internal/tui/keys/notificationKeys.go
@@ -105,8 +105,8 @@ func rebindNotificationKeys(keys []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(notifKey.Key),
-					key.WithHelp(notifKey.Key, name),
+					key.WithKeys(notifKey.Key...),
+					key.WithHelp(notifKey.Key.String(), name),
 				)
 
 				CustomNotificationBindings = append(CustomNotificationBindings, customBinding)
@@ -145,13 +145,13 @@ func rebindNotificationKeys(keys []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in notification key: '%s'", notifKey.Builtin)
 		}
 
-		key.SetKeys(notifKey.Key)
+		key.SetKeys(notifKey.Key...)
 
 		helpDesc := key.Help().Desc
 		if notifKey.Name != "" {
 			helpDesc = notifKey.Name
 		}
-		key.SetHelp(notifKey.Key, helpDesc)
+		key.SetHelp(notifKey.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/keys/prKeys.go
+++ b/internal/tui/keys/prKeys.go
@@ -146,8 +146,8 @@ func rebindPRKeys(keys []config.Keybinding) error {
 				}
 
 				customBinding := key.NewBinding(
-					key.WithKeys(prKey.Key),
-					key.WithHelp(prKey.Key, name),
+					key.WithKeys(prKey.Key...),
+					key.WithHelp(prKey.Key.String(), name),
 				)
 
 				CustomPRBindings = append(CustomPRBindings, customBinding)
@@ -200,13 +200,13 @@ func rebindPRKeys(keys []config.Keybinding) error {
 			return fmt.Errorf("unknown built-in pr key: '%s'", prKey.Builtin)
 		}
 
-		key.SetKeys(prKey.Key)
+		key.SetKeys(prKey.Key...)
 
 		helpDesc := key.Help().Desc
 		if prKey.Name != "" {
 			helpDesc = prKey.Name
 		}
-		key.SetHelp(prKey.Key, helpDesc)
+		key.SetHelp(prKey.Key.String(), helpDesc)
 	}
 
 	return nil

--- a/internal/tui/modelUtils.go
+++ b/internal/tui/modelUtils.go
@@ -68,7 +68,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 	currRowData := m.getCurrRowData()
 
 	for _, keybinding := range m.ctx.Config.Keybindings.Universal {
-		if keybinding.Key != key {
+		if !keybinding.Key.Contains(key) {
 			continue
 		}
 
@@ -79,7 +79,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 	switch m.ctx.View {
 	case config.IssuesView:
 		for _, keybinding := range m.ctx.Config.Keybindings.Issues {
-			if keybinding.Key != key {
+			if !keybinding.Key.Contains(key) {
 				continue
 			}
 
@@ -90,7 +90,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 		}
 	case config.PRsView:
 		for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-			if keybinding.Key != key || keybinding.Command == "" {
+			if !keybinding.Key.Contains(key) || keybinding.Command == "" {
 				continue
 			}
 
@@ -103,7 +103,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 		}
 	case config.RepoView:
 		for _, keybinding := range m.ctx.Config.Keybindings.Branches {
-			if keybinding.Key != key || keybinding.Command == "" {
+			if !keybinding.Key.Contains(key) || keybinding.Command == "" {
 				continue
 			}
 
@@ -116,7 +116,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 		}
 	case config.NotificationsView:
 		for _, keybinding := range m.ctx.Config.Keybindings.Notifications {
-			if keybinding.Key != key || keybinding.Command == "" {
+			if !keybinding.Key.Contains(key) || keybinding.Command == "" {
 				continue
 			}
 			log.Debug(
@@ -135,7 +135,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 			switch nData.Notification.Subject.Type {
 			case "PullRequest":
 				for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-					if keybinding.Key != key || keybinding.Command == "" {
+					if !keybinding.Key.Contains(key) || keybinding.Command == "" {
 						continue
 					}
 					log.Debug(
@@ -149,7 +149,7 @@ func (m *Model) executeKeybinding(key string) tea.Cmd {
 				}
 			case "Issue":
 				for _, keybinding := range m.ctx.Config.Keybindings.Issues {
-					if keybinding.Key != key || keybinding.Command == "" {
+					if !keybinding.Key.Contains(key) || keybinding.Command == "" {
 						continue
 					}
 					log.Debug(

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -1679,14 +1679,14 @@ func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
 		return false
 	}
 	for _, keybinding := range m.ctx.Config.Keybindings.Universal {
-		if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+		if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 			return true
 		}
 	}
 
 	if m.ctx.View == config.IssuesView {
 		for _, keybinding := range m.ctx.Config.Keybindings.Issues {
-			if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+			if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 				return true
 			}
 		}
@@ -1694,7 +1694,7 @@ func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
 
 	if m.ctx.View == config.PRsView {
 		for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-			if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+			if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 				return true
 			}
 		}
@@ -1702,7 +1702,7 @@ func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
 
 	if m.ctx.View == config.RepoView {
 		for _, keybinding := range m.ctx.Config.Keybindings.Branches {
-			if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+			if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 				return true
 			}
 		}
@@ -1710,7 +1710,7 @@ func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
 
 	if m.ctx.View == config.NotificationsView {
 		for _, keybinding := range m.ctx.Config.Keybindings.Notifications {
-			if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+			if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 				return true
 			}
 		}
@@ -1720,13 +1720,13 @@ func (m *Model) isUserDefinedKeybinding(msg tea.KeyMsg) bool {
 			switch nData.Notification.Subject.Type {
 			case "PullRequest":
 				for _, keybinding := range m.ctx.Config.Keybindings.Prs {
-					if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+					if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 						return true
 					}
 				}
 			case "Issue":
 				for _, keybinding := range m.ctx.Config.Keybindings.Issues {
-					if keybinding.Builtin == "" && keybinding.Key == msg.String() {
+					if keybinding.Builtin == "" && keybinding.Key.Contains(msg.String()) {
 						return true
 					}
 				}

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -1830,7 +1830,7 @@ func TestIsUserDefinedKeybinding_NotificationsView_PRNotification(t *testing.T) 
 
 	// Add a custom PR keybinding
 	cfg.Keybindings.Prs = []config.Keybinding{
-		{Key: "B", Command: "gh pr view -w {{.PrNumber}}"},
+		{Key: config.KeyList{"B"}, Command: "gh pr view -w {{.PrNumber}}"},
 	}
 
 	ctx := &context.ProgramContext{
@@ -1891,7 +1891,7 @@ func TestIsUserDefinedKeybinding_NotificationsView_IssueNotification(t *testing.
 
 	// Add a custom Issue keybinding
 	cfg.Keybindings.Issues = []config.Keybinding{
-		{Key: "B", Command: "gh issue view -w {{.IssueNumber}}"},
+		{Key: config.KeyList{"B"}, Command: "gh issue view -w {{.IssueNumber}}"},
 	}
 
 	ctx := &context.ProgramContext{
@@ -1946,7 +1946,7 @@ func TestIsUserDefinedKeybinding_NotificationsView_NonPRIssueNotification(t *tes
 	require.NoError(t, err)
 
 	cfg.Keybindings.Prs = []config.Keybinding{
-		{Key: "B", Command: "gh pr view -w {{.PrNumber}}"},
+		{Key: config.KeyList{"B"}, Command: "gh pr view -w {{.PrNumber}}"},
 	}
 
 	ctx := &context.ProgramContext{
@@ -2177,7 +2177,7 @@ func TestIsUserDefinedKeybinding_NotificationsView_NotificationKeybinding(t *tes
 
 	// Add a custom notification keybinding
 	cfg.Keybindings.Notifications = []config.Keybinding{
-		{Key: "N", Command: "echo {{.RepoName}} {{.Number}}"},
+		{Key: config.KeyList{"N"}, Command: "echo {{.RepoName}} {{.Number}}"},
 	}
 
 	ctx := &context.ProgramContext{


### PR DESCRIPTION
## Summary

Closes #504. A keybinding's `key` may now be **either a single key or a list of keys**, so one action can be bound to several keys:

```yaml
keybindings:
  universal:
    - builtin: pageDown
      key: [ctrl+d, pgdown]   # both keys page down
    - builtin: pageUp
      key: [ctrl+u, pgup]
    - builtin: nextSection
      key: [right, tab]       # the original #504 example
```

A plain scalar (`key: ctrl+d`) keeps working unchanged.

## Why this differs from #505

#505 added an `UnmarshalYAML` to a `KeyList` type, but config is decoded through **koanf + mapstructure** (`UnmarshalWithConf{Tag: "yaml"}`), which never calls `UnmarshalYAML` — so that hook was dead code, and the type change wasn't propagated to the consumers, which is what produced the build errors reported on that PR.

This PR takes the mechanism the decoder actually uses:

- koanf's default mapstructure config sets `WeaklyTypedInput: true`, and mapstructure's slice decoder lifts a scalar into a one-element slice (`"a string becomes a string slice"`). So simply changing `Keybinding.Key` from `string` to a `[]string`-based `KeyList` makes **both** the scalar and list forms decode with **no** custom unmarshaler.
- Every consumer is updated for the slice type: `SetKeys`/`WithKeys` take the variadic spread, help text uses `KeyList.String()` (rendered `a/b`, matching the existing multi-key help convention), and the custom-command dispatch matches via `KeyList.Contains()`.
- The layered-config merge (`mergeKeybindings`/`keybindingsByType`) modeled each binding as `map[string]string` keyed by the key string, which silently **dropped** a list-valued key. It now preserves bindings as `map[string]any` and dedups via a canonical key form, so multi-key bindings survive merges/`include:`.

Credit to @gabriellanata for #504/#505 and to @Omnikron13 for suggesting the YAML-list syntax.

## How tested

- `go build ./... && go test ./... && golangci-lint run` — all green.
- New tests: config decoding of both scalar and list forms (`TestParseConfig_KeyListScalarAndList`); rebinding a builtin to multiple keys incl. its help label (`TestRebindNotificationKeys_BuiltinMultipleKeys`).
- Manually ran the built binary with `key: [ctrl+d, pgdown]` / `[ctrl+u, pgup]`; both keys page the preview pane and existing single-key bindings are unaffected.

## Follow-up (separate PR)

Key-name validation (warn on an unrecognized key like a typo'd `pgdwn`) — bubbletea matches keys by raw string with no validation surface, so it'd be a maintained allowlist; intentionally left out of this change to keep it focused.
