### PR TITLE
fix: cursor between boundaries crash

### DIFF
--- a/internal/tui/components/fuzzyselect/mentions.go
+++ b/internal/tui/components/fuzzyselect/mentions.go
@@ -49,7 +49,7 @@ func (src *UserMentionSource) ExtractContext(input string, cursorPos tea.Positio
 	}
 
 	if userStart >= len(runes)+1 ||
-		(userStart > 0 && userStart < len(runes) && src.WithAtSymbol && runes[userStart-1] != '@') {
+		(userStart > 0 && userStart <= len(runes) && src.WithAtSymbol && runes[userStart-1] != '@') {
 		return Context{}
 	}
 

--- a/internal/tui/components/fuzzyselect/source_test.go
+++ b/internal/tui/components/fuzzyselect/source_test.go
@@ -238,6 +238,41 @@ func TestUserMentionSource(t *testing.T) {
 	require.Equal(t, tea.Position{X: 12}, newCursor)
 }
 
+func TestUserMentionSourceCursorBetweenBoundaries(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		cursorPos tea.Position
+	}{
+		{
+			name:      "cursor between two trailing spaces",
+			input:     "hello  ",
+			cursorPos: tea.Position{X: 6},
+		},
+		{
+			name:      "cursor before the only char, which is a boundary",
+			input:     " ",
+			cursorPos: tea.Position{X: 0},
+		},
+		{
+			name:      "cursor between a space and a trailing punctuation mark",
+			input:     "hello @octo .",
+			cursorPos: tea.Position{X: 12},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, withAt := range []bool{true, false} {
+				source := UserMentionSource{WithAtSymbol: withAt}
+				require.NotPanics(t, func() {
+					source.ExtractContext(tc.input, tc.cursorPos)
+				})
+			}
+		})
+	}
+}
+
 func TestUserMentionSourceWithoutAtSymbol(t *testing.T) {
 	source := UserMentionSource{WithAtSymbol: false}
 	require.Equal(


### PR DESCRIPTION
# Summary

- [x] I have read the [Contributing](../CONTRIBUTING.md) and the strict [No-AI Policy](../AI_POLICY.md) guides.

- [x] Closes #939

When the mentions.go does the check to see if there is a username after
an "@", the cursors loc was able to get out of bounds, causing a
runtime error. Now userStart is able to be the same value as len(runes).

## Testing process

- Created TestUserMentionSourceCursorBetweenBoundaries in [source_test.go](../internal/tui/components/fuzzyselect/mentions.go) and tested against the unchanged main branch and found panics with "slice bounds out of range [7:6]"
- Updated the mentions.go to fix the bounds
- Tested again and found no regression
- Green on full test suite

## Video Solution
<img width="808" height="632" alt="comment-boundary-issue-solved" src="https://github.com/user-attachments/assets/0f2ccc7b-ad8b-4096-a602-f5d6f7cba52a" />
