### PR TITLE
fix(markdown): handle nil ProgramContext in GetMarkdownRenderer

### DIFF
--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -35,6 +35,20 @@ func InitializeMarkdownStyle(ctx *context.ProgramContext) {
 }
 
 func GetMarkdownRenderer(width int, ctx *context.ProgramContext) glamour.TermRenderer {
+	if ctx == nil {
+		// If context is nil, use a default renderer without custom styling
+		markdownRenderer, err := glamour.NewTermRenderer(
+			glamour.WithWordWrap(width),
+		)
+		if err != nil || markdownRenderer == nil {
+			fallback, _ := glamour.NewTermRenderer()
+			if fallback != nil {
+				return *fallback
+			}
+			panic("failed to create markdown renderer: " + err.Error())
+		}
+		return *markdownRenderer
+	}
 	if markdownStyle == nil {
 		InitializeMarkdownStyle(ctx)
 	}


### PR DESCRIPTION
- [x] Closes issue #922

GetMarkdownRenderer dereferenced ctx without a nil check, causing a panic when the issue view is rendered before the program context is initialized. Falls back to a default renderer (no custom styling) when ctx is nil.