### PR TITLE
fix: correct dateFormat schema type

### DIFF
--- a/docs/src/pages/schema/defaults.json.ts
+++ b/docs/src/pages/schema/defaults.json.ts
@@ -81,9 +81,8 @@ export function GET() {
         dateFormat: {
           title: "Date format",
           description: "Specifies how dates are formatted.",
-          type: "integer",
-          minimum: 1,
-          default: 30,
+          type: "string",
+          default: "relative",
         },
         view: {
           title: "Default View",


### PR DESCRIPTION
## Summary

- correct `defaults.dateFormat` from an integer to a string in the published configuration schema
- align the schema default with the documented and runtime default, `relative`

## Evidence

`internal/config/parser.go` defines `DateFormat string`, and the configuration documentation describes either `relative` or a Go time format string. The current schema mistakenly copied the integer shape/default from `refetchIntervalMinutes`, causing valid configurations to fail validation.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`

The docs build succeeds. It reports the same three existing broken internal links unrelated to this change.