### PR TITLE
feat: snooze PRs, issues, and notifications

### DIFF
--- a/docs/src/content/docs/configuration/defaults.mdx
+++ b/docs/src/content/docs/configuration/defaults.mdx
@@ -237,6 +237,39 @@ view when it first loads.
 
 By default, the dashboard displays the PRs view.
 
+### Snooze Presets (`snoozePresets`)
+
+| Type  | Default                                          |
+| :---- | :------------------------------------------------ |
+| Array | 10m, 1h, 4h, Tomorrow, This Friday, Next week      |
+
+This setting defines the list of presets offered when you [snooze] a PR, issue, or
+notification. Each preset has a `label` (shown in the prompt) and an `after` value, which is
+either a duration (e.g. `10m`, `1h`, `4h`) or one of the keywords `tomorrow`, `this <weekday>`,
+or `next week`.
+
+```yaml
+defaults:
+  snoozePresets:
+    - label: 10m
+      after: 10m
+    - label: 1h
+      after: 1h
+    - label: 4h
+      after: 4h
+    - label: Tomorrow
+      after: tomorrow
+    - label: This Friday
+      after: this friday
+    - label: Next week
+      after: next week
+```
+
+Snoozing hides the item until the computed wake-up time, at which point it reappears
+automatically. Snooze state is stored locally and isn't synced to GitHub.
+
+[snooze]: /getting-started/keybindings/selected-pr/
+
 ### PR Approval (`prApproveComment`)
 
 | Type   | Default |

--- a/docs/src/content/docs/configuration/keybindings/index.mdx
+++ b/docs/src/content/docs/configuration/keybindings/index.mdx
@@ -128,6 +128,7 @@ The following built-in PR commands can be overridden with custom keybinds:
 | `approveWorkflows` | approve the runs of the PR                  |
 | `viewIssues`       | switch to the Issues view                   |
 | `summaryViewMore`  | expand the truncated PR description         |
+| `snooze`           | snooze the PR                               |
 
 See [PR keys](../../getting-started/keybindings/selected-pr/) for more details.
 
@@ -169,6 +170,7 @@ The following built-in issue commands can be overridden with custom keybinds:
 | `close`    | close the issue                      |
 | `reopen`   | reopen a closed issue                |
 | `viewPrs`  | switch to the PRs view               |
+| `snooze`   | snooze the issue                     |
 
 See [issue keys](../../getting-started/keybindings/selected-issue/) for more details.
 
@@ -216,6 +218,7 @@ The following built-in notifications commands can be overridden with custom keyb
 | `markAllAsRead`  | mark all as read                                   |
 | `unsubscribe`    | unsubscribe from thread                            |
 | `toggleBookmark` | toggle bookmark                                    |
+| `snooze`         | snooze (hide until a chosen time)                  |
 
 See [notification keys](../../getting-started/keybindings/selected-notification/) for more details.
 

--- a/docs/src/content/docs/getting-started/keybindings/selected-issue.mdx
+++ b/docs/src/content/docs/getting-started/keybindings/selected-issue.mdx
@@ -92,3 +92,9 @@ want to reopen the closed issue.
 reopens the issue only after you approve the action.
 
 </Aside>
