### PR TITLE
Fix panic in user mention extraction on empty @user input

### DIFF
--- a/internal/tui/components/fuzzyselect/mentions.go
+++ b/internal/tui/components/fuzzyselect/mentions.go
@@ -61,6 +61,10 @@ func (src *UserMentionSource) ExtractContext(input string, cursorPos tea.Positio
 		}
 	}
 
+	if userStart >= userEnd {
+		return Context{}
+	}
+
 	return Context{
 		Start:   tea.Position{X: userStart, Y: cursorPos.Y},
 		End:     tea.Position{X: userEnd, Y: cursorPos.Y},


### PR DESCRIPTION
## Summary

When `WithAtSymbol` is `true`, `userStart` can exceed `userEnd` after the forward scan, causing `runes[userStart:userEnd]` to panic with `runtime error: slice bounds out of range`.

This adds a bounds check returning an empty `Context{}` (the same safe return used elsewhere in the function) before the slice operation.

Fixes #877

## Root Cause

1. Backward scan finds a word boundary, sets `userStart = i + 1`
2. `WithAtSymbol` increments `userStart` by 1, potentially pushing it past `len(runes)`
3. The existing guard at line 51 has a gap: when `userStart == len(runes)`, neither condition catches it
4. Forward scan may set `userEnd` to a value less than `userStart`
5. `runes[userStart:userEnd]` panics

## Test plan

- [ ] Type `@:"` in a comment box — previously crashed, should now be safe
- [ ] Normal `@username` mentions still work
- [ ] Existing mention tests pass