### PR TITLE
fix: use HasGHRepo helper instead of direct nil checks

### DIFF
--- a/internal/tui/components/section/section.go
+++ b/internal/tui/components/section/section.go
@@ -70,7 +70,7 @@ func (options NewSectionOptions) GetConfigFiltersWithCurrentRemoteAdded(
 	if !ctx.Config.SmartFilteringAtLaunch {
 		return searchValue
 	}
-	if ctx.GHRepo == nil {
+	if !ctx.HasGHRepo() {
 		return searchValue
 	}
 	for token := range strings.FieldsSeq(searchValue) {
@@ -87,7 +87,7 @@ func NewModel(
 ) BaseModel {
 	filters := options.GetConfigFiltersWithCurrentRemoteAdded(ctx)
 	isFilteredByCurrentRemote := false
-	if ctx.GHRepo != nil {
+	if ctx.HasGHRepo() {
 		currentCloneFilter := fmt.Sprintf("repo:%s/%s", ctx.GHRepo.Owner, ctx.GHRepo.Name)
 		for token := range strings.FieldsSeq(filters) {
 			if token == currentCloneFilter {
@@ -220,7 +220,7 @@ func (m *BaseModel) HasRepoNameInConfiguredFilter() bool {
 
 func (m *BaseModel) HasCurrentRepoNameInConfiguredFilter() bool {
 	filters := m.SearchValue
-	if m.Ctx.GHRepo == nil {
+	if !m.Ctx.HasGHRepo() {
 		return false
 	}
 	currentCloneFilter := fmt.Sprintf("repo:%s/%s", m.Ctx.GHRepo.Owner, m.Ctx.GHRepo.Name)
@@ -238,7 +238,7 @@ func (m *BaseModel) SyncSmartFilterWithSearchValue() {
 
 func (m *BaseModel) GetSearchValue() string {
 	searchValue := m.enrichSearchWithTemplateVars()
-	if m.Ctx.GHRepo == nil {
+	if !m.Ctx.HasGHRepo() {
 		return searchValue
 	}
 

--- a/internal/tui/context/context.go
+++ b/internal/tui/context/context.go
@@ -56,6 +56,10 @@ type ProgramContext struct {
 	Styles               Styles
 }
 
+func (ctx *ProgramContext) HasGHRepo() bool {
+	return ctx.GHRepo != nil && *ctx.GHRepo != (repository.Repository{})
+}
+
 func (ctx *ProgramContext) GetViewSectionsConfig() []config.SectionConfig {
 	var configs []config.SectionConfig
 	switch ctx.View {


### PR DESCRIPTION
# Summary

Noticed a bug on the latest main where the nil checks for GHRepo were not working. For the smart filtering feature in non-git repos, I got the `repo:/` filter for my PRs and issues, etc.

I addressed this by introducing a new method for not only checking the nil pointer, but also checking whether the struct is not empty.

This issue was introduced in https://github.com/dlvhdr/gh-dash/pull/911 as far as I can see and could have been addressed a different way as well, this is just one possible solution, so let me know what you think.


## How Did You Test this Change?

The original symptom after these changes was fixed 👍

## Guidelines

- [x] I have read the [Contributing](https://github.com/dlvhdr/gh-dash/CONTRIBUTING.md) and the strict [No-AI Policy](https://github.com/dlvhdr/gh-dash/AI_POLICY.md) guides.