+
+## `z` - Snooze Issue
+
+Press <kbd>z</kbd> to snooze the issue. When you do, the dashboard prompts you to pick one of the
+configured [`defaults.snoozePresets`](/configuration/defaults/#snooze-presets-snoozepresets).
+The issue disappears from the section until the chosen time, then reappears automatically.

--- a/docs/src/content/docs/getting-started/keybindings/selected-notification.mdx
+++ b/docs/src/content/docs/getting-started/keybindings/selected-notification.mdx
@@ -13,6 +13,7 @@ weight: 5
 | M     | Mark all as read                                   |
 | u     | Unsubscribe from thread                            |
 | b     | Toggle bookmark                                    |
+| z     | Snooze (hide until a chosen time)                  |
 | t     | Toggle smart filtering (filter to current repo)    |
 | y     | Copy PR/Issue number                               |
 | Y     | Copy URL                                           |

--- a/docs/src/content/docs/getting-started/keybindings/selected-pr.mdx
+++ b/docs/src/content/docs/getting-started/keybindings/selected-pr.mdx
@@ -107,6 +107,12 @@ close the PR.
 Press <kbd>X</kbd> to reopen a closed PR. When you do, the dashboard uses the `gh pr reopen`
 command to reopen the PR.
 
+## `z` - Snooze PR
+
+Press <kbd>z</kbd> to snooze the PR. When you do, the dashboard prompts you to pick one of the
+configured [`defaults.snoozePresets`](/configuration/defaults/#snooze-presets-snoozepresets).
+The PR disappears from the section until the chosen time, then reappears automatically.
+
 <Aside type="caution" title="Watch out!">
 **Prior to v3.10.0:** When you use some commands, the dashboard acts immediately and without
 prompting for confirmation.

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -185,7 +185,7 @@ type LayoutConfig struct {
 
 type SnoozePreset struct {
 	Label string `yaml:"label"`
-	After string `yaml:"after"`
+	After string `yaml:"after" validate:"snoozepreset"`
 }
 
 type Defaults struct {
@@ -817,6 +817,10 @@ func validateColor(fl validator.FieldLevel) bool {
 	return err == nil && n >= 0 && n <= 255
 }
 
+func validateSnoozePreset(fl validator.FieldLevel) bool {
+	return utils.IsValidSnoozePreset(fl.Field().String())
+}
+
 func initParser() ConfigParser {
 	validate = validator.New()
 
@@ -829,6 +833,7 @@ func initParser() ConfigParser {
 	})
 
 	validate.RegisterValidation("color", validateColor)
+	validate.RegisterValidation("snoozepreset", validateSnoozePreset)
 
 	return ConfigParser{
 		k: koanf.NewWithConf(conf),

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -183,16 +183,22 @@ type LayoutConfig struct {
 	Issues IssuesLayoutConfig `yaml:"issues,omitempty"`
 }
 
+type SnoozePreset struct {
+	Label string `yaml:"label"`
+	After string `yaml:"after"`
+}
+
 type Defaults struct {
-	Preview                PreviewConfig `yaml:"preview"`
-	PrsLimit               int           `yaml:"prsLimit"`
-	PrApproveComment       string        `yaml:"prApproveComment,omitempty"`
-	IssuesLimit            int           `yaml:"issuesLimit"`
-	NotificationsLimit     int           `yaml:"notificationsLimit"`
-	View                   ViewType      `yaml:"view"`
-	Layout                 LayoutConfig  `yaml:"layout,omitempty"`
-	RefetchIntervalMinutes int           `yaml:"refetchIntervalMinutes,omitempty"`
-	DateFormat             string        `yaml:"dateFormat,omitempty"`
+	Preview                PreviewConfig  `yaml:"preview"`
+	PrsLimit               int            `yaml:"prsLimit"`
+	PrApproveComment       string         `yaml:"prApproveComment,omitempty"`
+	IssuesLimit            int            `yaml:"issuesLimit"`
+	NotificationsLimit     int            `yaml:"notificationsLimit"`
+	View                   ViewType       `yaml:"view"`
+	Layout                 LayoutConfig   `yaml:"layout,omitempty"`
+	RefetchIntervalMinutes int            `yaml:"refetchIntervalMinutes,omitempty"`
+	DateFormat             string         `yaml:"dateFormat,omitempty"`
+	SnoozePresets          []SnoozePreset `yaml:"snoozePresets,omitempty"`
 }
 
 type RepoConfig struct {
@@ -358,6 +364,14 @@ func (parser ConfigParser) getDefaultConfig() Config {
 			NotificationsLimit:     20,
 			View:                   PRsView,
 			RefetchIntervalMinutes: 30,
+			SnoozePresets: []SnoozePreset{
+				{Label: "10m", After: "10m"},
+				{Label: "1h", After: "1h"},
+				{Label: "4h", After: "4h"},
+				{Label: "Tomorrow", After: "tomorrow"},
+				{Label: "This Friday", After: "this friday"},
+				{Label: "Next week", After: "next week"},
+			},
 			Layout: LayoutConfig{
 				Prs: PrsLayoutConfig{
 					UpdatedAt: ColumnConfig{

--- a/internal/config/parser_test.go
+++ b/internal/config/parser_test.go
@@ -223,6 +223,27 @@ func setXDGConfigHomeEnvVar(t *testing.T, dir string) func() {
 	}
 }
 
+func TestValidateSnoozePreset(t *testing.T) {
+	// initParser registers the custom "snoozepreset" validator
+	initParser()
+
+	type testPreset struct {
+		After string `validate:"snoozepreset"`
+	}
+
+	valid := []string{"10m", "1h", "4h", "tomorrow", "this friday", "next week"}
+	for _, v := range valid {
+		err := validate.Struct(testPreset{After: v})
+		assert.NoErrorf(t, err, "expected %q to be valid", v)
+	}
+
+	invalid := []string{"", "bogus", "this someday"}
+	for _, v := range invalid {
+		err := validate.Struct(testPreset{After: v})
+		assert.Errorf(t, err, "expected %q to be invalid", v)
+	}
+}
+
 func TestValidateColor(t *testing.T) {
 	// initParser registers the custom "color" validator
 	initParser()

--- a/internal/config/testdata/global-config.golden.yml
+++ b/internal/config/testdata/global-config.golden.yml
@@ -88,6 +88,19 @@ defaults:
         width: 20
         hidden: true
   refetchIntervalMinutes: 5
+  snoozePresets:
+    - label: 10m
+      after: 10m
+    - label: 1h
+      after: 1h
+    - label: 4h
+      after: 4h
+    - label: Tomorrow
+      after: tomorrow
+    - label: This Friday
+      after: this friday
+    - label: Next week
+      after: next week
 keybindings:
   universal:
     - key: g

--- a/internal/config/testdata/merged-config.golden.yml
+++ b/internal/config/testdata/merged-config.golden.yml
@@ -79,6 +79,19 @@ defaults:
         width: 20
         hidden: true
   refetchIntervalMinutes: 10
+  snoozePresets:
+    - label: 10m
+      after: 10m
+    - label: 1h
+      after: 1h
+    - label: 4h
+      after: 4h
+    - label: Tomorrow
+      after: tomorrow
+    - label: This Friday
+      after: this friday
+    - label: Next week
+      after: next week
 keybindings:
   universal:
     - key: "n"

--- a/internal/data/snoozestore.go
+++ b/internal/data/snoozestore.go
@@ -1,0 +1,185 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"charm.land/log/v2"
+)
+
+// SnoozeStore persists item IDs (PRs, Issues, or Notifications) along with
+// the "wake-at" timestamp at which they should reappear. Unlike DoneStore,
+// new activity on a snoozed item does not un-snooze it - IsSnoozed only
+// checks the stored wake-at time against the current time.
+type SnoozeStore struct {
+	mu       sync.RWMutex
+	entries  map[string]time.Time // id -> wake-at time
+	filePath string
+}
+
+func newSnoozeStore(filename string) *SnoozeStore {
+	store := &SnoozeStore{
+		entries: make(map[string]time.Time),
+	}
+	filePath, err := getStateFilePath(filename)
+	if err != nil {
+		log.Error("Failed to get state file path for snoozed items", "err", err)
+	}
+	store.filePath = filePath
+	if err := store.load(); err != nil {
+		log.Error("Failed to load snoozed items", "err", err)
+	}
+	return store
+}
+
+// load reads the snooze store from disk: {"id": "2024-01-15T10:30:00Z", ...}
+// (map of ID → RFC 3339 wake-at timestamp).
+func (s *SnoozeStore) load() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.filePath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(s.filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var tsMap map[string]string
+	if err := json.Unmarshal(data, &tsMap); err != nil {
+		return err
+	}
+
+	for id, raw := range tsMap {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			log.Warn(
+				"Skipping snooze entry with invalid timestamp",
+				"id",
+				id,
+				"raw",
+				raw,
+				"err",
+				err,
+			)
+			continue
+		}
+		s.entries[id] = t
+	}
+	s.prune()
+	log.Debug("Loaded snoozed items", "count", len(s.entries))
+	return nil
+}
+
+// prune removes entries whose wake-at time has already passed: an expired
+// snooze entry serves no purpose.
+func (s *SnoozeStore) prune() {
+	now := time.Now()
+	for id, wakeAt := range s.entries {
+		if !now.Before(wakeAt) {
+			delete(s.entries, id)
+		}
+	}
+}
+
+func (s *SnoozeStore) save() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.filePath == "" {
+		return nil
+	}
+
+	tsMap := make(map[string]string, len(s.entries))
+	for id, t := range s.entries {
+		tsMap[id] = t.Format(time.RFC3339)
+	}
+
+	data, err := json.Marshal(tsMap)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(s.filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write(data); err != nil {
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, s.filePath); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+
+	log.Debug("Saved snoozed items", "count", len(tsMap))
+	return nil
+}
+
+// Snooze records the wake-at time for the given ID.
+func (s *SnoozeStore) Snooze(id string, until time.Time) {
+	s.mu.Lock()
+	s.entries[id] = until
+	s.mu.Unlock()
+	go s.save()
+}
+
+// IsSnoozed returns true if the item is still snoozed, i.e. its wake-at
+// time is in the future.
+func (s *SnoozeStore) IsSnoozed(id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	wakeAt, ok := s.entries[id]
+	if !ok {
+		return false
+	}
+	return time.Now().Before(wakeAt)
+}
+
+// Remove removes an item from the snooze store.
+func (s *SnoozeStore) Remove(id string) {
+	s.mu.Lock()
+	delete(s.entries, id)
+	s.mu.Unlock()
+	go s.save()
+}
+
+// Flush forces an immediate synchronous save.
+func (s *SnoozeStore) Flush() error {
+	return s.save()
+}
+
+// Singleton
+
+var (
+	snoozeStore     *SnoozeStore
+	snoozeStoreOnce sync.Once
+)
+
+// GetSnoozeStore returns the singleton snooze store.
+func GetSnoozeStore() *SnoozeStore {
+	snoozeStoreOnce.Do(func() {
+		snoozeStore = newSnoozeStore("snoozed.json")
+	})
+	return snoozeStore
+}

--- a/internal/data/snoozestore_test.go
+++ b/internal/data/snoozestore_test.go
@@ -1,0 +1,209 @@
+package data
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSnoozeStore(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "gh-dash-snoozestore-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	t.Run("Snooze and IsSnoozed while wake time is in the future", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test1.json"),
+		}
+
+		store.Snooze("id1", time.Now().Add(1*time.Hour))
+		if !store.IsSnoozed("id1") {
+			t.Error("Should be snoozed when wake time is in the future")
+		}
+	})
+
+	t.Run("IsSnoozed after wake time has passed returns false", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test2.json"),
+		}
+
+		store.Snooze("id1", time.Now().Add(-1*time.Hour))
+		if store.IsSnoozed("id1") {
+			t.Error("Should NOT be snoozed once wake time has passed")
+		}
+	})
+
+	t.Run("IsSnoozed for unknown ID returns false", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test3.json"),
+		}
+
+		if store.IsSnoozed("unknown") {
+			t.Error("Should NOT be snoozed for an ID not in the store")
+		}
+	})
+
+	t.Run("new activity does not un-snooze", func(t *testing.T) {
+		// Unlike DoneStore, SnoozeStore has no concept of item updatedAt at all -
+		// IsSnoozed only depends on wall-clock time versus the stored wake time.
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test4.json"),
+		}
+		store.Snooze("id1", time.Now().Add(1*time.Hour))
+		if !store.IsSnoozed("id1") {
+			t.Error("Should remain snoozed regardless of any external activity")
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test5.json"),
+		}
+
+		store.Snooze("id1", time.Now().Add(1*time.Hour))
+		store.Remove("id1")
+		if store.IsSnoozed("id1") {
+			t.Error("Should NOT be snoozed after Remove")
+		}
+	})
+
+	t.Run("Snooze overwrites wake time on same ID", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "test6.json"),
+		}
+
+		store.Snooze("id1", time.Now().Add(-1*time.Hour))
+		if store.IsSnoozed("id1") {
+			t.Error("Should not be snoozed with a past wake time")
+		}
+		store.Snooze("id1", time.Now().Add(1*time.Hour))
+		if !store.IsSnoozed("id1") {
+			t.Error("Should be snoozed after re-snoozing with a future wake time")
+		}
+	})
+
+	t.Run("persistence round-trip", func(t *testing.T) {
+		persistFile := filepath.Join(tempDir, "persist.json")
+		wakeAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
+
+		store1 := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: persistFile,
+		}
+		store1.Snooze("id1", wakeAt)
+		if err := store1.Flush(); err != nil {
+			t.Fatalf("Flush failed: %v", err)
+		}
+
+		store2 := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: persistFile,
+		}
+		if err := store2.load(); err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+
+		if !store2.IsSnoozed("id1") {
+			t.Error("Loaded store should have id1 as snoozed")
+		}
+	})
+
+	t.Run("load from non-existent file", func(t *testing.T) {
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: filepath.Join(tempDir, "nonexistent.json"),
+		}
+		if err := store.load(); err != nil {
+			t.Errorf("load from non-existent file should not error, got: %v", err)
+		}
+	})
+
+	t.Run("load from corrupted JSON", func(t *testing.T) {
+		corruptedFile := filepath.Join(tempDir, "corrupted.json")
+		if err := os.WriteFile(corruptedFile, []byte("{invalid json"), 0o644); err != nil {
+			t.Fatalf("Failed to create corrupted file: %v", err)
+		}
+
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: corruptedFile,
+		}
+		if err := store.load(); err == nil {
+			t.Error("load from corrupted JSON should return an error")
+		}
+	})
+
+	t.Run("load prunes entries whose wake time has already passed", func(t *testing.T) {
+		pruneFile := filepath.Join(tempDir, "prune.json")
+		now := time.Now().UTC().Truncate(time.Second)
+
+		tsMap := map[string]string{
+			"future":  now.Add(1 * time.Hour).Format(time.RFC3339),
+			"past":    now.Add(-1 * time.Hour).Format(time.RFC3339),
+			"ancient": now.Add(-90 * 24 * time.Hour).Format(time.RFC3339),
+		}
+		raw, err := json.Marshal(tsMap)
+		if err != nil {
+			t.Fatalf("Failed to marshal test data: %v", err)
+		}
+		if err := os.WriteFile(pruneFile, raw, 0o644); err != nil {
+			t.Fatalf("Failed to write prune file: %v", err)
+		}
+
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: pruneFile,
+		}
+		if err := store.load(); err != nil {
+			t.Fatalf("load failed: %v", err)
+		}
+
+		if !store.IsSnoozed("future") {
+			t.Error("Future wake time entry should survive pruning")
+		}
+		if _, ok := store.entries["past"]; ok {
+			t.Error("Past wake time entry should be pruned on load")
+		}
+		if _, ok := store.entries["ancient"]; ok {
+			t.Error("Ancient wake time entry should be pruned on load")
+		}
+	})
+
+	t.Run("save then load preserves RFC3339 format", func(t *testing.T) {
+		file := filepath.Join(tempDir, "format.json")
+		store := &SnoozeStore{
+			entries:  make(map[string]time.Time),
+			filePath: file,
+		}
+		store.Snooze("id1", time.Now().Add(1*time.Hour))
+		if err := store.Flush(); err != nil {
+			t.Fatalf("Flush failed: %v", err)
+		}
+
+		raw, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("ReadFile failed: %v", err)
+		}
+
+		var tsMap map[string]string
+		if err := json.Unmarshal(raw, &tsMap); err != nil {
+			t.Fatalf("Should be a JSON object: %v", err)
+		}
+		if _, ok := tsMap["id1"]; !ok {
+			t.Error("Should have id1 key")
+		}
+		if _, err := time.Parse(time.RFC3339, tsMap["id1"]); err != nil {
+			t.Errorf("Timestamp should be RFC3339: %v", err)
+		}
+	})
+}

--- a/internal/data/snoozestore_testing.go
+++ b/internal/data/snoozestore_testing.go
@@ -1,0 +1,23 @@
+package data
+
+import (
+	"time"
+)
+
+// NewSnoozeStoreForTesting creates a SnoozeStore backed by the given file path.
+func NewSnoozeStoreForTesting(filePath string) *SnoozeStore {
+	return &SnoozeStore{
+		entries:  make(map[string]time.Time),
+		filePath: filePath,
+	}
+}
+
+// OverrideSnoozeStoreForTesting replaces the singleton SnoozeStore with the
+// given store. It returns a function that restores the original store.
+func OverrideSnoozeStoreForTesting(store *SnoozeStore) func() {
+	// Ensure the singleton is initialized so sync.Once has fired.
+	GetSnoozeStore()
+	old := snoozeStore
+	snoozeStore = store
+	return func() { snoozeStore = old }
+}

