### PR TITLE
fix(issueview): set program context in NewModel to prevent markdown panic

### DIFF
--- a/internal/tui/components/issueview/action_test.go
+++ b/internal/tui/components/issueview/action_test.go
@@ -31,7 +31,6 @@ func newTestModelForAction(t *testing.T) Model {
 	}
 
 	m := NewModel(ctx)
-	m.ctx = ctx
 	m.issue = &issuerow.Issue{
 		Ctx:  ctx,
 		Data: data.IssueData{},

--- a/internal/tui/components/issueview/issueview.go
+++ b/internal/tui/components/issueview/issueview.go
@@ -43,6 +43,7 @@ func NewModel(ctx *context.ProgramContext) Model {
 	cmp := cmpcontroller.New(ctx, inputbox.ModelOpts{TextArea: &ta})
 
 	return Model{
+		ctx:    ctx,
 		issue:  nil,
 		editor: cmp,
 	}

--- a/internal/tui/components/issueview/issueview_test.go
+++ b/internal/tui/components/issueview/issueview_test.go
@@ -1,0 +1,53 @@
+package issueview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
+)
+
+func newTestContext(t *testing.T) *context.ProgramContext {
+	t.Helper()
+
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+
+	thm := theme.ParseTheme(&cfg)
+	return &context.ProgramContext{
+		Config:            &cfg,
+		Theme:             thm,
+		Styles:            context.InitStyles(thm),
+		HasDarkBackground: true,
+		BackgroundSource:  "default",
+	}
+}
+
+func TestNewModelSetsProgramContext(t *testing.T) {
+	ctx := newTestContext(t)
+	m := NewModel(ctx)
+
+	require.NotNil(t, m.ctx)
+	require.Same(t, ctx, m.ctx)
+}
+
+func TestRenderBodyDoesNotPanicBeforeContextSync(t *testing.T) {
+	ctx := newTestContext(t)
+	m := NewModel(ctx)
+	m.SetWidth(80)
+	m.SetRow(&data.IssueData{
+		Title: "Example issue",
+		Body:  "Hello **world**",
+	})
+
+	require.NotPanics(t, func() {
+		_ = m.renderBody()
+	})
+}

--- a/internal/tui/components/prview/prview.go
+++ b/internal/tui/components/prview/prview.go
@@ -54,6 +54,7 @@ func NewModel(ctx *context.ProgramContext) Model {
 	cmp := cmpcontroller.New(ctx, inputbox.ModelOpts{TextArea: &ta})
 
 	return Model{
+		ctx:      ctx,
 		pr:       nil,
 		carousel: c,
 		editor:   cmp,

--- a/internal/tui/markdown/markdownRenderer.go
+++ b/internal/tui/markdown/markdownRenderer.go
@@ -20,16 +20,23 @@ func InitializeMarkdownStyle(ctx *context.ProgramContext) {
 		return
 	}
 
-	if ctx.HasDarkBackground {
+	hasDarkBackground := true
+	backgroundSource := "default"
+	if ctx != nil {
+		hasDarkBackground = ctx.HasDarkBackground
+		backgroundSource = ctx.BackgroundSource
+	}
+
+	if hasDarkBackground {
 		markdownStyle = &CustomDarkStyleConfig
 	} else {
 		markdownStyle = &styles.LightStyleConfig
 	}
-	markdownStyleSource = ctx.BackgroundSource
+	markdownStyleSource = backgroundSource
 
 	log.Debugf(
 		"InitializeMarkdownStyle: assigned ctx.hasDarkBackground=%t, markdownStyleSource=%q",
-		ctx.HasDarkBackground,
+		hasDarkBackground,
 		markdownStyleSource,
 	)
 }
@@ -50,7 +57,11 @@ func GetMarkdownRenderer(width int, ctx *context.ProgramContext) glamour.TermRen
 			return *fallback
 		}
 		// If even fallback fails, panic with helpful message
-		panic("failed to create markdown renderer: " + err.Error())
+		msg := "unknown error"
+		if err != nil {
+			msg = err.Error()
+		}
+		panic("failed to create markdown renderer: " + msg)
 	}
 
 	return *markdownRenderer

--- a/internal/tui/markdown/markdownRenderer_test.go
+++ b/internal/tui/markdown/markdownRenderer_test.go
@@ -1,0 +1,30 @@
+package markdown
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMarkdownRendererNilContext(t *testing.T) {
+	markdownStyle = nil
+	markdownStyleSource = ""
+
+	require.NotPanics(t, func() {
+		renderer := GetMarkdownRenderer(80, nil)
+		rendered, err := renderer.Render("# hello")
+		require.NoError(t, err)
+		require.NotEmpty(t, rendered)
+	})
+}
+
+func TestInitializeMarkdownStyleNilContext(t *testing.T) {
+	markdownStyle = nil
+	markdownStyleSource = ""
+
+	require.NotPanics(t, func() {
+		InitializeMarkdownStyle(nil)
+	})
+
+	require.NotNil(t, markdownStyle)
+}


### PR DESCRIPTION
# Summary

- [x] Closes issue #922
- [x] I have read the [Contributing](../CONTRIBUTING.md) and the strict [No-AI Policy](../AI_POLICY.md) guides.

Fixes #922

`issueview.NewModel` accepted `ctx` but did not store it on the model. The first sidebar render could therefore call `GetMarkdownRenderer` with a nil context and panic. The same latent bug existed in `prview.NewModel`.

## How Did You Test this Change?

- `go test ./internal/tui/components/issueview/...`
- `go test ./internal/tui/markdown/...`
- `go test ./...`

Added regression tests:
- `TestNewModelSetsProgramContext`
- `TestRenderBodyDoesNotPanicBeforeContextSync`
- `TestGetMarkdownRendererNilContext`

## Images/Videos

N/A (crash fix)