--- a/internal/data/snoozetime.go
+++ b/internal/data/snoozetime.go
@@ -1,0 +1,97 @@
+package data
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/utils"
+)
+
+// snoozeMorningHour is the local hour used for "morning" snooze presets
+// (tomorrow, this <weekday>, next week), matching Gmail's own defaults.
+const snoozeMorningHour = 8
+
+var weekdayNames = map[string]time.Weekday{
+	"sunday":    time.Sunday,
+	"monday":    time.Monday,
+	"tuesday":   time.Tuesday,
+	"wednesday": time.Wednesday,
+	"thursday":  time.Thursday,
+	"friday":    time.Friday,
+	"saturday":  time.Saturday,
+}
+
+// ComputeWakeTime computes the time at which a snoozed item should reappear,
+// given a preset string and the current time.
+//
+// Keyword presets are checked before duration parsing: utils.ParseDuration
+// returns a zero duration (and no error) for any string with no numeric
+// component, which would otherwise silently swallow keywords like "tomorrow".
+func ComputeWakeTime(preset string, now time.Time) (time.Time, error) {
+	lower := strings.ToLower(strings.TrimSpace(preset))
+
+	switch {
+	case lower == "tomorrow":
+		return atMorning(now.AddDate(0, 0, 1)), nil
+	case lower == "next week":
+		return nextOccurrenceOf(now, time.Monday), nil
+	case strings.HasPrefix(lower, "this "):
+		if wd, ok := weekdayNames[strings.TrimPrefix(lower, "this ")]; ok {
+			return nextOccurrenceOf(now, wd), nil
+		}
+	}
+
+	// utils.ParseDuration returns a zero duration (and no error) for any
+	// string with no digits at all, so only attempt it for strings that
+	// could plausibly be a duration - otherwise every unrecognized keyword
+	// would silently resolve to "now".
+	if strings.ContainsAny(preset, "0123456789") {
+		if d, err := utils.ParseDuration(preset); err == nil {
+			return now.Add(d), nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unrecognized snooze preset: %q", preset)
+}
+
+// ResolveSnoozePreset parses input as a 1-based index into presets and
+// resolves it to a wake-at time. ok is false for invalid input (non-numeric,
+// out of range) or an unrecognized preset, in which case callers should
+// silently ignore the input.
+func ResolveSnoozePreset(
+	input string,
+	presets []config.SnoozePreset,
+	now time.Time,
+) (wakeAt time.Time, ok bool) {
+	idx, err := strconv.Atoi(input)
+	if err != nil || idx < 1 || idx > len(presets) {
+		return time.Time{}, false
+	}
+
+	wakeAt, err = ComputeWakeTime(presets[idx-1].After, now)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return wakeAt, true
+}
+
+// atMorning returns t with its time-of-day set to snoozeMorningHour:00:00.
+func atMorning(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), snoozeMorningHour, 0, 0, 0, t.Location())
+}
+
+// nextOccurrenceOf returns the next occurrence of the given weekday at
+// snoozeMorningHour, at least one day out. If now falls on the target
+// weekday, it rolls to next week's occurrence rather than possibly returning
+// a time already in the past today.
+func nextOccurrenceOf(now time.Time, target time.Weekday) time.Time {
+	daysUntil := (int(target) - int(now.Weekday()) + 7) % 7
+	if daysUntil == 0 {
+		daysUntil = 7
+	}
+	return atMorning(now.AddDate(0, 0, daysUntil))
+}

--- a/internal/data/snoozetime.go
+++ b/internal/data/snoozetime.go
@@ -14,16 +14,6 @@ import (
 // (tomorrow, this <weekday>, next week), matching Gmail's own defaults.
 const snoozeMorningHour = 8
 
-var weekdayNames = map[string]time.Weekday{
-	"sunday":    time.Sunday,
-	"monday":    time.Monday,
-	"tuesday":   time.Tuesday,
-	"wednesday": time.Wednesday,
-	"thursday":  time.Thursday,
-	"friday":    time.Friday,
-	"saturday":  time.Saturday,
-}
-
 // ComputeWakeTime computes the time at which a snoozed item should reappear,
 // given a preset string and the current time.
 //
@@ -37,10 +27,10 @@ func ComputeWakeTime(preset string, now time.Time) (time.Time, error) {
 	case lower == "tomorrow":
 		return atMorning(now.AddDate(0, 0, 1)), nil
 	case lower == "next week":
-		return nextOccurrenceOf(now, time.Monday), nil
+		return nextOccurrenceOf(now, time.Monday, true), nil
 	case strings.HasPrefix(lower, "this "):
-		if wd, ok := weekdayNames[strings.TrimPrefix(lower, "this ")]; ok {
-			return nextOccurrenceOf(now, wd), nil
+		if wd, ok := utils.SnoozeWeekdayNames[strings.TrimPrefix(lower, "this ")]; ok {
+			return nextOccurrenceOf(now, wd, false), nil
 		}
 	}
 
@@ -79,18 +69,34 @@ func ResolveSnoozePreset(
 	return wakeAt, true
 }
 
+// ApplySnoozePreset parses input as a 1-based index into presets and, if
+// valid, records the computed wake-at time for key in the snooze store.
+// Returns false, with no effect on the store, for invalid input (bad index,
+// non-numeric, unrecognized preset).
+func ApplySnoozePreset(input, key string, presets []config.SnoozePreset) bool {
+	wakeAt, ok := ResolveSnoozePreset(input, presets, time.Now())
+	if !ok {
+		return false
+	}
+
+	GetSnoozeStore().Snooze(key, wakeAt)
+	return true
+}
+
 // atMorning returns t with its time-of-day set to snoozeMorningHour:00:00.
 func atMorning(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), snoozeMorningHour, 0, 0, 0, t.Location())
 }
 
 // nextOccurrenceOf returns the next occurrence of the given weekday at
-// snoozeMorningHour, at least one day out. If now falls on the target
-// weekday, it rolls to next week's occurrence rather than possibly returning
-// a time already in the past today.
-func nextOccurrenceOf(now time.Time, target time.Weekday) time.Time {
+// snoozeMorningHour. If now falls on the target weekday, alwaysSkipToday
+// controls the behavior: "next week" always rolls to next week's occurrence
+// (alwaysSkipToday=true), while "this <weekday>" only rolls forward if
+// snoozeMorningHour has already passed today - otherwise it resolves to
+// later today.
+func nextOccurrenceOf(now time.Time, target time.Weekday, alwaysSkipToday bool) time.Time {
 	daysUntil := (int(target) - int(now.Weekday()) + 7) % 7
-	if daysUntil == 0 {
+	if daysUntil == 0 && (alwaysSkipToday || !now.Before(atMorning(now))) {
 		daysUntil = 7
 	}
 	return atMorning(now.AddDate(0, 0, daysUntil))

--- a/internal/data/snoozetime_test.go
+++ b/internal/data/snoozetime_test.go
@@ -1,8 +1,12 @@
 package data
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 )
@@ -68,6 +72,18 @@ func TestComputeWakeTime(t *testing.T) {
 		}
 	})
 
+	t.Run("this friday when today is friday before cutoff resolves to today", func(t *testing.T) {
+		now := mustDate(t, "2024-01-12 07:00") // Friday, before 8am
+		got, err := ComputeWakeTime("this friday", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-12 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
 	t.Run("this friday when today is friday rolls to next week", func(t *testing.T) {
 		now := mustDate(t, "2024-01-12 09:00") // Friday, already past 8am
 		got, err := ComputeWakeTime("this friday", now)
@@ -121,6 +137,38 @@ func TestComputeWakeTime(t *testing.T) {
 		if _, err := ComputeWakeTime("bogus", now); err == nil {
 			t.Error("expected an error for an unrecognized preset")
 		}
+	})
+}
+
+func withTestSnoozeStore(t *testing.T) *SnoozeStore {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "gh-dash-snooze-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	store := NewSnoozeStoreForTesting(filepath.Join(tempDir, "snoozed.json"))
+	restore := OverrideSnoozeStoreForTesting(store)
+	t.Cleanup(restore)
+	return store
+}
+
+func TestApplySnoozePreset(t *testing.T) {
+	presets := []config.SnoozePreset{
+		{Label: "10m", After: "10m"},
+	}
+
+	t.Run("valid index snoozes the key and reports applied", func(t *testing.T) {
+		withTestSnoozeStore(t)
+		applied := ApplySnoozePreset("1", "some-key", presets)
+		require.True(t, applied)
+		require.True(t, GetSnoozeStore().IsSnoozed("some-key"))
+	})
+
+	t.Run("invalid index does not snooze and reports not applied", func(t *testing.T) {
+		withTestSnoozeStore(t)
+		applied := ApplySnoozePreset("99", "some-key", presets)
+		require.False(t, applied)
+		require.False(t, GetSnoozeStore().IsSnoozed("some-key"))
 	})
 }
 

--- a/internal/data/snoozetime_test.go
+++ b/internal/data/snoozetime_test.go
@@ -1,0 +1,158 @@
+package data
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+)
+
+// Jan 1, 2024 is a Monday, so:
+//
+//	Jan 8  = Monday
+//	Jan 10 = Wednesday
+//	Jan 12 = Friday
+//	Jan 15 = Monday (next week)
+//	Jan 19 = Friday (next week)
+func mustDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02 15:04", s)
+	if err != nil {
+		t.Fatalf("failed to parse test date %q: %v", s, err)
+	}
+	return parsed
+}
+
+func TestComputeWakeTime(t *testing.T) {
+	t.Run("duration presets", func(t *testing.T) {
+		now := mustDate(t, "2024-01-10 12:00")
+		cases := map[string]time.Duration{
+			"10m": 10 * time.Minute,
+			"1h":  time.Hour,
+			"4h":  4 * time.Hour,
+			"-2w": -2 * 7 * 24 * time.Hour,
+		}
+		for preset, want := range cases {
+			got, err := ComputeWakeTime(preset, now)
+			if err != nil {
+				t.Fatalf("preset %q: unexpected error: %v", preset, err)
+			}
+			if !got.Equal(now.Add(want)) {
+				t.Errorf("preset %q: got %v, want %v", preset, got, now.Add(want))
+			}
+		}
+	})
+
+	t.Run("tomorrow always advances exactly one day", func(t *testing.T) {
+		// Wednesday
+		now := mustDate(t, "2024-01-10 23:30")
+		got, err := ComputeWakeTime("tomorrow", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-11 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("this friday from a wednesday goes to this week's friday", func(t *testing.T) {
+		now := mustDate(t, "2024-01-10 09:00") // Wednesday
+		got, err := ComputeWakeTime("this friday", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-12 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("this friday when today is friday rolls to next week", func(t *testing.T) {
+		now := mustDate(t, "2024-01-12 09:00") // Friday, already past 8am
+		got, err := ComputeWakeTime("this friday", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-19 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("next week from a wednesday goes to the upcoming monday", func(t *testing.T) {
+		now := mustDate(t, "2024-01-10 09:00") // Wednesday
+		got, err := ComputeWakeTime("next week", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-15 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("next week when today is monday rolls to next monday", func(t *testing.T) {
+		now := mustDate(t, "2024-01-08 07:00") // Monday, before 8am
+		got, err := ComputeWakeTime("next week", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-15 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("keyword presets are case-insensitive", func(t *testing.T) {
+		now := mustDate(t, "2024-01-10 09:00") // Wednesday
+		got, err := ComputeWakeTime("This Friday", now)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := mustDate(t, "2024-01-12 08:00")
+		if !got.Equal(want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unrecognized preset returns an error", func(t *testing.T) {
+		now := mustDate(t, "2024-01-10 09:00")
+		if _, err := ComputeWakeTime("bogus", now); err == nil {
+			t.Error("expected an error for an unrecognized preset")
+		}
+	})
+}
+
+func TestResolveSnoozePreset(t *testing.T) {
+	presets := []config.SnoozePreset{
+		{Label: "10m", After: "10m"},
+		{Label: "1h", After: "1h"},
+	}
+	now := mustDate(t, "2024-01-10 09:00")
+
+	t.Run("valid 1-based index resolves the wake time", func(t *testing.T) {
+		wakeAt, ok := ResolveSnoozePreset("1", presets, now)
+		if !ok {
+			t.Fatal("expected ok=true for a valid index")
+		}
+		if want := now.Add(10 * time.Minute); !wakeAt.Equal(want) {
+			t.Errorf("got %v, want %v", wakeAt, want)
+		}
+	})
+
+	t.Run("non-numeric input is rejected", func(t *testing.T) {
+		if _, ok := ResolveSnoozePreset("abc", presets, now); ok {
+			t.Error("expected ok=false for non-numeric input")
+		}
+	})
+
+	t.Run("out-of-range index is rejected", func(t *testing.T) {
+		if _, ok := ResolveSnoozePreset("99", presets, now); ok {
+			t.Error("expected ok=false for an out-of-range index")
+		}
+		if _, ok := ResolveSnoozePreset("0", presets, now); ok {
+			t.Error("expected ok=false for index 0")
+		}
+	})
+}

--- a/internal/tui/components/issuessection/issuessection.go
+++ b/internal/tui/components/issuessection/issuessection.go
@@ -88,11 +88,18 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
 				issue := m.GetCurrRow()
+				sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
 				if action == "snooze" {
-					m.applySnooze(input, issue)
+					if m.applySnooze(input, issue) {
+						cmd = tasks.SnoozeFeedback(
+							m.Ctx,
+							sid,
+							snoozeKey(issue),
+							fmt.Sprintf("Issue #%d", issue.GetNumber()),
+						)
+					}
 					m.Table.SetRows(m.BuildRows())
 				} else if input == "Y" || input == "y" {
-					sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
 					switch action {
 					case "close":
 						cmd = tasks.CloseIssue(m.Ctx, sid, issue)
@@ -294,7 +301,7 @@ func (m Model) BuildRows() []table.Row {
 }
 
 func (m *Model) NumRows() int {
-	return len(m.Issues)
+	return len(m.visibleIssues())
 }
 
 func (m *Model) GetCurrRow() data.RowData {
@@ -446,8 +453,17 @@ func (m Model) GetItemPluralForm() string {
 	return "Issues"
 }
 
+// visibleTotalCount adjusts TotalCount by the number of currently-snoozed
+// issues among the fetched rows, so the tab badge and pager reflect what's
+// actually visible. It self-corrects as snoozes expire since
+// visibleIssues() re-evaluates time.Now() on every call.
+func (m Model) visibleTotalCount() int {
+	numSnoozed := len(m.Issues) - len(m.visibleIssues())
+	return utils.Max(0, m.TotalCount-numSnoozed)
+}
+
 func (m Model) GetTotalCount() int {
-	return m.TotalCount
+	return m.visibleTotalCount()
 }
 
 func (m *Model) GetIsLoading() bool {
@@ -461,14 +477,15 @@ func (m *Model) SetIsLoading(val bool) {
 
 func (m Model) GetPagerContent() string {
 	pagerContent := ""
-	if m.TotalCount > 0 {
+	totalCount := m.visibleTotalCount()
+	if totalCount > 0 {
 		pagerContent = fmt.Sprintf(
 			"%v %v • %v %v/%v • Fetched %v",
 			constants.WaitingIcon,
 			m.LastUpdated().Format("01/02 15:04:05"),
 			m.SingularForm,
 			m.Table.GetCurrItem()+1,
-			m.TotalCount,
+			totalCount,
 			len(m.Table.Rows),
 		)
 	}

--- a/internal/tui/components/issuessection/issuessection.go
+++ b/internal/tui/components/issuessection/issuessection.go
@@ -87,8 +87,11 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 			case "enter":
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
-				if input == "Y" || input == "y" {
-					issue := m.GetCurrRow()
+				issue := m.GetCurrRow()
+				if action == "snooze" {
+					m.applySnooze(input, issue)
+					m.Table.SetRows(m.BuildRows())
+				} else if input == "Y" || input == "y" {
 					sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
 					switch action {
 					case "close":
@@ -261,9 +264,24 @@ func GetSectionColumns(
 	}
 }
 
+// visibleIssues returns m.Issues with snoozed issues filtered out. It's used
+// by both BuildRows and GetCurrRow so that the table's row index (which only
+// ever spans visible rows) maps consistently to the underlying data.
+func (m Model) visibleIssues() []data.IssueData {
+	snoozeStore := data.GetSnoozeStore()
+	visible := make([]data.IssueData, 0, len(m.Issues))
+	for _, issue := range m.Issues {
+		if snoozeStore.IsSnoozed(snoozeKey(&issue)) {
+			continue
+		}
+		visible = append(visible, issue)
+	}
+	return visible
+}
+
 func (m Model) BuildRows() []table.Row {
 	var rows []table.Row
-	for _, currIssue := range m.Issues {
+	for _, currIssue := range m.visibleIssues() {
 		issueModel := issuerow.Issue{Ctx: m.Ctx, Data: currIssue, ShowAuthorIcon: m.ShowAuthorIcon}
 		rows = append(rows, issueModel.ToTableRow())
 	}
@@ -281,10 +299,11 @@ func (m *Model) NumRows() int {
 
 func (m *Model) GetCurrRow() data.RowData {
 	idx := m.Table.GetCurrItem()
-	if idx < 0 || idx >= len(m.Issues) {
+	visible := m.visibleIssues()
+	if idx < 0 || idx >= len(visible) {
 		return nil
 	}
-	issue := m.Issues[idx]
+	issue := visible[idx]
 	return &issue
 }
 

--- a/internal/tui/components/issuessection/issuessection_test.go
+++ b/internal/tui/components/issuessection/issuessection_test.go
@@ -1,0 +1,142 @@
+package issuessection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prompt"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/section"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
+)
+
+// newTestModel creates a minimal Model with the prompt confirmation box
+// focused and a single issue row so that GetCurrRow returns non-nil.
+func newTestModel(action string) Model {
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	thm := theme.ParseTheme(&cfg)
+	ctx := &context.ProgramContext{
+		Config: &cfg,
+		Theme:  thm,
+		Styles: context.InitStyles(thm),
+		StartTask: func(task context.Task) tea.Cmd {
+			return func() tea.Msg { return nil }
+		},
+	}
+	m := Model{
+		BaseModel: section.BaseModel{
+			Ctx:                       ctx,
+			IsPromptConfirmationShown: true,
+			PromptConfirmationAction:  action,
+			PromptConfirmationBox:     prompt.NewModel(ctx),
+		},
+		Issues: []data.IssueData{
+			{Number: 42},
+		},
+	}
+	m.PromptConfirmationBox.Focus()
+	m.Table.UpdateProgramContext(ctx)
+	return m
+}
+
+func withTestSnoozeStore(t *testing.T) *data.SnoozeStore {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "gh-dash-snooze-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	store := data.NewSnoozeStoreForTesting(filepath.Join(tempDir, "snoozed.json"))
+	restore := data.OverrideSnoozeStoreForTesting(store)
+	t.Cleanup(restore)
+	return store
+}
+
+func TestConfirmation_EmptyInputDoesNotConfirm(t *testing.T) {
+	m := newTestModel("close")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, m.IsPromptConfirmationShown,
+		"confirmation prompt should be dismissed")
+}
+
+func TestConfirmation_AcceptWithLowercaseY(t *testing.T) {
+	m := newTestModel("close")
+	m.PromptConfirmationBox.SetValue("y")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	require.NotNil(t, cmd, "lowercase y should execute the action")
+}
+
+func TestApplySnooze_ValidPresetSnoozesIssue(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.True(t, data.GetSnoozeStore().IsSnoozed("issue:#42"),
+		"issue should be snoozed after confirming preset 1")
+}
+
+func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, data.GetSnoozeStore().IsSnoozed("issue:#42"),
+		"invalid preset index should be silently ignored")
+}
+
+func TestBuildRows_FiltersSnoozedIssues(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("issue:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Issues = []data.IssueData{
+		{Number: 1, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+		{Number: 2, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+	}
+
+	rows := m.BuildRows()
+	require.Len(t, rows, 1, "snoozed issue should be filtered out of BuildRows")
+}
+
+func TestGetCurrRow_IndexesIntoVisibleIssuesOnly(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("issue:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Issues = []data.IssueData{
+		{Number: 1, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+		{Number: 2, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+	}
+
+	row := m.GetCurrRow()
+	require.NotNil(t, row)
+	require.Equal(t, 2, row.GetNumber())
+}

--- a/internal/tui/components/issuessection/issuessection_test.go
+++ b/internal/tui/components/issuessection/issuessection_test.go
@@ -13,9 +13,28 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prompt"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/section"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
 )
+
+// collectMsgs executes cmd, flattening any tea.BatchMsg it produces into the
+// individual tea.Msg values that would ultimately be dispatched.
+func collectMsgs(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, collectMsgs(t, c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
 
 // newTestModel creates a minimal Model with the prompt confirmation box
 // focused and a single issue row so that GetCurrRow returns non-nil.
@@ -112,6 +131,44 @@ func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {
 		"invalid preset index should be silently ignored")
 }
 
+func TestApplySnooze_FiresSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	var found bool
+	for _, msg := range collectMsgs(t, cmd) {
+		if finished, ok := msg.(constants.TaskFinishedMsg); ok {
+			found = true
+			require.Equal(t, m.Id, finished.SectionId)
+			require.Equal(t, SectionType, finished.SectionType)
+		}
+	}
+	require.True(t, found, "confirming a snooze should surface footer feedback")
+}
+
+func TestApplySnooze_InvalidIndexDoesNotFireSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	for _, msg := range collectMsgs(t, cmd) {
+		if _, ok := msg.(constants.TaskFinishedMsg); ok {
+			t.Fatal("an invalid snooze should not surface footer feedback")
+		}
+	}
+}
+
 func TestBuildRows_FiltersSnoozedIssues(t *testing.T) {
 	store := withTestSnoozeStore(t)
 	store.Snooze("issue:owner/repo#1", time.Now().Add(time.Hour))
@@ -124,6 +181,35 @@ func TestBuildRows_FiltersSnoozedIssues(t *testing.T) {
 
 	rows := m.BuildRows()
 	require.Len(t, rows, 1, "snoozed issue should be filtered out of BuildRows")
+}
+
+func TestNumRows_ExcludesSnoozedIssues(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("issue:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Issues = []data.IssueData{
+		{Number: 1, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+		{Number: 2, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+	}
+
+	require.Equal(t, 1, m.NumRows(),
+		"NumRows should exclude snoozed issues so pagination triggers correctly")
+}
+
+func TestGetTotalCount_AdjustsForSnoozedIssues(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("issue:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Issues = []data.IssueData{
+		{Number: 1, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+		{Number: 2, Repository: data.Repository{NameWithOwner: "owner/repo"}},
+	}
+	m.TotalCount = 2
+
+	require.Equal(t, 1, m.GetTotalCount(),
+		"GetTotalCount should exclude snoozed issues so the tab badge matches visible rows")
 }
 
 func TestGetCurrRow_IndexesIntoVisibleIssuesOnly(t *testing.T) {

--- a/internal/tui/components/issuessection/snooze.go
+++ b/internal/tui/components/issuessection/snooze.go
@@ -2,7 +2,6 @@ package issuessection
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 )
@@ -14,16 +13,12 @@ func snoozeKey(issue data.RowData) string {
 
 // applySnooze parses input as a 1-based index into the configured snooze
 // presets and, if valid, snoozes issue until the computed wake time. Invalid
-// input (bad index, non-numeric, unrecognized preset) is silently ignored.
-func (m *Model) applySnooze(input string, issue data.RowData) {
+// input (bad index, non-numeric, unrecognized preset) is silently ignored,
+// in which case applySnooze returns false.
+func (m *Model) applySnooze(input string, issue data.RowData) bool {
 	if issue == nil {
-		return
+		return false
 	}
 
-	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
-	if !ok {
-		return
-	}
-
-	data.GetSnoozeStore().Snooze(snoozeKey(issue), wakeAt)
+	return data.ApplySnoozePreset(input, snoozeKey(issue), m.Ctx.Config.Defaults.SnoozePresets)
 }

--- a/internal/tui/components/issuessection/snooze.go
+++ b/internal/tui/components/issuessection/snooze.go
@@ -1,0 +1,29 @@
+package issuessection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+)
+
+// snoozeKey builds the SnoozeStore key for an issue.
+func snoozeKey(issue data.RowData) string {
+	return fmt.Sprintf("issue:%s#%d", issue.GetRepoNameWithOwner(), issue.GetNumber())
+}
+
+// applySnooze parses input as a 1-based index into the configured snooze
+// presets and, if valid, snoozes issue until the computed wake time. Invalid
+// input (bad index, non-numeric, unrecognized preset) is silently ignored.
+func (m *Model) applySnooze(input string, issue data.RowData) {
+	if issue == nil {
+		return
+	}
+
+	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
+	if !ok {
+		return
+	}
+
+	data.GetSnoozeStore().Snooze(snoozeKey(issue), wakeAt)
+}

--- a/internal/tui/components/listviewport/listviewport.go
+++ b/internal/tui/components/listviewport/listviewport.go
@@ -57,6 +57,7 @@ func NewModel(
 func (m *Model) SetNumItems(numItems int) {
 	m.NumCurrentItems = numItems
 	m.bottomBoundId = utils.Min(m.NumCurrentItems-1, m.getNumPrsPerPage()-1)
+	m.currId = utils.Max(0, utils.Min(m.currId, m.NumCurrentItems-1))
 }
 
 func (m *Model) SetTotalItems(total int) {

--- a/internal/tui/components/listviewport/listviewport_test.go
+++ b/internal/tui/components/listviewport/listviewport_test.go
@@ -129,3 +129,34 @@ func TestNextItemAtLastItem(t *testing.T) {
 		t.Errorf("expected currId=9, got %d", m.GetCurrItem())
 	}
 }
+
+func TestSetNumItemsClampsCurrItem(t *testing.T) {
+	// Simulates snoozing/removing the currently selected bottom row: the
+	// list shrinks out from under the cursor, which must be clamped back
+	// into range rather than left pointing past the end.
+	m := newTestModel(testModelOpts{numItems: 10, viewportHeight: 5, itemHeight: 1})
+
+	for range 9 {
+		m.NextItem()
+	}
+	if m.GetCurrItem() != 9 {
+		t.Fatalf("expected currId=9, got %d", m.GetCurrItem())
+	}
+
+	m.SetNumItems(9)
+
+	if m.GetCurrItem() != 8 {
+		t.Errorf("expected currId to be clamped to 8, got %d", m.GetCurrItem())
+	}
+}
+
+func TestSetNumItemsClampsCurrItemToZeroWhenEmpty(t *testing.T) {
+	m := newTestModel(testModelOpts{numItems: 3, viewportHeight: 5, itemHeight: 1})
+
+	m.NextItem()
+	m.SetNumItems(0)
+
+	if m.GetCurrItem() != 0 {
+		t.Errorf("expected currId=0 when list is empty, got %d", m.GetCurrItem())
+	}
+}

--- a/internal/tui/components/notificationssection/notificationssection.go
+++ b/internal/tui/components/notificationssection/notificationssection.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/section"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/table"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/tasks"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/keys"
@@ -240,7 +241,16 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
 				if action == "snooze" {
-					m.applySnooze(input, m.GetCurrNotification())
+					notification := m.GetCurrNotification()
+					if m.applySnooze(input, notification) {
+						sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
+						cmd = tasks.SnoozeFeedback(
+							m.Ctx,
+							sid,
+							snoozeKey(notification.GetId()),
+							notification.GetTitle(),
+						)
+					}
 					m.Table.SetRows(m.BuildRows())
 				} else if input == "Y" || input == "y" {
 					switch action {

--- a/internal/tui/components/notificationssection/notificationssection.go
+++ b/internal/tui/components/notificationssection/notificationssection.go
@@ -239,7 +239,10 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 			case "enter":
 				input := m.PromptConfirmationBox.Value()
 				action := m.GetPromptConfirmationAction()
-				if input == "Y" || input == "y" {
+				if action == "snooze" {
+					m.applySnooze(input, m.GetCurrNotification())
+					m.Table.SetRows(m.BuildRows())
+				} else if input == "Y" || input == "y" {
 					switch action {
 					case "done":
 						cmd = m.markAsDone()
@@ -293,6 +296,13 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				m.Table.SetRows(m.BuildRows())
 			}
 			return m, nil
+
+		case key.Matches(msg, keys.NotificationKeys.Snooze):
+			if m.GetCurrRow() != nil {
+				m.SetPromptConfirmationAction("snooze")
+				cmd = m.SetIsPromptConfirmationShown(true)
+			}
+			return m, cmd
 
 		case key.Matches(msg, keys.NotificationKeys.SortByRepo):
 			m.toggleSortOrder()
@@ -619,6 +629,7 @@ func (m *Model) FetchNextPageSectionRows() []tea.Cmd {
 
 		// Initialize done store for filtering
 		doneStore := data.GetDoneStore()
+		snoozeStore := data.GetSnoozeStore()
 
 		// Track accumulated notifications across multiple pages.
 		// We may need to fetch additional pages if many notifications are filtered out
@@ -728,7 +739,8 @@ func (m *Model) FetchNextPageSectionRows() []tea.Cmd {
 			for _, n := range res.Notifications {
 				// Skip notifications marked as done (GitHub API still returns them with all=true)
 				// Check both persistent store and session state
-				if doneStore.IsDone(n.Id, n.UpdatedAt) || sessionMarkedDone[n.Id] {
+				if doneStore.IsDone(n.Id, n.UpdatedAt) || sessionMarkedDone[n.Id] ||
+					snoozeStore.IsSnoozed(snoozeKey(n.Id)) {
 					continue
 				}
 

--- a/internal/tui/components/notificationssection/snooze.go
+++ b/internal/tui/components/notificationssection/snooze.go
@@ -1,0 +1,40 @@
+package notificationssection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
+)
+
+// snoozeKey builds the SnoozeStore key for a notification thread ID.
+func snoozeKey(id string) string {
+	return fmt.Sprintf("notification:%s", id)
+}
+
+// applySnooze parses input as a 1-based index into the configured snooze
+// presets and, if valid, snoozes notification and removes it from the
+// visible list immediately (no need to wait for the next fetch). Invalid
+// input (bad index, non-numeric, unrecognized preset) is silently ignored.
+func (m *Model) applySnooze(input string, notification *notificationrow.Data) {
+	if notification == nil {
+		return
+	}
+
+	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
+	if !ok {
+		return
+	}
+
+	id := notification.GetId()
+	data.GetSnoozeStore().Snooze(snoozeKey(id), wakeAt)
+
+	for i, n := range m.Notifications {
+		if n.GetId() == id {
+			m.Notifications = append(m.Notifications[:i], m.Notifications[i+1:]...)
+			break
+		}
+	}
+	m.TotalCount = len(m.Notifications)
+}

--- a/internal/tui/components/notificationssection/snooze.go
+++ b/internal/tui/components/notificationssection/snooze.go
@@ -2,7 +2,6 @@ package notificationssection
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
@@ -16,19 +15,17 @@ func snoozeKey(id string) string {
 // applySnooze parses input as a 1-based index into the configured snooze
 // presets and, if valid, snoozes notification and removes it from the
 // visible list immediately (no need to wait for the next fetch). Invalid
-// input (bad index, non-numeric, unrecognized preset) is silently ignored.
-func (m *Model) applySnooze(input string, notification *notificationrow.Data) {
+// input (bad index, non-numeric, unrecognized preset) is silently ignored,
+// in which case applySnooze returns false.
+func (m *Model) applySnooze(input string, notification *notificationrow.Data) bool {
 	if notification == nil {
-		return
-	}
-
-	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
-	if !ok {
-		return
+		return false
 	}
 
 	id := notification.GetId()
-	data.GetSnoozeStore().Snooze(snoozeKey(id), wakeAt)
+	if !data.ApplySnoozePreset(input, snoozeKey(id), m.Ctx.Config.Defaults.SnoozePresets) {
+		return false
+	}
 
 	for i, n := range m.Notifications {
 		if n.GetId() == id {
@@ -37,4 +34,5 @@ func (m *Model) applySnooze(input string, notification *notificationrow.Data) {
 		}
 	}
 	m.TotalCount = len(m.Notifications)
+	return true
 }

--- a/internal/tui/components/notificationssection/snooze_test.go
+++ b/internal/tui/components/notificationssection/snooze_test.go
@@ -1,0 +1,120 @@
+package notificationssection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
+)
+
+func withTestSnoozeStore(t *testing.T) *data.SnoozeStore {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "gh-dash-snooze-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	store := data.NewSnoozeStoreForTesting(filepath.Join(tempDir, "snoozed.json"))
+	restore := data.OverrideSnoozeStoreForTesting(store)
+	t.Cleanup(restore)
+	return store
+}
+
+// newTestModel creates a real, fully-initialized Model (mirroring
+// TestUpdateNotificationKeepsCursorOnNewLastItem in commands_test.go) with
+// the prompt confirmation box focused for the given action and a single
+// notification so GetCurrNotification returns non-nil.
+func newTestModel(t *testing.T, action string) Model {
+	t.Helper()
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	require.NoError(t, err)
+
+	ctx := &context.ProgramContext{Config: &cfg}
+	ctx.Theme = theme.ParseTheme(ctx.Config)
+	ctx.Styles = context.InitStyles(ctx.Theme)
+	ctx.StartTask = func(task context.Task) tea.Cmd {
+		return func() tea.Msg { return nil }
+	}
+
+	m := NewModel(0, ctx, config.NotificationsSectionConfig{}, time.Now())
+	m.Notifications = []notificationrow.Data{
+		{Notification: data.NotificationData{Id: "notif-A"}},
+	}
+	m.TotalCount = len(m.Notifications)
+	m.Table.SetRows(m.BuildRows())
+
+	m.SetPromptConfirmationAction(action)
+	m.SetIsPromptConfirmationShown(true)
+	m.PromptConfirmationBox.Focus()
+
+	return m
+}
+
+func TestApplySnooze_ValidPresetSnoozesNotification(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.True(t, data.GetSnoozeStore().IsSnoozed("notification:notif-A"),
+		"notification should be snoozed after confirming preset 1")
+}
+
+func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, data.GetSnoozeStore().IsSnoozed("notification:notif-A"),
+		"invalid preset index should be silently ignored")
+}
+
+func TestApplySnooze_NonNumericInputIsIgnored(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("abc")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, data.GetSnoozeStore().IsSnoozed("notification:notif-A"),
+		"non-numeric input should be silently ignored")
+}
+
+func TestApplySnooze_RemovesNotificationImmediately(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	updated, _ := m.Update(msg)
+	m = *updated.(*Model)
+
+	require.Empty(t, m.Notifications,
+		"snoozed notification should be removed from the list immediately")
+	require.Equal(t, 0, m.TotalCount)
+}

--- a/internal/tui/components/notificationssection/snooze_test.go
+++ b/internal/tui/components/notificationssection/snooze_test.go
@@ -12,9 +12,28 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/notificationrow"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
 )
+
+// collectMsgs executes cmd, flattening any tea.BatchMsg it produces into the
+// individual tea.Msg values that would ultimately be dispatched.
+func collectMsgs(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, collectMsgs(t, c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
 
 func withTestSnoozeStore(t *testing.T) *data.SnoozeStore {
 	t.Helper()
@@ -73,6 +92,44 @@ func TestApplySnooze_ValidPresetSnoozesNotification(t *testing.T) {
 
 	require.True(t, data.GetSnoozeStore().IsSnoozed("notification:notif-A"),
 		"notification should be snoozed after confirming preset 1")
+}
+
+func TestApplySnooze_FiresSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	var found bool
+	for _, msg := range collectMsgs(t, cmd) {
+		if finished, ok := msg.(constants.TaskFinishedMsg); ok {
+			found = true
+			require.Equal(t, m.Id, finished.SectionId)
+			require.Equal(t, SectionType, finished.SectionType)
+		}
+	}
+	require.True(t, found, "confirming a snooze should surface footer feedback")
+}
+
+func TestApplySnooze_InvalidIndexDoesNotFireSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel(t, "snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	for _, msg := range collectMsgs(t, cmd) {
+		if _, ok := msg.(constants.TaskFinishedMsg); ok {
+			t.Fatal("an invalid snooze should not surface footer feedback")
+		}
+	}
 }
 
 func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {

--- a/internal/tui/components/prssection/prssection.go
+++ b/internal/tui/components/prssection/prssection.go
@@ -92,7 +92,14 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				pr := m.GetCurrRow()
 				sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
 				if action == "snooze" {
-					m.applySnooze(input, pr)
+					if m.applySnooze(input, pr) {
+						cmd = tasks.SnoozeFeedback(
+							m.Ctx,
+							sid,
+							snoozeKey(pr),
+							fmt.Sprintf("PR #%d", pr.GetNumber()),
+						)
+					}
 					m.Table.SetRows(m.BuildRows())
 				} else if input == "Y" || input == "y" {
 					switch action {
@@ -444,7 +451,7 @@ func (m Model) BuildRows() []table.Row {
 }
 
 func (m *Model) NumRows() int {
-	return len(m.Prs)
+	return len(m.visiblePRs())
 }
 
 type SectionPullRequestsFetchedMsg struct {
@@ -609,8 +616,17 @@ func (m Model) GetItemPluralForm() string {
 	return "PRs"
 }
 
+// visibleTotalCount adjusts TotalCount by the number of currently-snoozed
+// PRs among the fetched rows, so the tab badge and pager reflect what's
+// actually visible. It self-corrects as snoozes expire since visiblePRs()
+// re-evaluates time.Now() on every call.
+func (m Model) visibleTotalCount() int {
+	numSnoozed := len(m.Prs) - len(m.visiblePRs())
+	return utils.Max(0, m.TotalCount-numSnoozed)
+}
+
 func (m Model) GetTotalCount() int {
-	return m.TotalCount
+	return m.visibleTotalCount()
 }
 
 func (m *Model) SetIsLoading(val bool) {
@@ -626,14 +642,15 @@ func (m Model) GetPagerContent() string {
 	} else {
 		timeElapsed = fmt.Sprintf("~%v ago", timeElapsed)
 	}
-	if m.TotalCount > 0 {
+	totalCount := m.visibleTotalCount()
+	if totalCount > 0 {
 		pagerContent = fmt.Sprintf(
 			"%v Updated %v • %v %v/%v (fetched %v)",
 			constants.WaitingIcon,
 			timeElapsed,
 			m.SingularForm,
 			m.Table.GetCurrItem()+1,
-			m.TotalCount,
+			totalCount,
 			len(m.Table.Rows),
 		)
 	}

--- a/internal/tui/components/prssection/prssection.go
+++ b/internal/tui/components/prssection/prssection.go
@@ -91,7 +91,10 @@ func (m *Model) Update(msg tea.Msg) (section.Section, tea.Cmd) {
 				action := m.GetPromptConfirmationAction()
 				pr := m.GetCurrRow()
 				sid := tasks.SectionIdentifier{Id: m.Id, Type: SectionType}
-				if input == "Y" || input == "y" {
+				if action == "snooze" {
+					m.applySnooze(input, pr)
+					m.Table.SetRows(m.BuildRows())
+				} else if input == "Y" || input == "y" {
 					switch action {
 					case "close":
 						cmd = tasks.ClosePR(m.Ctx, sid, pr)
@@ -403,10 +406,25 @@ func GetSectionColumns(
 	}
 }
 
+// visiblePRs returns m.Prs with snoozed PRs filtered out. It's used by both
+// BuildRows and GetCurrRow so that the table's row index (which only ever
+// spans visible rows) maps consistently to the underlying data.
+func (m Model) visiblePRs() []prrow.Data {
+	snoozeStore := data.GetSnoozeStore()
+	visible := make([]prrow.Data, 0, len(m.Prs))
+	for _, pr := range m.Prs {
+		if snoozeStore.IsSnoozed(snoozeKey(&pr)) {
+			continue
+		}
+		visible = append(visible, pr)
+	}
+	return visible
+}
+
 func (m Model) BuildRows() []table.Row {
 	var rows []table.Row
 	currItem := m.Table.GetCurrItem()
-	for i, currPr := range m.Prs {
+	for i, currPr := range m.visiblePRs() {
 		prModel := prrow.PullRequest{
 			Ctx:     m.Ctx,
 			Data:    &currPr,
@@ -438,10 +456,11 @@ type SectionPullRequestsFetchedMsg struct {
 
 func (m *Model) GetCurrRow() data.RowData {
 	idx := m.Table.GetCurrItem()
-	if idx < 0 || idx >= len(m.Prs) {
+	visible := m.visiblePRs()
+	if idx < 0 || idx >= len(visible) {
 		return nil
 	}
-	pr := m.Prs[idx]
+	pr := visible[idx]
 	return &pr
 }
 

--- a/internal/tui/components/prssection/prssection_test.go
+++ b/internal/tui/components/prssection/prssection_test.go
@@ -6,17 +6,30 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prompt"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prrow"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/section"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/theme"
 )
 
 // newTestModel creates a minimal Model with the prompt confirmation box
 // focused and a single PR row so that GetCurrRow returns non-nil.
 func newTestModel(action string) Model {
+	cfg, err := config.ParseConfig(config.Location{
+		ConfigFlag:       "../../../config/testdata/test-config.yml",
+		SkipGlobalConfig: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	thm := theme.ParseTheme(&cfg)
 	ctx := &context.ProgramContext{
+		Config: &cfg,
+		Theme:  thm,
+		Styles: context.InitStyles(thm),
 		StartTask: func(task context.Task) tea.Cmd {
 			return func() tea.Msg { return nil }
 		},
@@ -33,6 +46,7 @@ func newTestModel(action string) Model {
 		},
 	}
 	m.PromptConfirmationBox.Focus()
+	m.Table.UpdateProgramContext(ctx)
 	return m
 }
 

--- a/internal/tui/components/prssection/snooze.go
+++ b/internal/tui/components/prssection/snooze.go
@@ -1,0 +1,29 @@
+package prssection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+)
+
+// snoozeKey builds the SnoozeStore key for a PR.
+func snoozeKey(pr data.RowData) string {
+	return fmt.Sprintf("pr:%s#%d", pr.GetRepoNameWithOwner(), pr.GetNumber())
+}
+
+// applySnooze parses input as a 1-based index into the configured snooze
+// presets and, if valid, snoozes pr until the computed wake time. Invalid
+// input (bad index, non-numeric, unrecognized preset) is silently ignored.
+func (m *Model) applySnooze(input string, pr data.RowData) {
+	if pr == nil {
+		return
+	}
+
+	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
+	if !ok {
+		return
+	}
+
+	data.GetSnoozeStore().Snooze(snoozeKey(pr), wakeAt)
+}

--- a/internal/tui/components/prssection/snooze.go
+++ b/internal/tui/components/prssection/snooze.go
@@ -2,7 +2,6 @@ package prssection
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 )
@@ -14,16 +13,12 @@ func snoozeKey(pr data.RowData) string {
 
 // applySnooze parses input as a 1-based index into the configured snooze
 // presets and, if valid, snoozes pr until the computed wake time. Invalid
-// input (bad index, non-numeric, unrecognized preset) is silently ignored.
-func (m *Model) applySnooze(input string, pr data.RowData) {
+// input (bad index, non-numeric, unrecognized preset) is silently ignored,
+// in which case applySnooze returns false.
+func (m *Model) applySnooze(input string, pr data.RowData) bool {
 	if pr == nil {
-		return
+		return false
 	}
 
-	wakeAt, ok := data.ResolveSnoozePreset(input, m.Ctx.Config.Defaults.SnoozePresets, time.Now())
-	if !ok {
-		return
-	}
-
-	data.GetSnoozeStore().Snooze(snoozeKey(pr), wakeAt)
+	return data.ApplySnoozePreset(input, snoozeKey(pr), m.Ctx.Config.Defaults.SnoozePresets)
 }

--- a/internal/tui/components/prssection/snooze_test.go
+++ b/internal/tui/components/prssection/snooze_test.go
@@ -12,7 +12,26 @@ import (
 	"github.com/dlvhdr/gh-dash/v4/internal/config"
 	"github.com/dlvhdr/gh-dash/v4/internal/data"
 	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prrow"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
 )
+
+// collectMsgs executes cmd, flattening any tea.BatchMsg it produces into the
+// individual tea.Msg values that would ultimately be dispatched.
+func collectMsgs(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, collectMsgs(t, c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
 
 func withTestSnoozeStore(t *testing.T) *data.SnoozeStore {
 	t.Helper()
@@ -38,6 +57,44 @@ func TestApplySnooze_ValidPresetSnoozesPR(t *testing.T) {
 
 	require.True(t, data.GetSnoozeStore().IsSnoozed("pr:#42"),
 		"PR should be snoozed after confirming preset 1")
+}
+
+func TestApplySnooze_FiresSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	var found bool
+	for _, msg := range collectMsgs(t, cmd) {
+		if finished, ok := msg.(constants.TaskFinishedMsg); ok {
+			found = true
+			require.Equal(t, m.Id, finished.SectionId)
+			require.Equal(t, SectionType, finished.SectionType)
+		}
+	}
+	require.True(t, found, "confirming a snooze should surface footer feedback")
+}
+
+func TestApplySnooze_InvalidIndexDoesNotFireSnoozeFeedback(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, cmd := m.Update(msg)
+
+	for _, msg := range collectMsgs(t, cmd) {
+		if _, ok := msg.(constants.TaskFinishedMsg); ok {
+			t.Fatal("an invalid snooze should not surface footer feedback")
+		}
+	}
 }
 
 func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {
@@ -86,6 +143,47 @@ func TestBuildRows_FiltersSnoozedPRs(t *testing.T) {
 
 	rows := m.BuildRows()
 	require.Len(t, rows, 1, "snoozed PR should be filtered out of BuildRows")
+}
+
+func TestNumRows_ExcludesSnoozedPRs(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("pr:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Prs = []prrow.Data{
+		{Primary: &data.PullRequestData{
+			Number:     1,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+		{Primary: &data.PullRequestData{
+			Number:     2,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+	}
+
+	require.Equal(t, 1, m.NumRows(),
+		"NumRows should exclude snoozed PRs so pagination triggers correctly")
+}
+
+func TestGetTotalCount_AdjustsForSnoozedPRs(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("pr:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Prs = []prrow.Data{
+		{Primary: &data.PullRequestData{
+			Number:     1,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+		{Primary: &data.PullRequestData{
+			Number:     2,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+	}
+	m.TotalCount = 2
+
+	require.Equal(t, 1, m.GetTotalCount(),
+		"GetTotalCount should exclude snoozed PRs so the tab badge matches visible rows")
 }
 
 func TestGetCurrRow_IndexesIntoVisiblePRsOnly(t *testing.T) {

--- a/internal/tui/components/prssection/snooze_test.go
+++ b/internal/tui/components/prssection/snooze_test.go
@@ -1,0 +1,111 @@
+package prssection
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/config"
+	"github.com/dlvhdr/gh-dash/v4/internal/data"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/components/prrow"
+)
+
+func withTestSnoozeStore(t *testing.T) *data.SnoozeStore {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "gh-dash-snooze-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	store := data.NewSnoozeStoreForTesting(filepath.Join(tempDir, "snoozed.json"))
+	restore := data.OverrideSnoozeStoreForTesting(store)
+	t.Cleanup(restore)
+	return store
+}
+
+func TestApplySnooze_ValidPresetSnoozesPR(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("1")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.True(t, data.GetSnoozeStore().IsSnoozed("pr:#42"),
+		"PR should be snoozed after confirming preset 1")
+}
+
+func TestApplySnooze_InvalidIndexIsIgnored(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("99")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, data.GetSnoozeStore().IsSnoozed("pr:#42"),
+		"invalid preset index should be silently ignored")
+}
+
+func TestApplySnooze_NonNumericInputIsIgnored(t *testing.T) {
+	withTestSnoozeStore(t)
+
+	m := newTestModel("snooze")
+	m.Ctx.Config.Defaults.SnoozePresets = []config.SnoozePreset{{Label: "10m", After: "10m"}}
+	m.PromptConfirmationBox.SetValue("abc")
+
+	msg := tea.KeyPressMsg{Code: tea.KeyEnter}
+	_, _ = m.Update(msg)
+
+	require.False(t, data.GetSnoozeStore().IsSnoozed("pr:#42"),
+		"non-numeric input should be silently ignored")
+}
+
+func TestBuildRows_FiltersSnoozedPRs(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("pr:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Prs = []prrow.Data{
+		{Primary: &data.PullRequestData{
+			Number:     1,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+		{Primary: &data.PullRequestData{
+			Number:     2,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+	}
+
+	rows := m.BuildRows()
+	require.Len(t, rows, 1, "snoozed PR should be filtered out of BuildRows")
+}
+
+func TestGetCurrRow_IndexesIntoVisiblePRsOnly(t *testing.T) {
+	store := withTestSnoozeStore(t)
+	store.Snooze("pr:owner/repo#1", time.Now().Add(time.Hour))
+
+	m := newTestModel("")
+	m.Prs = []prrow.Data{
+		{Primary: &data.PullRequestData{
+			Number:     1,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+		{Primary: &data.PullRequestData{
+			Number:     2,
+			Repository: data.Repository{NameWithOwner: "owner/repo"},
+		}},
+	}
+	// The table cursor is at index 0, which should now refer to the second
+	// (visible) PR, since the first is snoozed.
+	row := m.GetCurrRow()
+	require.NotNil(t, row)
+	require.Equal(t, 2, row.GetNumber())
+}

--- a/internal/tui/components/section/section.go
+++ b/internal/tui/components/section/section.go
@@ -506,6 +506,13 @@ func (m *BaseModel) GetPromptConfirmation() string {
 			prompt = "Enter PR title: "
 		case m.PromptConfirmationAction == "done_all" && m.Ctx.View == config.NotificationsView:
 			prompt = "Are you sure you want to mark all as done? (y/N) "
+
+		case m.PromptConfirmationAction == "snooze":
+			var parts []string
+			for i, p := range m.Ctx.Config.Defaults.SnoozePresets {
+				parts = append(parts, fmt.Sprintf("[%d] %s", i+1, p.Label))
+			}
+			prompt = fmt.Sprintf("Snooze until: %s (Esc to cancel) ", strings.Join(parts, "  "))
 		}
 
 		m.PromptConfirmationBox.SetPrompt(prompt)

--- a/internal/tui/components/tasks/snooze.go
+++ b/internal/tui/components/tasks/snooze.go
@@ -1,0 +1,38 @@
+package tasks
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+)
+
+// SnoozeFeedback surfaces the same footer spinner/checkmark feedback used by
+// other actions (close, merge, reopen, ...) for a snooze that has already
+// been applied synchronously. Since there's no external command to wait on,
+// it starts the task and immediately reports it as finished.
+func SnoozeFeedback(
+	ctx *context.ProgramContext,
+	section SectionIdentifier,
+	key, itemDescription string,
+) tea.Cmd {
+	taskId := fmt.Sprintf("snooze_%s", key)
+	start := context.Task{
+		Id:           taskId,
+		StartText:    fmt.Sprintf("Snoozing %s", itemDescription),
+		FinishedText: fmt.Sprintf("%s has been snoozed", itemDescription),
+		State:        context.TaskStart,
+		Error:        nil,
+	}
+
+	startCmd := ctx.StartTask(start)
+	return tea.Batch(startCmd, func() tea.Msg {
+		return constants.TaskFinishedMsg{
+			TaskId:      taskId,
+			SectionId:   section.Id,
+			SectionType: section.Type,
+		}
+	})
+}

--- a/internal/tui/components/tasks/snooze_test.go
+++ b/internal/tui/components/tasks/snooze_test.go
@@ -1,0 +1,74 @@
+package tasks
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/constants"
+	"github.com/dlvhdr/gh-dash/v4/internal/tui/context"
+)
+
+func TestSnoozeFeedback_TaskConfiguration(t *testing.T) {
+	var capturedTask context.Task
+	ctx := &context.ProgramContext{
+		StartTask: func(task context.Task) tea.Cmd {
+			capturedTask = task
+			return nil
+		},
+	}
+	section := SectionIdentifier{Id: 2, Type: "pr"}
+
+	_ = SnoozeFeedback(ctx, section, "pr:owner/repo#42", "PR #42")
+
+	require.Equal(t, "snooze_pr:owner/repo#42", capturedTask.Id)
+	require.Equal(t, "Snoozing PR #42", capturedTask.StartText)
+	require.Equal(t, "PR #42 has been snoozed", capturedTask.FinishedText)
+	require.Equal(t, context.TaskStart, capturedTask.State)
+	require.Nil(t, capturedTask.Error)
+}
+
+func TestSnoozeFeedback_ReturnsNonNilCommand(t *testing.T) {
+	ctx := &context.ProgramContext{StartTask: noopStartTask}
+	cmd := SnoozeFeedback(ctx, SectionIdentifier{}, "some-key", "some item")
+	require.NotNil(t, cmd, "SnoozeFeedback should return a non-nil command")
+}
+
+// collectMsgs executes cmd, flattening any tea.BatchMsg it produces into the
+// individual tea.Msg values that would ultimately be dispatched.
+func collectMsgs(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, collectMsgs(t, c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
+
+func TestSnoozeFeedback_ProducesTaskFinishedMsg(t *testing.T) {
+	ctx := &context.ProgramContext{StartTask: noopStartTask}
+	section := SectionIdentifier{Id: 3, Type: "issue"}
+
+	cmd := SnoozeFeedback(ctx, section, "issue:owner/repo#7", "Issue #7")
+	msgs := collectMsgs(t, cmd)
+
+	var found bool
+	for _, msg := range msgs {
+		if finished, ok := msg.(constants.TaskFinishedMsg); ok {
+			found = true
+			require.Equal(t, "snooze_issue:owner/repo#7", finished.TaskId)
+			require.Equal(t, section.Id, finished.SectionId)
+			require.Equal(t, section.Type, finished.SectionType)
+			require.NoError(t, finished.Err)
+		}
+	}
+	require.True(t, found, "expected a constants.TaskFinishedMsg among the produced messages")
+}

--- a/internal/tui/keys/issueKeys.go
+++ b/internal/tui/keys/issueKeys.go
@@ -19,6 +19,7 @@ type IssueKeyMap struct {
 	Reopen               key.Binding
 	ToggleSmartFiltering key.Binding
 	ViewPRs              key.Binding
+	Snooze               key.Binding
 }
 
 var IssueKeys = IssueKeyMap{
@@ -58,6 +59,10 @@ var IssueKeys = IssueKeyMap{
 		key.WithKeys("s"),
 		key.WithHelp("s", "switch to notifications"),
 	),
+	Snooze: key.NewBinding(
+		key.WithKeys("z"),
+		key.WithHelp("z", "snooze"),
+	),
 }
 
 func IssueFullHelp() []key.Binding {
@@ -71,6 +76,7 @@ func IssueFullHelp() []key.Binding {
 		IssueKeys.Reopen,
 		IssueKeys.ToggleSmartFiltering,
 		IssueKeys.ViewPRs,
+		IssueKeys.Snooze,
 	}
 }
 
@@ -117,6 +123,8 @@ func rebindIssueKeys(keys []config.Keybinding) error {
 			key = &IssueKeys.Reopen
 		case "viewPrs":
 			key = &IssueKeys.ViewPRs
+		case "snooze":
+			key = &IssueKeys.Snooze
 		default:
 			return fmt.Errorf("unknown built-in issue key: '%s'", issueKey.Builtin)
 		}

--- a/internal/tui/keys/notificationKeys.go
+++ b/internal/tui/keys/notificationKeys.go
@@ -22,6 +22,7 @@ type NotificationKeyMap struct {
 	SortByRepo           key.Binding
 	SwitchToPRs          key.Binding
 	ToggleSmartFiltering key.Binding
+	Snooze               key.Binding
 }
 
 var NotificationKeys = NotificationKeyMap{
@@ -73,6 +74,10 @@ var NotificationKeys = NotificationKeyMap{
 		key.WithKeys("t"),
 		key.WithHelp("t", "toggle smart filtering"),
 	),
+	Snooze: key.NewBinding(
+		key.WithKeys("z"),
+		key.WithHelp("z", "snooze"),
+	),
 }
 
 func NotificationFullHelp() []key.Binding {
@@ -89,6 +94,7 @@ func NotificationFullHelp() []key.Binding {
 		NotificationKeys.SortByRepo,
 		NotificationKeys.SwitchToPRs,
 		NotificationKeys.ToggleSmartFiltering,
+		NotificationKeys.Snooze,
 	}
 }
 
@@ -141,6 +147,8 @@ func rebindNotificationKeys(keys []config.Keybinding) error {
 			key = &NotificationKeys.SwitchToPRs
 		case "toggleSmartFiltering":
 			key = &NotificationKeys.ToggleSmartFiltering
+		case "snooze":
+			key = &NotificationKeys.Snooze
 		default:
 			return fmt.Errorf("unknown built-in notification key: '%s'", notifKey.Builtin)
 		}

--- a/internal/tui/keys/prKeys.go
+++ b/internal/tui/keys/prKeys.go
@@ -29,6 +29,7 @@ type PRKeyMap struct {
 	ApproveWorkflows     key.Binding
 	ToggleSmartFiltering key.Binding
 	ViewIssues           key.Binding
+	Snooze               key.Binding
 }
 
 var PRKeys = PRKeyMap{
@@ -108,6 +109,10 @@ var PRKeys = PRKeyMap{
 		key.WithKeys("s"),
 		key.WithHelp("s", "switch to issues"),
 	),
+	Snooze: key.NewBinding(
+		key.WithKeys("z"),
+		key.WithHelp("z", "snooze"),
+	),
 }
 
 func PRFullHelp() []key.Binding {
@@ -130,6 +135,7 @@ func PRFullHelp() []key.Binding {
 		PRKeys.ApproveWorkflows,
 		PRKeys.ToggleSmartFiltering,
 		PRKeys.ViewIssues,
+		PRKeys.Snooze,
 	}
 }
 
@@ -196,6 +202,8 @@ func rebindPRKeys(keys []config.Keybinding) error {
 			key = &PRKeys.ViewIssues
 		case "summaryViewMore":
 			key = &PRKeys.SummaryViewMore
+		case "snooze":
+			key = &PRKeys.Snooze
 		default:
 			return fmt.Errorf("unknown built-in pr key: '%s'", prKey.Builtin)
 		}

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -461,6 +461,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, cmd
 
+			case key.Matches(msg, keys.PRKeys.Snooze):
+				if currRowData != nil {
+					cmd = m.promptConfirmation(currSection, "snooze")
+				}
+				return m, cmd
+
 			case key.Matches(msg, keys.PRKeys.ViewIssues):
 				cmds = append(cmds, m.switchSelectedView())
 
@@ -502,6 +508,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case key.Matches(msg, keys.IssueKeys.Reopen):
 				if currRowData != nil {
 					cmd = m.promptConfirmation(currSection, "reopen")
+				}
+				return m, cmd
+
+			case key.Matches(msg, keys.IssueKeys.Snooze):
+				if currRowData != nil {
+					cmd = m.promptConfirmation(currSection, "snooze")
 				}
 				return m, cmd
 

--- a/internal/utils/templateHandler.go
+++ b/internal/utils/templateHandler.go
@@ -46,6 +46,44 @@ func (or *TemplateRegistry) RegisterAliases(aliasMap sprout.FunctionAliasMap) er
 	return nil
 }
 
+// SnoozeWeekdayNames maps lowercase weekday names to time.Weekday, for use
+// in "this <weekday>" snooze presets.
+var SnoozeWeekdayNames = map[string]time.Weekday{
+	"sunday":    time.Sunday,
+	"monday":    time.Monday,
+	"tuesday":   time.Tuesday,
+	"wednesday": time.Wednesday,
+	"thursday":  time.Thursday,
+	"friday":    time.Friday,
+	"saturday":  time.Saturday,
+}
+
+// IsValidSnoozePreset reports whether s is a recognized snooze preset:
+// either a duration string or one of the keyword presets ("tomorrow",
+// "next week", "this <weekday>").
+func IsValidSnoozePreset(s string) bool {
+	lower := strings.ToLower(strings.TrimSpace(s))
+
+	switch {
+	case lower == "tomorrow", lower == "next week":
+		return true
+	case strings.HasPrefix(lower, "this "):
+		_, ok := SnoozeWeekdayNames[strings.TrimPrefix(lower, "this ")]
+		return ok
+	}
+
+	// ParseDuration returns a zero duration (and no error) for any string
+	// with no digits at all, so only attempt it for strings that could
+	// plausibly be a duration - otherwise every unrecognized keyword would
+	// be misreported as valid.
+	if strings.ContainsAny(s, "0123456789") {
+		_, err := ParseDuration(s)
+		return err == nil
+	}
+
+	return false
+}
+
 // ParseDuration parses a duration string.
 // examples: "10d", "-1.5w" or "3Y4M5d".
 // Add time units are "d"="D", "w"="W", "mo=M", "y"="Y".

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -7,6 +7,29 @@ import (
 	"charm.land/lipgloss/v2/compat"
 )
 
+func TestIsValidSnoozePreset(t *testing.T) {
+	valid := []string{
+		"10m", "1h", "4h", "-2w", "3Y4M5d",
+		"tomorrow", "Tomorrow", "TOMORROW",
+		"next week", "Next Week",
+		"this friday", "This Monday", "this SUNDAY",
+	}
+	for _, v := range valid {
+		if !IsValidSnoozePreset(v) {
+			t.Errorf("expected %q to be a valid snooze preset", v)
+		}
+	}
+
+	invalid := []string{
+		"", "bogus", "this someday", "this", "whenever",
+	}
+	for _, v := range invalid {
+		if IsValidSnoozePreset(v) {
+			t.Errorf("expected %q to be an invalid snooze preset", v)
+		}
+	}
+}
+
 func TestGetStylePrefix(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- Adds a `z` snooze keybinding for PRs, issues, and notifications that hides an item until a chosen wake-up time
- Snooze durations are configurable via `defaults.snoozePresets` (defaults: 10m, 1h, 4h, Tomorrow, This Friday, Next week)
- Snooze state persists locally across restarts and items reappear automatically once their snooze expires

## Test plan
- [x] `go test ./...`
- [x] Manual run: snoozed a PR/issue/notification and confirmed it reappears after the snoozed duration
- [x] Verified custom `snoozePresets` in config are honored in the snooze prompt

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>